### PR TITLE
add synthetic cluster-wide host support to ops-zagg-client

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -69,6 +69,13 @@ zagg_client_config:
     - "{{ osohm_cluster_id }}"
     - "{{ osohm_environment }}"
 
+  synthetic_clusterwide:
+    host:
+      name: "{{ osohm_cluster_id }}-synthetic"
+    heartbeat:
+      templates:
+      - Template Heartbeat        # So we can send hearbeats
+
 # Generic Linux Checks
 host_monitoring_cron:
 - name: send pcp ping every 5 mintues

--- a/docker/oso-host-monitoring/centos7/monitoring-config.yml
+++ b/docker/oso-host-monitoring/centos7/monitoring-config.yml
@@ -54,6 +54,12 @@ zagg_client_config:
     hostgroups:
     - undefcid
     - undefenv
+  synthetic_clusterwide:
+    host:
+      name: undefcid-synthetic
+    heartbeat:
+      templates:
+      - Template Heartbeat        # So we can send heartbeats
 
 host_monitoring_cron:
 - name: send pcp ping every 5 minutes

--- a/docker/oso-host-monitoring/rhel7/monitoring-config.yml
+++ b/docker/oso-host-monitoring/rhel7/monitoring-config.yml
@@ -54,6 +54,12 @@ zagg_client_config:
     hostgroups:
     - undefcid
     - undefenv
+  synthetic_clusterwide:
+    host:
+      name: undefcid-synthetic
+    heartbeat:
+      templates:
+      - Template Heartbeat        # So we can send heartbeats
 
 host_monitoring_cron:
 - name: send pcp ping every 5 minutes

--- a/docker/oso-host-monitoring/src/monitoring-config.yml
+++ b/docker/oso-host-monitoring/src/monitoring-config.yml
@@ -54,6 +54,12 @@ zagg_client_config:
     hostgroups:
     - undefcid
     - undefenv
+  synthetic_clusterwide:
+    host:
+      name: undefcid-synthetic
+    heartbeat:
+      templates:
+      - Template Heartbeat        # So we can send heartbeats
 
 host_monitoring_cron:
 - name: send pcp ping every 5 minutes

--- a/scripts/monitoring/ops-zagg-client.py
+++ b/scripts/monitoring/ops-zagg-client.py
@@ -2,6 +2,8 @@
 # vim: expandtab:tabstop=4:shiftwidth=4
 #This is not a module, but pylint thinks it is.  This is a command.
 #pylint: disable=invalid-name
+# pylint flaggs import errors, as the bot doesn't know have openshift-tools libs
+#pylint: disable=import-error
 """
 ops-zagg-client: Script that sends metrics to zagg.
 
@@ -67,7 +69,13 @@ class OpsZaggClient(object):
         """ parse the args from the cli """
         parser = argparse.ArgumentParser(description='Zagg metric sender')
         parser.add_argument('--send-heartbeat', help="send heartbeat metric to zagg", action="store_true")
-        parser.add_argument('-s', '--host', help='specify host name as registered in Zabbix')
+
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('-s', '--host',
+                           help='specify host name as registered in Zabbix')
+        group.add_argument('--synthetic', default=False, action='store_true',
+                           help='send as cluster-wide synthetic host')
+
         parser.add_argument('-z', '--zagg-url', help='url of Zagg server')
         parser.add_argument('--zagg-user', help='username of the Zagg server')
         parser.add_argument('--zagg-pass', help='Password of the Zagg server')
@@ -101,7 +109,12 @@ class OpsZaggClient(object):
         zagg_verbose = self.args.verbose if self.args.verbose else self.config['zagg']['verbose']
         zagg_debug = self.args.debug if self.args.debug else self.config['zagg']['debug']
         zagg_ssl_verify = self.args.zagg_ssl_verify if self.args.zagg_ssl_verify else self.config['zagg']['ssl_verify']
-        host = self.args.host if self.args.host else self.config['host']['name']
+        if self.args.host:
+            host = self.args.host
+        elif self.args.synthetic:
+            host = self.config['synthetic_clusterwide']['host']['name']
+        else:
+            host = self.config['host']['name']
 
         if isinstance(zagg_verbose, str):
             zagg_verbose = (zagg_verbose == 'True')
@@ -123,9 +136,14 @@ class OpsZaggClient(object):
 
     def add_heartbeat(self):
         """ crate a hearbeat metric """
-        heartbeat = ZaggHeartbeat(templates=self.config['heartbeat']['templates'],
-                                  hostgroups=self.config['heartbeat']['hostgroups'],
-                                 )
+        if self.args.synthetic:
+            heartbeat = ZaggHeartbeat(templates=self.config['synthetic_clusterwide']['heartbeat']['templates'],
+                                      hostgroups=self.config['heartbeat']['hostgroups'],
+                                     )
+        else:
+            heartbeat = ZaggHeartbeat(templates=self.config['heartbeat']['templates'],
+                                      hostgroups=self.config['heartbeat']['hostgroups'],
+                                     )
         self.zagg_sender.add_heartbeat(heartbeat)
 
     def add_zabbix_key(self):


### PR DESCRIPTION
also add synthetic host metadata to zagg_client.yaml
Example registering and sending synthetic host data:
  ops-zagg-client --send-heartbeat --synthetic
  ops-zagg-client --synthetic -k heartbeat.ping -o 1
