### PR TITLE
use base python from RHEL for SNI support

### DIFF
--- a/openshift_tools/zbxapi/__init__.py
+++ b/openshift_tools/zbxapi/__init__.py
@@ -40,9 +40,6 @@ import requests
 import httplib
 import copy
 
-from urllib3.contrib import pyopenssl
-pyopenssl.inject_into_urllib3()
-
 class ZabbixAPIError(Exception):
     '''
         ZabbixAPIError


### PR DESCRIPTION
starting with python-2.7.5-34.el7.src.rpm (https://rhn.redhat.com/errata/RHSA-2015-2101.html) RHEL's python has native SNI support