### PR TITLE
Print first IP address in json output.

### DIFF
--- a/scripts/inventory-clients/ohi
+++ b/scripts/inventory-clients/ohi
@@ -104,7 +104,7 @@ class Ohi(object):
         for host in hosts:
             temp_host = {
                 'name': host,
-                'ip': self.aws.convert_to_ip(host)
+                'ip': self.aws.convert_to_ip(host)[0]
             }
             out_hosts.append(temp_host)
         print json.dumps(out_hosts)


### PR DESCRIPTION
convert_to_ip will return 1 ipaddress in our use case(awsutil converts the host into an array and returns the array of ip address).

:+1: by @kwoodson in #959 
