### PR TITLE
force create /etc/origin symlink

### DIFF
--- a/docker/oso-rhel7-host-monitoring/root/config.yml
+++ b/docker/oso-rhel7-host-monitoring/root/config.yml
@@ -180,6 +180,7 @@
       state: link
       src: /etc/openshift
       dest: /etc/origin
+      force: yes
     when: etc_origin.stat.exists == False and g_oso_host_type == 'master'
 
   - name: Setup Cron


### PR DESCRIPTION
Startup playbook checks for existence of /etc/origin, and then creates a softlink if it isn't there.
Ansible errors out if you create a soft link to a non-existent file.
There is a non-existent /etc/openshift when running host-monitoring locally.
Use 'force: yes' to let Ansible create a soflink to a non-existent file w/o erroring.