### PR TITLE
Adding cronie as a dependency for oso-f22-host-monitoring

### DIFF
--- a/docker/oso-f22-host-monitoring/Dockerfile
+++ b/docker/oso-f22-host-monitoring/Dockerfile
@@ -19,7 +19,7 @@ FROM pcp-base:latest
 RUN dnf --enablerepo=pcp-devel -y install pcp pcp-collector && dnf clean all
 
 # install useful utilities
-RUN dnf -y install vim less pexpect && dnf clean all
+RUN dnf -y install vim less pexpect cronie && dnf clean all
 
 #
 # Run in the container as root - avoids PCP_USER mismatches


### PR DESCRIPTION
Crond is required by pmlogger. Fixes the following error from pmlogger.

```
Starting pmcd ... 
Installing http_ping PMDA ...
/usr/share/pcp/lib/pmlogger: Warning: Performance Co-Pilot archive logger(s) not permanently enabled.
    To enable pmlogger, run the following as root:
    # /usr/bin/systemctl enable pmlogger.service
Starting pmlogger ... 
/usr/share/pcp/lib/pmlogger: line 290: /usr/sbin/crond: No such file or directory
```
