### PR TITLE
use renamed oo_ec2_ami20 module

### DIFF
--- a/ansible/roles/openshift_aws_ami_perms/README.md
+++ b/ansible/roles/openshift_aws_ami_perms/README.md
@@ -14,7 +14,7 @@ Role Variables
 
 osaap_src_ami_access_id: AWS Access Key (with permissions to share) of the SRC account
 osaap_src_ami_access_key  AWS Secret Key (with permissions to share) of the SRC account
-osaap_dest_aws_accountid: The account that needs access to the AMI
+osaap_dest_aws_accountid: The account that needs access to the AMI (launch and copy)
 osaap_region: region the ami lives in and will be shared in
 osaap_image_id: AMI id
 

--- a/ansible/roles/openshift_aws_ami_perms/tasks/main.yml
+++ b/ansible/roles/openshift_aws_ami_perms/tasks/main.yml
@@ -5,10 +5,11 @@
       user_ids:
       - "{{ osaap_dest_aws_accountid }}"
 
-- name: Add permissions to AMI to new aws account
-  ec2_ami20:
+- name: Add launch and copy permissions to AMI to new aws account
+  oo_ec2_ami20:
     aws_access_key: "{{ osaap_src_ami_access_id }}"
     aws_secret_key: "{{ osaap_src_ami_access_key }}"
     region: "{{ osaap_region }}"
     image_id: "{{ osaap_image_id }}"
     launch_permissions: "{{ dest_account_id }}"
+    copy_permissions: "{{ dest_account_id }}"


### PR DESCRIPTION
and unconditionally pass the account ID to oo_ec2_ami20 to also grant AMI copy permissions (to allow creating encrypted AMIs in the target account).
