### PR TITLE
add step to remove /etc/sysconfig/docker-storage file

### DIFF
--- a/ansible/playbooks/adhoc/docker_storage_reinitialize/ops-docker-storage-reinitialize.yml
+++ b/ansible/playbooks/adhoc/docker_storage_reinitialize/ops-docker-storage-reinitialize.yml
@@ -75,6 +75,11 @@
       path: /var/lib/docker
       state: absent
 
+  - name: remove /etc/sysconfig/docker-storage (for any stray references to pools)
+    file:
+      path: /etc/sysconfig/docker-storage
+      state: absent
+
   - name: start docker-storage-setup to initialize the docker storage
     service:
       name: docker-storage-setup


### PR DESCRIPTION
old thin pool settings in the file can keep docker-storage-setup from working properly
