### PR TITLE
Add tdgc role

### DIFF
--- a/ansible/roles/temp_dir_git_clone/.travis.yml
+++ b/ansible/roles/temp_dir_git_clone/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible/roles/temp_dir_git_clone/README.md
+++ b/ansible/roles/temp_dir_git_clone/README.md
@@ -1,0 +1,49 @@
+temp_dir_git_clone
+==================
+
+A simple ansible module that will checkout a git repo to a temp
+directory. It will set a fact called tdgc_retval_repo_dir with a path to
+the cloned repository.
+
+Requirements
+------------
+None
+
+Role Variables
+--------------
+- tdgc_repo_name: name of the repository, used for the directory to checkout into
+- tdgc_repo: The git repository. ex: git@github.com:openshift/openshift-ansible.git
+- tdgc_branch: The branch to checkout
+
+Dependencies
+------------
+None
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      roles:
+         - { role: temp_dir_git_clone, repo_name: openshift_ansible, repo: "git@github.com:openshift/openshift-ansible" }
+      tasks:
+         - debug: var=tdgc_retval_repo_dir
+
+License
+-------
+Copyright 2015 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author Information
+------------------
+Openshift Operations, Red Hat, Inc.

--- a/ansible/roles/temp_dir_git_clone/README.md
+++ b/ansible/roles/temp_dir_git_clone/README.md
@@ -24,7 +24,7 @@ Example Playbook
 
     - hosts: localhost
       roles:
-         - { role: temp_dir_git_clone, repo_name: openshift_ansible, repo: "git@github.com:openshift/openshift-ansible" }
+         - { role: temp_dir_git_clone, tdgc_repo_name: openshift_ansible, tdgc_repo: "git@github.com:openshift/openshift-ansible" }
       tasks:
          - debug: var=tdgc_retval_repo_dir
 

--- a/ansible/roles/temp_dir_git_clone/defaults/main.yml
+++ b/ansible/roles/temp_dir_git_clone/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for temp_dir_git_clone

--- a/ansible/roles/temp_dir_git_clone/handlers/main.yml
+++ b/ansible/roles/temp_dir_git_clone/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for temp_dir_git_clone

--- a/ansible/roles/temp_dir_git_clone/meta/main.yml
+++ b/ansible/roles/temp_dir_git_clone/meta/main.yml
@@ -1,0 +1,8 @@
+galaxy_info:
+  author: OpenShift Ops
+  description: Clones a git repo to a temp directory
+  company: Red Hat, Inc.
+  issue_tracker_url: https://github.com/openshift/openshift-ansible-ops/issues
+  license: Apache
+  min_ansible_version: 1.9
+dependencies: []

--- a/ansible/roles/temp_dir_git_clone/tasks/main.yml
+++ b/ansible/roles/temp_dir_git_clone/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- fail:
+    msg: "Please define {{ item }}"
+  when: "{{ item }} is undefined"
+  with_items:
+  - tdgc_repo_name
+  - tdgc_repo
+
+- name: Creating temp directory
+  command: mktemp -d -t git_clone_temp_dir-XXXXXX
+  register: tempdir_output
+  tags:
+    - always
+
+- set_fact:
+    tdgc_dest_dir: "{{ tempdir_output.stdout }}"
+  tags:
+    - always
+
+- name: Clone the registry
+  git:
+    repo: "{{ tdgc_repo }}"
+    clone: yes
+    dest: "{{ tdgc_dest_dir }}/{{ tdgc_repo_name }}"
+    refspec: "refs/heads/{{ tdgc_branch }}"
+  tags:
+    - always
+
+- set_fact:
+    tdgc_retval_repo_dir: "{{ tdgc_dest_dir }}/{{ tdgc_repo_name }}"
+  tags:
+    - always

--- a/ansible/roles/temp_dir_git_clone/tests/inventory
+++ b/ansible/roles/temp_dir_git_clone/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/ansible/roles/temp_dir_git_clone/tests/test.yml
+++ b/ansible/roles/temp_dir_git_clone/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - temp_dir_git_clone

--- a/ansible/roles/temp_dir_git_clone/vars/main.yml
+++ b/ansible/roles/temp_dir_git_clone/vars/main.yml
@@ -1,0 +1,2 @@
+---
+tdgc_branch: master


### PR DESCRIPTION
Add new role for cloning a repository into a temp directory.

Useful for automating commits to another git repository.
