### PR TITLE
add role that can be called during cluster creation

### DIFF
--- a/ansible/roles/openshift_aws_ami_copy/README.md
+++ b/ansible/roles/openshift_aws_ami_copy/README.md
@@ -1,0 +1,49 @@
+openshift_aws_ami_perms
+=========
+
+Ansible role for copying an AMI
+
+Requirements
+------------
+
+Ansible Modules:
+
+
+Role Variables
+--------------
+
+osaac_aws_access_key: AWS Access Key (can chose to not pass in and just read env vars)
+osaac_aws_secret_key: AWS Secret Key (can chose to not pass in and just read env vars)
+osaac_src_ami: source AMI id to copy from
+osaac_region: region where the AMI is found
+osaac_name: name to assign to new AMI
+osaac_kms_alias: AWS IAM KMS alias name of the key to use for encryption
+osaac_ami_directory: directory for where the role should place the yaml file that records the id of the AMI that was generated
+
+Dependencies
+------------
+
+
+Example Playbook
+----------------
+
+  - role: tools_roles/openshift_aws_ami_copy
+    osaac_aws_access_key: XXXXXXXXXX
+    osaac_aws_secret_key: YYYYYYYYY
+    osaac_region: us-west-1
+    osaac_src_ami: ami-123456
+    osaac_name: "new AMI with encryption"
+    osaac_encrypt: True
+    osaac_kms_alias: "alias/custom_kms_key"
+    osaac_ami_directory: "/var/lib/git/repo/ami"
+
+
+License
+-------
+
+Apache 2.0
+
+Author Information
+------------------
+
+Openshift Operations

--- a/ansible/roles/openshift_aws_ami_copy/meta/main.yml
+++ b/ansible/roles/openshift_aws_ami_copy/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: OpenShift Ops
+  description: Openshift Operations AWS AMI copy Role
+  company: Red Hat, Inc
+  license: ASL 2.0
+  min_ansible_version: 1.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+dependencies:
+- tools_roles/lib_utils

--- a/ansible/roles/openshift_aws_ami_copy/tasks/main.yml
+++ b/ansible/roles/openshift_aws_ami_copy/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- fail:
+    msg: "{{ item }} needs to be defined"
+  when: "{{ item }} is not defined"
+  with_items:
+  - osaac_ami_directory
+  - osaac_kms_alias
+  - osaac_src_ami
+  - osaac_name
+  - osaac_region
+
+- name: Create copied AMI image
+  oo_ec2_ami_copy:
+    state: present
+    region: "{{ osaac_region }}"
+    name: "{{ osaac_name }}"
+    ami_id: "{{ osaac_src_ami }}"
+    encrypt: True
+    kms_alias: "{{ osaac_kms_alias }}"
+    wait_sec: "{{ osaac_wait_sec | default(omit) }}"
+  register: copy_result
+    
+- debug: var=copy_result
+
+- name: create path to store AMI
+  file:
+    path: "{{ osaac_ami_directory }}"
+    recurse: yes
+    state: directory
+
+- name: Save AMI ID
+  copy:
+    content: |
+      ---
+      g_ec2_image:
+        {{ osaac_region }}: {{ copy_result['results']['ImageId'] }}
+    dest: "{{ osaac_ami_directory }}/ami.yml"


### PR DESCRIPTION
creates encrypted AMI using passed-in KMS alias name
saves ID of new AMI to specified directory (ie ../<account>/<env>/<cluster>/<sublocation>/ami.yml)
