### PR TITLE
zagg-server doesn't need monitoring-openshift

### DIFF
--- a/scripts/openshift-tools-scripts.spec
+++ b/scripts/openshift-tools-scripts.spec
@@ -148,7 +148,7 @@ OpenShift Tools Zagg Client Monitoring Scripts
 # ----------------------------------------------------------------------------------
 %package monitoring-zagg-server
 Summary:       OpenShift Tools Zagg Server Monitoring Scripts
-Requires:      python2,python-openshift-tools-monitoring-openshift,python-openshift-tools-monitoring-zagg,python-openshift-tools-ansible
+Requires:      python2,python-openshift-tools-monitoring-zagg,python-openshift-tools-ansible
 BuildRequires: python2-devel
 BuildArch:     noarch
 


### PR DESCRIPTION
this dependency is pulling in atomic-openshift into zagg-web (where it isn't needed/used)