### PR TITLE
set dm.basesize to 3G

### DIFF
--- a/ansible/roles/docker_storage_setup/templates/docker-storage-setup.j2
+++ b/ansible/roles/docker_storage_setup/templates/docker-storage-setup.j2
@@ -6,3 +6,4 @@ DEVS={{ dss_docker_device }}
 VG=docker_vg
 DATA_SIZE=99%VG
 AUTO_EXTEND_POOL=no
+EXTRA_DOCKER_STORAGE_OPTIONS="--storage-opt dm.basesize=3G"


### PR DESCRIPTION
EXTRA_DOCKER_STORAGE_OPTIONS is a no-op on 3.1 clusters because docker 1.8's /usr/bin/docker-storage-setup doesn't read/use it.
On 3.2 (docker 1.9) it will not allow container images sizes beyond 3G
