### PR TITLE
Add pcp/pmcd status check.

### DIFF
--- a/docker/oso-f22-host-monitoring/Dockerfile
+++ b/docker/oso-f22-host-monitoring/Dockerfile
@@ -38,6 +38,11 @@ ADD pmlogger_control /etc/pcp/pmlogger/control
 ADD pmdas/ /var/lib/pcp/pmdas/
 
 #
+# script to watch health of pmcd
+ADD check-pmcd-status.sh /usr/local/bin/check-pmcd-status.sh
+ADD container-start.sh /usr/local/bin/start.sh
+
+#
 # Expose pmcd's main port on the host interfaces.
 EXPOSE 44321
 
@@ -59,4 +64,4 @@ LABEL RUN docker run -d --privileged --net=host --pid=host --ipc=host -v /sys:/s
 # and can be overridden by passing additional parameters to docker run.
 ENV PATH /usr/share/pcp/lib:/usr/libexec/pcp/bin:$PATH
 #ENTRYPOINT ["pmcd"]
-CMD ["/usr/share/pcp/lib/pcp", "start"]
+CMD ["/usr/local/bin/start.sh"]

--- a/docker/oso-f22-host-monitoring/check-pmcd-status.sh
+++ b/docker/oso-f22-host-monitoring/check-pmcd-status.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Loop checking every 5 minutes whether pmcd is working well
+
+while true
+do
+	sleep 300
+	pminfo -f kernel.uname.distro | grep "No PMCD"
+
+	if [ $? -eq 0 ]; then
+		PID=$(pgrep -f "pcp start$")
+		kill -9 $PID
+	fi
+done

--- a/docker/oso-f22-host-monitoring/container-start.sh
+++ b/docker/oso-f22-host-monitoring/container-start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+check-pmcd-status.sh &
+pcp start


### PR DESCRIPTION
@twiest @kwoodson Will kill the main "pcp start" process which will cause the container to exit.