### PR TITLE
make sure to share the host's networking with oso-rhel7-zagg-client

### DIFF
--- a/docker/oso-rhel7-zagg-client/run.sh
+++ b/docker/oso-rhel7-zagg-client/run.sh
@@ -3,7 +3,7 @@
 sudo docker run --rm=true -it --name oso-rhel7-zagg-client \
            --privileged \
            --pid=host \
-           --net=container:oso-f22-host-monitoring \
+           --net=host \
            -e OSO_CLUSTER_GROUP=localcgrp                              \
            -e OSO_CLUSTER_ID=localcid                                   \
            -e OSO_HOST_TYPE=master      \

--- a/docker/oso-rhel7-zagg-client/zagg-client-docker.service.systemd
+++ b/docker/oso-rhel7-zagg-client/zagg-client-docker.service.systemd
@@ -31,6 +31,7 @@ ExecStartPre=-/usr/bin/docker rm "zagg-client"
 #           docker-registry.ops.rhcloud.com/ops/zagg-client
 
 ExecStart=/usr/bin/docker run --name zagg-client            \
+           --net=host --pid=host                            \
            -e NAME=zagg-client -e IMAGE=zagg-client         \
            -e ZAGG_SERVER=REPLACE_WITH_ZAGG_URL             \
            -e ZAGG_PASSWORD=REPLACE_WITH_ZAGG_PASSWORD      \


### PR DESCRIPTION
We want to share the host's networking with oso-rhel7-zagg-client for kublet/openshift-master API monitoring.