### PR TITLE
Etcd metric sender update with config

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_master.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_master.yml
@@ -349,6 +349,120 @@ g_template_openshift_master:
     applications:
     - Openshift Etcd
 
+  - key: openshift.etcd.server.file.descriptors.used.total
+    description: "High file descriptors might indicate a potential out of file descriptors issue. That might cause etcd fails to create new WAL files and panics"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.server.pending.proposal.total
+    description: "Pending proposal gives you an idea about how many proposal are in the queue and waiting for commit. An increasing pending number indicates a high client load or an unstable cluster."
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.server.proposal.failed.total
+    description: "Failed proposals are normally related to two issues: temporary failures related to a leader election or longer duration downtime caused by a loss of quorum in the cluster"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.storage.delete.total
+    description: "Total number of deletes seen by this member"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.storage.keys.total
+    description: "Total number of keys"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.storage.put.total
+    description: "Total number of puts seen by this member"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.storage.range.total
+    description: "Total number of ranges seen by this member"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.storage.txn.total
+    description: "Total number of txns seen by this member"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.expires.total
+    description: "Total number of expired keys (due to TTL)"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.reads.total.get
+    description: "Total number of reads from store, should differ among etcd members (local reads)"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.reads.total.getRecursive
+    description: "Total number of reads from store, should differ among etcd members (local reads)"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.watch.requests.total
+    description: "Total number of incoming watch requests to this etcd member (local watches)"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.watchers
+    description: "Current count of active watchers on this etcd member"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.writes.total.compareAndDelete
+    description: "Total number of writes to store, should be same among all etcd members"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.writes.total.compareAndSwap
+    description: "Total number of writes to store, should be same among all etcd members"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.writes.total.create
+    description: "Total number of writes to store, should be same among all etcd members"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.writes.total.delete
+    description: "Total number of writes to store, should be same among all etcd members"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.store.writes.total.set
+    description: "Total number of writes to store, should be same among all etcd members"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
+  - key: openshift.etcd.wal.last.index.saved
+    description: "The index of the last entry saved by wal"
+    value_type: int
+    applications:
+    - Openshift Etcd
+
   - key: openshift.master.metric.ping
     description: "This check verifies that the https://master/metrics check is alive and communicating properly."
     value_type: int
@@ -518,11 +632,6 @@ g_template_openshift_master:
     lifetime: 1
     description: "Dynamically register the Persistent Volumes"
 
-  - name: metrics.etcd
-    key: metrics.etcd
-    lifetime: 14
-    description: "Etcd metrics values coming from /metrics and"
-
   zitemprototypes:
   - discoveryrule_key: disc.pv
     name: "disc.pv.count.{#OSO_PV}"
@@ -537,20 +646,6 @@ g_template_openshift_master:
     key: "disc.pv.available[{#OSO_PV}]"
     value_type: int
     description: "Number of PV's of this size that are available"
-    applications:
-    - Openshift Master
-
-  - discoveryrule_key: metrics.etcd
-    name: "metrics.etcd.{#ETCD_METRIC}"
-    key: "metrics.etcd[{#ETCD_METRIC}]"
-    value_type: float
-    applications:
-    - Openshift Master
-
-  - discoveryrule_key: metrics.etcd
-    name: "metrics.etcd.name.{#ETCD_METRIC}"
-    key: "metrics.etcd.name[{#ETCD_METRIC}]"
-    value_type: text
     applications:
     - Openshift Master
 

--- a/ansible/roles/os_zabbix/vars/template_openshift_master.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_master.yml
@@ -518,6 +518,11 @@ g_template_openshift_master:
     lifetime: 1
     description: "Dynamically register the Persistent Volumes"
 
+  - name: metrics.etcd
+    key: metrics.etcd
+    lifetime: 14
+    description: "Etcd metrics values coming from /metrics and"
+
   zitemprototypes:
   - discoveryrule_key: disc.pv
     name: "disc.pv.count.{#OSO_PV}"
@@ -532,6 +537,20 @@ g_template_openshift_master:
     key: "disc.pv.available[{#OSO_PV}]"
     value_type: int
     description: "Number of PV's of this size that are available"
+    applications:
+    - Openshift Master
+
+  - discoveryrule_key: metrics.etcd
+    name: "metrics.etcd.{#ETCD_METRIC}"
+    key: "metrics.etcd[{#ETCD_METRIC}]"
+    value_type: float
+    applications:
+    - Openshift Master
+
+  - discoveryrule_key: metrics.etcd
+    name: "metrics.etcd.name.{#ETCD_METRIC}"
+    key: "metrics.etcd.name[{#ETCD_METRIC}]"
+    value_type: text
     applications:
     - Openshift Master
 

--- a/ansible/roles/oso_host_monitoring/files/etcd_metrics.yaml
+++ b/ansible/roles/oso_host_monitoring/files/etcd_metrics.yaml
@@ -1,0 +1,114 @@
+---
+etcd_info:
+  files:
+    ssl_client_cert: '/etc/origin/master/master.etcd-client.crt'
+    ssl_client_key: '/etc/origin/master/master.etcd-client.key'
+    openshift_master_config: '/etc/origin/master/master-config.yaml'
+  common:
+    prefix: 'openshift.master.'
+    disc_key: 'metrics.etcd'
+    disc_macro: '#ETCD_METRIC'
+  metrics:
+    - type: 'json'
+      path: '/v2/stats/store'
+      values:
+        - zab_key: 'create.success'
+          src: 'createSuccess'
+        - zab_key: 'create.fail'
+          src: 'createFail'
+        - zab_key: 'delete.success'
+          src: 'deleteSuccess'
+        - zab_key: 'delete.fail'
+          src: 'deleteFail'
+        - zab_key: 'get.success'
+          src: 'getsSuccess'
+        - zab_key: 'get.fail'
+          src: 'getsFail'
+        - zab_key: 'set.success'
+          src: 'setsSuccess'
+        - zab_key: 'set.fail'
+          src: 'setsFail'
+        - zab_key: 'update.success'
+          src: 'updateSuccess'
+        - zab_key: 'update.fail'
+          src: 'updateFail'
+        - zab_key: 'watchers'
+          src: 'watchers'
+    - type: 'text'
+      path: '/metrics'
+      values:
+        'etcd_server_file_descriptors_used_total' :
+        'etcd_server_pending_proposal_total' :
+        'etcd_server_proposal_failed_total' :
+        'etcd_storage_delete_total' :
+        'etcd_storage_keys_total' :
+        'etcd_storage_put_total' :
+        'etcd_storage_range_total' :
+        'etcd_storage_txn_total' :
+        'etcd_store_expires_total' :
+        'etcd_store_reads_total' : 'action'
+        'etcd_store_watch_requests_total' :
+        'etcd_store_watchers' :
+        'etcd_store_writes_total' : 'action'
+        'etcd_wal_last_index_saved' :
+
+
+# etcd 2.2.1 available metrics
+# TYPE etcd_rafthttp_message_sent_failed_total counter
+# TYPE etcd_rafthttp_message_sent_latency_microseconds summary
+# TYPE etcd_server_file_descriptors_used_total gauge
+# TYPE etcd_server_pending_proposal_total gauge
+# TYPE etcd_server_proposal_durations_milliseconds summary
+# TYPE etcd_server_proposal_failed_total counter
+# TYPE etcd_snapshot_save_marshalling_durations_microseconds summary
+# TYPE etcd_snapshot_save_total_durations_microseconds summary
+# TYPE etcd_storage_db_compaction_pause_duration_milliseconds histogram
+# TYPE etcd_storage_db_compaction_total_duration_milliseconds histogram
+# TYPE etcd_storage_delete_total counter
+# TYPE etcd_storage_index_compaction_pause_duration_milliseconds histogram
+# TYPE etcd_storage_keys_total gauge
+# TYPE etcd_storage_put_total counter
+# TYPE etcd_storage_range_total counter
+# TYPE etcd_storage_txn_total counter
+# TYPE etcd_store_expires_total counter
+# TYPE etcd_store_reads_total counter
+# TYPE etcd_store_watch_requests_total counter
+# TYPE etcd_store_watchers gauge
+# TYPE etcd_store_writes_total counter
+# TYPE etcd_wal_fsync_durations_microseconds summary
+# TYPE etcd_wal_last_index_saved gauge
+# TYPE go_gc_duration_seconds summary
+# TYPE go_goroutines gauge
+# TYPE go_memstats_alloc_bytes gauge
+# TYPE go_memstats_alloc_bytes_total counter
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+# TYPE go_memstats_frees_total counter
+# TYPE go_memstats_gc_sys_bytes gauge
+# TYPE go_memstats_heap_alloc_bytes gauge
+# TYPE go_memstats_heap_idle_bytes gauge
+# TYPE go_memstats_heap_inuse_bytes gauge
+# TYPE go_memstats_heap_objects gauge
+# TYPE go_memstats_heap_released_bytes_total counter
+# TYPE go_memstats_heap_sys_bytes gauge
+# TYPE go_memstats_last_gc_time_seconds gauge
+# TYPE go_memstats_lookups_total counter
+# TYPE go_memstats_mallocs_total counter
+# TYPE go_memstats_mcache_inuse_bytes gauge
+# TYPE go_memstats_mcache_sys_bytes gauge
+# TYPE go_memstats_mspan_inuse_bytes gauge
+# TYPE go_memstats_mspan_sys_bytes gauge
+# TYPE go_memstats_next_gc_bytes gauge
+# TYPE go_memstats_other_sys_bytes gauge
+# TYPE go_memstats_stack_inuse_bytes gauge
+# TYPE go_memstats_stack_sys_bytes gauge
+# TYPE go_memstats_sys_bytes gauge
+# TYPE http_request_duration_microseconds summary
+# TYPE http_request_size_bytes summary
+# TYPE http_requests_total counter
+# TYPE http_response_size_bytes summary
+# TYPE process_cpu_seconds_total counter
+# TYPE process_max_fds gauge
+# TYPE process_open_fds gauge
+# TYPE process_resident_memory_bytes gauge
+# TYPE process_start_time_seconds gauge
+# TYPE process_virtual_memory_bytes gauge

--- a/ansible/roles/oso_host_monitoring/files/etcd_metrics.yaml
+++ b/ansible/roles/oso_host_monitoring/files/etcd_metrics.yaml
@@ -4,12 +4,9 @@ etcd_info:
     ssl_client_cert: '/etc/origin/master/master.etcd-client.crt'
     ssl_client_key: '/etc/origin/master/master.etcd-client.key'
     openshift_master_config: '/etc/origin/master/master-config.yaml'
-  common:
-    prefix: 'openshift.master.'
-    disc_key: 'metrics.etcd'
-    disc_macro: '#ETCD_METRIC'
   metrics:
     - type: 'json'
+      prefix: 'openshift.etcd.'
       path: '/v2/stats/store'
       values:
         - zab_key: 'create.success'
@@ -35,6 +32,7 @@ etcd_info:
         - zab_key: 'watchers'
           src: 'watchers'
     - type: 'text'
+      prefix: 'openshift.'
       path: '/metrics'
       values:
         'etcd_server_file_descriptors_used_total' :

--- a/ansible/roles/oso_host_monitoring/tasks/main.yml
+++ b/ansible/roles/oso_host_monitoring/tasks/main.yml
@@ -54,6 +54,14 @@
   notify:
   - "Restart the {{ osohm_host_monitoring }} service"
 
+- name: "Copy etcd metrics config file"
+  copy:
+    src: etcd_metrics.yaml
+    dest: /etc/openshift_tools/etcd_metrics.yaml
+    owner: root
+    group: root
+    mode: 0644
+  
 - name: "Copy {{ osohm_host_monitoring }} systemd file"
   template:
     src: "{{ osohm_host_monitoring }}.service.j2"

--- a/scripts/monitoring/cron-send-etcd-status.py
+++ b/scripts/monitoring/cron-send-etcd-status.py
@@ -2,61 +2,150 @@
 '''
    Command to send status of etcd to zabbix
 '''
-
+# vim: expandtab:tabstop=4:shiftwidth=4
 #This is not a module, but pylint thinks it is.  This is a command.
 #pylint: disable=invalid-name
+#If we break the few lines it will be harder to read in this case
+#pylint: disable=line-too-long
 
-from openshift_tools.monitoring.zagg_sender import ZaggSender
+
+import argparse
 import json
+import sys
 import yaml
 import requests
 
-def main():
-    ''' Get data from etcd API
-    '''
+# Reason: disable pylint import-error because our libs aren't loaded on jenkins.
+# Status: temporary until we start testing in a container where our stuff is installed.
+# pylint: disable=import-error
+from openshift_tools.monitoring.zagg_sender import ZaggSender
+from prometheus_client.parser import text_string_to_metric_families
 
-    SSL_CLIENT_CERT = '/etc/origin/master/master.etcd-client.crt'
-    SSL_CLIENT_KEY = '/etc/origin/master/master.etcd-client.key'
-    OPENSHIFT_MASTER_CONFIG = '/etc/origin/master/master-config.yaml'
+class EtcdStatusZaggSender(object):
+    """ class to gather all metrics from etcd daemons """
 
-    # find out the etcd port
-    with open(OPENSHIFT_MASTER_CONFIG, 'r') as f:
-        config = yaml.load(f)
+    def __init__(self):
+        self.api_host = None
+        self.args = None
+        self.parser = None
+        self.config = None
+        self.etcd_ping = 0
+        self.default_config = '/etc/openshift_tools/etcd_metrics.yaml'
+        self.zagg_sender = ZaggSender()
 
-    API_HOST = config["etcdClientInfo"]["urls"][0]
+    def parse_args(self):
+        '''Parse the arguments for this script'''
+        self.parser = argparse.ArgumentParser(description="Script that gathers metrics from etcd")
+        self.parser.add_argument('-d', '--debug', default=False,
+                                 action="store_true", help="debug mode")
+        self.parser.add_argument('-v', '--verbose', default=False,
+                                 action="store_true", help="Verbose?")
+        self.parser.add_argument('-t', '--test', default=False,
+                                 action="store_true", help="Run the script but don't send to zabbix")
+        self.parser.add_argument('-c', '--configfile', default=self.default_config,
+                                 help="Config file that contains metrics to be collected, defaults to etcd_metrics.yml")
 
-    # define the store API URL
-    API_URL = API_HOST + "/v2/stats/store"
+        self.args = self.parser.parse_args()
 
+    def call_etcd_api(self, rest_path):
+        '''Makes the API calls to rest endpoints in etcd'''
+        try:
+            response = requests.get(self.api_host + rest_path,
+                                    cert=(self.config['etcd_info']['files']['ssl_client_cert'],
+                                          self.config['etcd_info']['files']['ssl_client_key']),
+                                    verify=False)
+            self.etcd_ping = 1
+        except requests.exceptions.ConnectionError as ex:
+            print "ERROR talking to etcd API: {0}".format(ex.message)
+        else:
+            return response.content
 
-    zs = ZaggSender()
-    # Fetch the store statics from API
-    try:
-        request = requests.get(API_URL, cert=(SSL_CLIENT_CERT, SSL_CLIENT_KEY), verify=False)
-        content = json.loads(request.content)
-        etcd_ping = 1
+    def json_metric(self, met):
+        '''process json data from etcd'''
+        return_data = {}
+        api_response = self.call_etcd_api(met['path'])
+        if api_response:
+            content = json.loads(api_response.json())
 
-        # parse the items and add it as metrics
-        zs.add_zabbix_keys({'openshift.master.etcd.create.success' : content['createSuccess']})
-        zs.add_zabbix_keys({'openshift.master.etcd.create.fail' : content['createFail']})
-        zs.add_zabbix_keys({'openshift.master.etcd.delete.success' : content['deleteSuccess']})
-        zs.add_zabbix_keys({'openshift.master.etcd.delete.fail' : content['deleteFail']})
-        zs.add_zabbix_keys({'openshift.master.etcd.get.success' : content['getsSuccess']})
-        zs.add_zabbix_keys({'openshift.master.etcd.get.fail' : content['getsFail']})
-        zs.add_zabbix_keys({'openshift.master.etcd.set.success' : content['setsSuccess']})
-        zs.add_zabbix_keys({'openshift.master.etcd.set.fail' : content['setsFail']})
-        zs.add_zabbix_keys({'openshift.master.etcd.update.success' : content['updateSuccess']})
-        zs.add_zabbix_keys({'openshift.master.etcd.update.fail' : content['updateFail']})
-        zs.add_zabbix_keys({'openshift.master.etcd.watchers' : content['watchers']})
+            for item in met['values']:
+                return_data[self.config['etcd_info']['common']['prefix'] + item['zab_key']] = content[item['src']]
 
-    except requests.exceptions.ConnectionError as ex:
-        print "ERROR talking to etcd API: %s" % ex.message
-        etcd_ping = 0
+        return return_data
 
-    zs.add_zabbix_keys({'openshift.master.etcd.ping' : etcd_ping})
+    def text_metric(self, met):
+        '''process text value from etcd'''
+        return_data = {}
+        dyn_keys = []
 
-    # Finally, sent them to zabbix
-    zs.send_metrics()
+        content = self.call_etcd_api(met['path'])
+        if content:
+            for metric in text_string_to_metric_families(content):
+                # skipping histogram and summary types unless we find a good way to add them to zabbix (unlikely)
+                if metric.type in ['histogram', 'summary']:
+                    continue
+                elif metric.type in ['counter', 'gauge'] and metric.name in met['values']:
+                    zab_metric_name = metric.name.replace('_', '.')
+                    return_data['metrics.etcd.name[{0}]'.format(zab_metric_name)] = zab_metric_name
+                    if len(metric.samples) > 1:
+                        if met['values'][metric.name]:
+                            sub_key = met['values'][metric.name]
+                        for singlemetric in metric.samples:
+                            return_data['metrics.etcd[{0}.{1}]'.format(zab_metric_name, singlemetric[1][sub_key])] = singlemetric[2]
+                            dyn_keys.append(zab_metric_name + '.' + singlemetric[1][sub_key])
+                    else:
+                        return_data['metrics.etcd[{0}]'.format(zab_metric_name)] = metric.samples[0][2]
+                        dyn_keys.append(zab_metric_name)
+                else:
+                    if self.args.debug:
+                        print 'Got unknown type of metric from etcd, skipping it: ({0}) '.format(metric.type)
+
+        return return_data, dyn_keys
+
+    def run(self):
+        ''' Get data from etcd API
+        '''
+        self.parse_args()
+
+        try:
+            with open(self.args.configfile, 'r') as configfile:
+                self.config = yaml.load(configfile)
+        except IOError as ex:
+            print 'There was a problem opening the config file: {0}'.format(ex)
+            print 'Exiting'
+            sys.exit(1)
+
+        # find out the etcd port
+        try:
+            with open(self.config['etcd_info']['files']['openshift_master_config'], 'r') as f:
+                om_config = yaml.load(f)
+        except IOError as ex:
+            print 'Problem opening openshift master config: {0}'.format(ex)
+            sys.exit(2)
+        else:
+            self.api_host = om_config["etcdClientInfo"]["urls"][0]
+
+        # let's get the metrics
+        for metric in self.config['etcd_info']['metrics']:
+            if metric['type'] == 'text':
+                zkeys, dynamic_keys = self.text_metric(metric)
+                if zkeys and dynamic_keys:
+                    self.zagg_sender.add_zabbix_dynamic_item('metrics.etcd', '#ETCD_METRIC', dynamic_keys)
+                    self.zagg_sender.add_zabbix_keys(zkeys)
+            elif metric['type'] == 'json':
+                self.zagg_sender.add_zabbix_keys(self.json_metric(metric))
+
+        self.send_zagg_data()
+
+    def send_zagg_data(self):
+        ''' Sending the data to zagg or displaying it in console when test option is used
+        '''
+        self.zagg_sender.add_zabbix_keys({'openshift.master.etcd.ping' : self.etcd_ping})
+
+        if not self.args.test:
+            self.zagg_sender.send_metrics()
+        else:
+            self.zagg_sender.print_unique_metrics()
 
 if __name__ == '__main__':
-    main()
+    ESZS = EtcdStatusZaggSender()
+    ESZS.run()


### PR DESCRIPTION
No changes to the spec file or crontabs deployed in oso_host_monitoring because I rewrote the existing etcd_stats sender and incorporated the old parts as a separate section coming from the config  in the new design. 

The reason there is 2 commits in this PR because I wanted to preserve the fully dynamic way in case we decide to go that route in the future or we need something like it in a different check.
