### PR TITLE
Load the etcd port as it can be different when using external etcd

### DIFF
--- a/docker/oso-rhel7-zagg-client/zagg-client-docker.service.systemd
+++ b/docker/oso-rhel7-zagg-client/zagg-client-docker.service.systemd
@@ -38,6 +38,7 @@ ExecStart=/usr/bin/docker run --name zagg-client            \
            -v /etc/localtime:/etc/localtime                 \
            -v /etc/openshift/master/master.etcd-client.crt:/etc/openshift/master/master.etcd-client.crt \
            -v /etc/openshift/master/master.etcd-client.key:/etc/openshift/master/master.etcd-client.key \
+           -v /etc/openshift/master/master-config.yaml:/etc/openshift/master/master-config.yaml \
            -v /run/pcp:/run/pcp                             \
            docker-registry.ops.rhcloud.com/ops/zagg-client
 

--- a/scripts/monitoring/cron-send-etcd-status.py
+++ b/scripts/monitoring/cron-send-etcd-status.py
@@ -8,20 +8,31 @@
 
 from openshift_tools.monitoring.zagg_sender import ZaggSender
 import json
+import yaml
 import requests
 
 def main():
     ''' Get data from etcd API
     '''
 
-    API_HOST = 'https://localhost:4001/v2/stats/store'
     SSL_CLIENT_CERT = '/etc/openshift/master/master.etcd-client.crt'
     SSL_CLIENT_KEY = '/etc/openshift/master/master.etcd-client.key'
-    zs = ZaggSender()
+    OPENSHIFT_MASTER_CONFIG = '/etc/openshift/master/master-config.yaml'
 
+    # find out the etcd port
+    with open(OPENSHIFT_MASTER_CONFIG, 'r') as f:
+        config = yaml.load(f)
+
+    API_HOST = config["etcdClientInfo"]["urls"][0]
+
+    # define the store API URL
+    API_URL = API_HOST + "/v2/stats/store"
+
+
+    zs = ZaggSender()
     # Fetch the store statics from API
     try:
-        request = requests.get(API_HOST, cert=(SSL_CLIENT_CERT, SSL_CLIENT_KEY), verify=False)
+        request = requests.get(API_URL, cert=(SSL_CLIENT_CERT, SSL_CLIENT_KEY), verify=False)
         content = json.loads(request.content)
         etcd_ping = 1
 


### PR DESCRIPTION
When not using the build-in etcd component, the port and the url of the etcd api may be different. We need to load it from the configuration file to be sure.