### PR TITLE
role to setup/install openshift-tools-scripts-inventory-clients

### DIFF
--- a/ansible/roles/ansible_inventory/README.md
+++ b/ansible/roles/ansible_inventory/README.md
@@ -1,0 +1,41 @@
+OpenShift Ansible Inventory
+=========
+
+Install and configure openshift-tools-scripts-inventory-clients.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+oo_inventory_group
+oo_inventory_user
+oo_inventory_accounts
+oo_inventory_cache_max_age
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+ASL 2.0
+
+Author Information
+------------------
+
+OpenShift operations, Red Hat, Inc

--- a/ansible/roles/ansible_inventory/defaults/main.yml
+++ b/ansible/roles/ansible_inventory/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+oo_inventory_group: root
+oo_inventory_owner: root
+oo_inventory_cache_max_age: 1800

--- a/ansible/roles/ansible_inventory/handlers/main.yml
+++ b/ansible/roles/ansible_inventory/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for openshift_ansible_inventory

--- a/ansible/roles/ansible_inventory/meta/main.yml
+++ b/ansible/roles/ansible_inventory/meta/main.yml
@@ -1,0 +1,8 @@
+---
+galaxy_info:
+  author: OpenShift Ops
+  description:  Install and configure openshift-tools-scripts-inventory-clients
+  company: Red Hat, Inc
+  license: ASL 2.0
+  min_ansible_version: 1.2
+dependencies: []

--- a/ansible/roles/ansible_inventory/tasks/main.yml
+++ b/ansible/roles/ansible_inventory/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Install openshift-tools-scripts-inventory-clients
+  yum:
+    name: openshift-tools-scripts-inventory-clients
+    state: present
+
+- name: Create/update multi_inventory.yaml
+  copy:
+    content: "{{ oo_inventory_accounts | to_nice_yaml }}"
+    dest: /etc/ansible/multi_inventory.yaml
+    group: "{{ oo_inventory_group }}"
+    owner: "{{ oo_inventory_owner }}"
+    mode: "0640"
+
+- file:
+    state: directory
+    dest: /etc/ansible/inventory
+    owner: root
+    group: libra_ops
+    mode: 0750
+
+- file:
+    state: link
+    src: /usr/share/ansible/inventory/multi_inventory.py
+    dest: /etc/ansible/inventory/multi_inventory.py
+    owner: root
+    group: libra_ops
+
+# This cron uses the above location to call its job
+- name: Cron to keep cache fresh
+  cron:
+    name: 'multi_inventory'
+    minute: '*/10'
+    job: '/usr/share/ansible/inventory/multi_inventory.py --refresh-cache &> /dev/null'
+  when: oo_cron_refresh_cache is defined and oo_cron_refresh_cache
+
+- name: Set cache location
+  file:
+    state: directory
+    dest: "{{ oo_inventory_cache_location | dirname }}"
+    owner: root
+    group: libra_ops
+    recurse: yes
+    mode: '2770'
+  when: oo_inventory_cache_location is defined

--- a/ansible/roles/ansible_inventory/vars/main.yml
+++ b/ansible/roles/ansible_inventory/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for openshift_ansible_inventory


### PR DESCRIPTION
copied from openshift-tools/openshift/installer/atomic-openshift-3.1/roles/openshift_ansible_inventory and modified to use openshift-tools\* RPMs
