### PR TITLE
Continer ID in bash prompt and Zabbix registration name

### DIFF
--- a/docker/oso-rhel7-ops-base/bashrc
+++ b/docker/oso-rhel7-ops-base/bashrc
@@ -17,5 +17,5 @@ fi
 #   --net=host
 #   --net=container
 # Both of these docker run options give confusing bash prompts inside the container.
-CTR_ID=$(echo $container_uuid | awk '{ gsub(/-/,"",$1); print substr($1,1,13)}')
-export PS1="[CTR][\u@$CTR_ID \W]\$ "
+export container_uuid=$(cat /proc/self/cgroup | grep -o -e "docker-.*.scope" | head -n1 | sed -e "s/docker-\(.*\)\.scope/\\1/" | cut -c1-12)
+export PS1="[CTR][\u@$container_uuid \W]\$ "

--- a/docker/oso-rhel7-zagg-client/root/default_vars.yml
+++ b/docker/oso-rhel7-zagg-client/root/default_vars.yml
@@ -1,6 +1,6 @@
 ---
 # These are defaults variables, override using zagg_client_vars.yml vars file
-g_default_zagg_client_hostname: "UNNAMED-ZAGG-CLIENT-CTR-{{ '%05x' | format(1048576 | random) }}"
+g_default_zagg_client_hostname: "UNNAMED-ZAGG-CLIENT-CTR-{{ lookup('env', 'container_uuid') }}"
 g_default_zagg_url: https://localhost:8443
 g_default_zagg_user: admin
 g_default_zagg_pass: password

--- a/docker/oso-rhel7-zagg-client/start.sh
+++ b/docker/oso-rhel7-zagg-client/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# interactive shells read .bashrc (which this script doesn't execute as) so force it
+source /root/.bashrc
+
 # Configure the container
 time ansible-playbook /root/config.yml
 


### PR DESCRIPTION
@twiest Change base container bash prompt to show the container ID on the bash prompt.

Update zagg-client ansible playbook to use the container ID when registering to Zabbix. Force include .bashrc on start.sh script to make container ID available.