### PR TITLE
raise timeout when doing DNS tests

### DIFF
--- a/scripts/monitoring/cron-send-docker-existing-dns-resolution.py
+++ b/scripts/monitoring/cron-send-docker-existing-dns-resolution.py
@@ -18,7 +18,7 @@ ZBX_KEY = "docker.container.existing.dns.resolution.failed"
 CMD_NOT_FOUND = -1
 
 if __name__ == "__main__":
-    cli = AutoVersionClient(base_url='unix://var/run/docker.sock')
+    cli = AutoVersionClient(base_url='unix://var/run/docker.sock', timeout=120)
     bad_dns_count = 0
 
     for ctr in cli.containers():


### PR DESCRIPTION
have seen getent take up to 80 sec to complete
raise timeout to allow it to finish