### PR TITLE
 container build env fingerprint

### DIFF
--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -85,6 +85,9 @@ RUN mkdir -p /root/.aws && \
     touch /root/.aws/credentials && \
     chmod g+rw /root/.aws/credentials
 
+# Add container-build-env-fingerprint
+ADD container-build-env-fingerprint.output /etc/oso-container-build-env-fingerprint
+
 # Add the start script and tell the container to run it by default
 ADD start.sh /usr/local/bin/
 CMD /usr/local/bin/start.sh

--- a/docker/oso-host-monitoring/centos7/build.sh
+++ b/docker/oso-host-monitoring/centos7/build.sh
@@ -14,6 +14,10 @@ sudo echo -e "\nTesting sudo works...\n"
 # We MUST be in the same directory as this script for the build to work properly
 cd $(dirname $0)
 
+# generate container fingerprint (user/location/timestamp/git information)
+container_fingerprint='./container-build-env-fingerprint.output'
+./container-build-env-fingerprint.sh > ${container_fingerprint}
+
 ## Make sure base is built with latest changes since we depend on it.
 # commenting this out for now because ops-base does a full rebuild everytime
 #if ../oso-rhel7-ops-base/build.sh ; then
@@ -23,3 +27,6 @@ cd $(dirname $0)
   sudo time docker build $@ -t oso-centos7-host-monitoring . && \
   sudo docker tag -f oso-centos7-host-monitoring openshifttools/oso-centos7-host-monitoring:latest
 #fi
+
+# cleanup
+rm -f ${container_fingerprint}

--- a/docker/oso-host-monitoring/centos7/container-build-env-fingerprint.sh
+++ b/docker/oso-host-monitoring/centos7/container-build-env-fingerprint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cat << EOF
+BuildUsername: `whoami`
+BuildDate: `date`
+BuildHostname: `hostname`
+BuildFilesystemLocation: `pwd`
+
+git remote -v
+`git remote -v`
+
+git log -3:
+`git log -3`
+EOF
+

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -79,6 +79,9 @@ RUN mkdir -p /root/.aws && \
     touch /root/.aws/credentials && \
     chmod g+rw /root/.aws/credentials
 
+# Add container-build-env-fingerprint
+ADD container-build-env-fingerprint.output /etc/oso-container-build-env-fingerprint
+
 # Add the start script and tell the container to run it by default
 ADD start.sh /usr/local/bin/
 CMD /usr/local/bin/start.sh

--- a/docker/oso-host-monitoring/rhel7/build.sh
+++ b/docker/oso-host-monitoring/rhel7/build.sh
@@ -14,6 +14,10 @@ sudo echo -e "\nTesting sudo works...\n"
 # We MUST be in the same directory as this script for the build to work properly
 cd $(dirname $0)
 
+# generate container fingerprint (user/location/timestamp/git information)
+container_fingerprint='./container-build-env-fingerprint.output'
+./container-build-env-fingerprint.sh > ${container_fingerprint}
+
 ## Make sure base is built with latest changes since we depend on it.
 # commenting this out for now because ops-base does a full rebuild everytime
 #if ../oso-rhel7-ops-base/build.sh ; then
@@ -23,3 +27,6 @@ cd $(dirname $0)
   sudo time docker build $@ -t oso-rhel7-host-monitoring . && \
   sudo docker tag -f oso-rhel7-host-monitoring docker-registry.ops.rhcloud.com/ops/oso-rhel7-host-monitoring
 #fi
+
+# cleanup
+rm -f ${container_fingerprint}

--- a/docker/oso-host-monitoring/rhel7/container-build-env-fingerprint.sh
+++ b/docker/oso-host-monitoring/rhel7/container-build-env-fingerprint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cat << EOF
+BuildUsername: `whoami`
+BuildDate: `date`
+BuildHostname: `hostname`
+BuildFilesystemLocation: `pwd`
+
+git remote -v
+`git remote -v`
+
+git log -3:
+`git log -3`
+EOF
+

--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -83,6 +83,9 @@ RUN mkdir -p /root/.aws && \
     touch /root/.aws/credentials && \
     chmod g+rw /root/.aws/credentials
 
+# Add container-build-env-fingerprint
+ADD container-build-env-fingerprint.output /etc/oso-container-build-env-fingerprint
+
 # Add the start script and tell the container to run it by default
 ADD start.sh /usr/local/bin/
 CMD /usr/local/bin/start.sh

--- a/docker/oso-host-monitoring/src/build.sh.j2
+++ b/docker/oso-host-monitoring/src/build.sh.j2
@@ -6,6 +6,10 @@ sudo echo -e "\nTesting sudo works...\n"
 # We MUST be in the same directory as this script for the build to work properly
 cd $(dirname $0)
 
+# generate container fingerprint (user/location/timestamp/git information)
+container_fingerprint='./container-build-env-fingerprint.output'
+./container-build-env-fingerprint.sh > ${container_fingerprint}
+
 ## Make sure base is built with latest changes since we depend on it.
 # commenting this out for now because ops-base does a full rebuild everytime
 #if ../oso-rhel7-ops-base/build.sh ; then
@@ -20,3 +24,6 @@ cd $(dirname $0)
   sudo docker tag -f oso-centos7-host-monitoring openshifttools/oso-centos7-host-monitoring:latest
 {% endif %}
 #fi
+
+# cleanup
+rm -f ${container_fingerprint}

--- a/docker/oso-host-monitoring/src/container-build-env-fingerprint.sh
+++ b/docker/oso-host-monitoring/src/container-build-env-fingerprint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cat << EOF
+BuildUsername: `whoami`
+BuildDate: `date`
+BuildHostname: `hostname`
+BuildFilesystemLocation: `pwd`
+
+git remote -v
+`git remote -v`
+
+git log -3:
+`git log -3`
+EOF
+


### PR DESCRIPTION
Gather information from the build environment and store this in /etc/oso-container-build-env-fingerprint.

This is to help quickly identify exactly which version of the container is currently deployed, along with who built it, and from which machine it was built.

It will help solve problems when older versions of the container are built, tagged as latest, and deployed.

Was https://github.com/openshift/openshift-tools/pull/892

Speaking with @gburges I wasn't aware we don't merge stg->prod any time .. this PR should solve that
