### PR TITLE
use base python from RHEL for SNI support

### DIFF
--- a/openshift_tools/web/rest.py
+++ b/openshift_tools/web/rest.py
@@ -12,9 +12,6 @@ import requests.packages.urllib3.connectionpool as httplib
 import time
 import urllib3
 
-from urllib3.contrib import pyopenssl
-pyopenssl.inject_into_urllib3()
-
 #Currently only one method is used.
 #More will be added in the future, and this can be disabled
 #pylint: disable=too-few-public-methods


### PR DESCRIPTION
starting with python-2.7.5-34.el7.src.rpm (https://rhn.redhat.com/errata/RHSA-2015-2101.html) RHEL's python has native SNI support