### PR TITLE
etcd status monitoring

### DIFF
--- a/docker/oso-rhel7-zagg-client/root/config.yml
+++ b/docker/oso-rhel7-zagg-client/root/config.yml
@@ -73,6 +73,10 @@
     - name: send openshift-master project count
       hour: "*/4"
       job: ops-runner -n cspc.openshift.master.project.count /usr/bin/cron-send-project-count
+    - name: send openshift-master etcd status
+      hour: "*/4"
+      job: ops-runner -n cspc.openshift.master.etcd.status /usr/bin/cron-send-etcd-status
+
 
   pre_tasks:
   - stat:

--- a/docker/oso-rhel7-zagg-client/zagg-client-docker.service.systemd
+++ b/docker/oso-rhel7-zagg-client/zagg-client-docker.service.systemd
@@ -36,6 +36,8 @@ ExecStart=/usr/bin/docker run --name zagg-client            \
            -e ZAGG_SERVER=REPLACE_WITH_ZAGG_URL             \
            -e ZAGG_PASSWORD=REPLACE_WITH_ZAGG_PASSWORD      \
            -v /etc/localtime:/etc/localtime                 \
+           -v /etc/openshift/master/master.etcd-client.crt:/etc/openshift/master/master.etcd-client.crt \
+           -v /etc/openshift/master/master.etcd-client.key:/etc/openshift/master/master.etcd-client.key \
            -v /run/pcp:/run/pcp                             \
            docker-registry.ops.rhcloud.com/ops/zagg-client
 

--- a/scripts/monitoring/cron-send-etcd-status.py
+++ b/scripts/monitoring/cron-send-etcd-status.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+'''
+   Command to send status of etcd to zabbix
+'''
+
+#This is not a module, but pylint thinks it is.  This is a command.
+#pylint: disable=invalid-name
+
+from openshift_tools.monitoring.zagg_sender import ZaggSender
+import json
+import requests
+
+def main():
+    ''' Get data from etcd API
+    '''
+
+    API_HOST = 'https://localhost:4001/v2/stats/store'
+    SSL_CLIENT_CERT = '/etc/openshift/master/master.etcd-client.crt'
+    SSL_CLIENT_KEY = '/etc/openshift/master/master.etcd-client.key'
+    zs = ZaggSender()
+
+    # Fetch the store statics from API
+    try:
+        request = requests.get(API_HOST, cert=(SSL_CLIENT_CERT, SSL_CLIENT_KEY), verify=False)
+        content = json.loads(request.content)
+        etcd_ping = 1
+
+        # parse the items and add it as metrics
+        zs.add_zabbix_keys({'openshift.master.etcd.create.success' : content['createSuccess']})
+        zs.add_zabbix_keys({'openshift.master.etcd.create.fail' : content['createFail']})
+        zs.add_zabbix_keys({'openshift.master.etcd.delete.success' : content['deleteSuccess']})
+        zs.add_zabbix_keys({'openshift.master.etcd.delete.fail' : content['deleteFail']})
+        zs.add_zabbix_keys({'openshift.master.etcd.get.success' : content['getsSuccess']})
+        zs.add_zabbix_keys({'openshift.master.etcd.get.fail' : content['getsFail']})
+        zs.add_zabbix_keys({'openshift.master.etcd.set.success' : content['setsSuccess']})
+        zs.add_zabbix_keys({'openshift.master.etcd.set.fail' : content['setsFail']})
+        zs.add_zabbix_keys({'openshift.master.etcd.update.success' : content['updateSuccess']})
+        zs.add_zabbix_keys({'openshift.master.etcd.update.fail' : content['updateFail']})
+        zs.add_zabbix_keys({'openshift.master.etcd.watchers' : content['watchers']})
+
+    except requests.exceptions.ConnectionError as ex:
+        print "ERROR talking to etcd API: %s" % ex.message
+        etcd_ping = 0
+
+    zs.add_zabbix_keys({'openshift.master.etcd.ping' : etcd_ping})
+
+    # Finally, sent them to zabbix
+    zs.send_metrics()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/openshift-tools-scripts.spec
+++ b/scripts/openshift-tools-scripts.spec
@@ -31,6 +31,7 @@ cp -p monitoring/cron-send-pod-count.py %{buildroot}/usr/bin/cron-send-pod-count
 cp -p monitoring/cron-send-ovs-status.py %{buildroot}/usr/bin/cron-send-ovs-status
 cp -p monitoring/cron-send-project-count.sh %{buildroot}/usr/bin/cron-send-project-count
 cp -p monitoring/cron-send-pcp-ping.sh %{buildroot}/usr/bin/cron-send-pcp-ping
+cp -p monitoring/cron-send-etcd-status.py %{buildroot}/usr/bin/cron-send-etcd-status
 
 mkdir -p %{buildroot}/etc/openshift_tools
 cp -p monitoring/zagg_client.yaml.example %{buildroot}/etc/openshift_tools/zagg_client.yaml


### PR DESCRIPTION
etcd status check retrieves the store status from etcd API and collect interesting items which can be plotted into graphs.

We need to bind mount the etcd client certs to access the API.