### PR TITLE
Installing xz on oso-f22-host-monitoring

### DIFF
--- a/docker/oso-f22-host-monitoring/Dockerfile
+++ b/docker/oso-f22-host-monitoring/Dockerfile
@@ -16,7 +16,7 @@ FROM pcp-base:latest
 
 #
 # install pcp-collector and it's dependencies, clean the cache.
-RUN dnf --enablerepo=pcp-devel -y install pcp pcp-collector && dnf clean all
+RUN dnf --enablerepo=pcp-devel -y install pcp pcp-collector xz && dnf clean all
 
 # install useful utilities
 RUN dnf -y install vim less pexpect cronie && dnf clean all


### PR DESCRIPTION
The pmlogger is running pmlogger_daily which is supposed to rotate the old data. This is not happening as it is missing the xz to compress these, so they are never rotated.

```
sh-4.3# grep daily /etc/cron.d/pcp-pmlogger                                                                                                                                                  
# daily processing of archive logs (with compression enabled)
10     0  *  *  *  pcp  /usr/libexec/pcp/bin/pmlogger_daily -X xz -x 3
sh-4.3# /usr/libexec/pcp/bin/pmlogger_daily -X xz -x 3
xargs: xz: No such file or directory
sh-4.3# 
```