### PR TITLE
[POC]  Send numerical metrics to Hawkular time-series database

### DIFF
--- a/openshift_tools/monitoring/hawk_client.py
+++ b/openshift_tools/monitoring/hawk_client.py
@@ -5,30 +5,36 @@ HawkClient uses the openshift_tools.web/rest.py
 
 Example usage:
 
-
+    from openshift_tools.monitoring.metricmanager import UniqueMetric
     from openshift_tools.monitoring.hawk_common import HawkConnection
+    from openshift_tools.monitoring.hawk_client import HawkClient
 
-     ml = []
-     # UniqueMetric from openshift_tools.monitoring.metricmanager
-     new_metric = UniqueMetric('example.com','cpu/usage',12.34)
-     ml.append(new_metric)
-     new_metric = UniqueMetric('example.org','cpu/usage',4.2)
-     ml.append(new_metric)
+    ml = []
+    # UniqueMetric from openshift_tools.monitoring.metricmanager
+    new_metric = UniqueMetric('example.com','cpu/usage',12.34)
+    ml.append(new_metric)
+    new_metric = UniqueMetric('example.org','cpu/usage',4.2)
+    ml.append(new_metric)
 
-     # No Auth
-     zc = HawkClient(host='172.17.0.27:8000')
+    # No Auth
+    connection = HawkConnection(url='172.17.0.27:8000')
 
-     # Basic Auth
-     zc = HawkClient(host='172.17.0.27:8000', user='user', passwd='password')
+    # Basic Auth
+    connection = HawkConnection(url='172.17.0.27:8000', user='user', passwd='password')
 
-     print zc.add_metric(ml)
-
+    client = HawkClient(connection)
+    print client.add_metric(ml)
 """
 #These are not installed on the buildbot, disabling this
 #pylint: disable=no-name-in-module,unused-import
 from openshift_tools.monitoring.metricmanager import UniqueMetric, MetricManager
 from openshift_tools.monitoring.hawk_common import HawkConnection
-from hawkular.metrics import HawkularMetricsClient, MetricType, Availability
+
+# The hawkular client is optional
+try:
+    from hawkular.metrics import HawkularMetricsClient, MetricType, Availability
+except ImportError:
+    pass
 
 #This class implements rest calls. We only have one rest call implemented
 # add-metric.  More could be added here
@@ -42,6 +48,12 @@ class HawkClient(object):
         # pylint doesn't know where RestAPI is
         #pylint: disable=undefined-variable
         self.hawk_conn = hawk_connection
+        self.client = None
+
+        # Do not create a client if inactive
+        if self.hawk_conn.inactive:
+            return
+
         self.client = HawkularMetricsClient(host=self.hawk_conn.host,
                                             port=self.hawk_conn.port,
                                             scheme=self.hawk_conn.scheme,
@@ -78,6 +90,10 @@ class HawkClient(object):
         """
         Add a list of UniqueMetrics (unique_metric_list) via hawkular client
         """
+        # Do not run if inactive
+        if not self.client:
+            return
+
         metric_list = [m for m in unique_metric_list if m.key != 'heartbeat']
         heartbeat_list = [m for m in unique_metric_list if m.key == 'heartbeat']
 

--- a/openshift_tools/monitoring/hawk_client.py
+++ b/openshift_tools/monitoring/hawk_client.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python2
+# vim: expandtab:tabstop=4:shiftwidth=4
+"""
+HawkClient uses the openshift_tools.web/rest.py
+
+Example usage:
+
+
+    from openshift_tools.monitoring.hawk_common import HawkConnection
+
+     ml = []
+     # UniqueMetric from openshift_tools.monitoring.metricmanager
+     new_metric = UniqueMetric('example.com','cpu/usage',12.34)
+     ml.append(new_metric)
+     new_metric = UniqueMetric('example.org','cpu/usage',4.2)
+     ml.append(new_metric)
+
+     # No Auth
+     zc = HawkClient(host='172.17.0.27:8000')
+
+     # Basic Auth
+     zc = HawkClient(host='172.17.0.27:8000', user='user', passwd='password')
+
+     print zc.add_metric(ml)
+
+"""
+#These are not installed on the buildbot, disabling this
+#pylint: disable=no-name-in-module,unused-import
+from openshift_tools.monitoring.metricmanager import UniqueMetric, MetricManager
+from openshift_tools.monitoring.hawk_common import HawkConnection
+from hawkular.metrics import HawkularMetricsClient, MetricType
+
+#This class implements rest calls. We only have one rest call implemented
+# add-metric.  More could be added here
+#pylint: disable=too-few-public-methods
+class HawkClient(object):
+    """
+    wrappers class around hawkular client python so use can use it with UniqueMetric
+    """
+
+    def __init__(self, hawk_connection, headers=None):
+        # pylint doesn't know where RestAPI is
+        #pylint: disable=undefined-variable
+        self.hawk_conn = hawk_connection
+        self.client = HawkularMetricsClient(host=self.hawk_conn.host,
+                                            port=self.hawk_conn.port,
+                                            scheme=self.hawk_conn.scheme,
+                                            username=self.hawk_conn.username,
+                                            password=self.hawk_conn.password,
+                                            context=self.hawk_conn.context,
+                                            tenant_id=self.hawk_conn.tenant_id,
+                                           )
+
+    def add_metric(self, unique_metric_list):
+        """
+        Add a list of UniqueMetrics (unique_metric_list) via hawkular client
+        """
+        metric_list = []
+        for metric in unique_metric_list:
+            # Hawkular metrics support only numeric values
+            value = float(metric.value)
+            # Hawkular metrics use milliseconds
+            clock = metric.clock * 1000
+            # Add the group and host to the key
+            key = '{0}/{1}/{2}'.format('ops', metric.host, metric.key)
+            # Use MetricType.Gauge for metrics data
+            metric_type = MetricType.Gauge
+
+            self.client.push(metric_type, key, value, clock)
+
+        status, raw_respons = None, None
+        return (status, raw_respons)

--- a/openshift_tools/monitoring/hawk_common.py
+++ b/openshift_tools/monitoring/hawk_common.py
@@ -5,7 +5,7 @@ hawk_common contains common data structures and utils
 Example usage:
     from openshift_tools.monitoring.hawk_common import HawkConnection, HawkHeartbeat
 
-    ZAGGCONN = HawkConnection(host='172.17.0.151', user='admin', password='pass')
+    ZAGGCONN = HawkConnection(url='172.17.0.151', user='admin', password='pass')
     ZAGGHEARTBEAT = HawkHeartbeat(templates=['template1', 'template2'], hostgroups=['hostgroup1', 'hostgroup2'])
 
 """
@@ -20,12 +20,13 @@ class HawkConnection(object):
     '''
     # pylint: disable=too-many-arguments
     # This now supports ssl and need a couple of extra params
-    def __init__(self, url, user, password, ssl_verify=False, debug=False):
+    def __init__(self, url, user, password, ssl_verify=False, debug=False, inactive=False):
         self.url = url if url.startswith('http') else 'http://' + url
         self.username = user
         self.password = password
         self.ssl_verify = ssl_verify
         self.debug = debug
+        self.inactive = inactive # We do not want this lib to work ansless explisitly activated
 
         url_params = urlparse(self.url)
         self.host = url_params.hostname

--- a/openshift_tools/monitoring/hawk_common.py
+++ b/openshift_tools/monitoring/hawk_common.py
@@ -1,0 +1,37 @@
+# vim: expandtab:tabstop=4:shiftwidth=4
+"""
+hawk_common contains common data structures and utils
+
+Example usage:
+    from openshift_tools.monitoring.hawk_common import HawkConnection, HawkHeartbeat
+
+    ZAGGCONN = HawkConnection(host='172.17.0.151', user='admin', password='pass')
+    ZAGGHEARTBEAT = HawkHeartbeat(templates=['template1', 'template2'], hostgroups=['hostgroup1', 'hostgroup2'])
+
+"""
+from collections import namedtuple
+from urlparse import urlparse
+import ssl
+
+# pylint: disable=too-few-public-methods
+# This is a DTO.  It needs to be a class because we need default values
+class HawkConnection(object):
+    ''' DTO for hawkular connection
+    '''
+    # pylint: disable=too-many-arguments
+    # This now supports ssl and need a couple of extra params
+    def __init__(self, url, user, password, ssl_verify=False, debug=False):
+        self.url = url if url.startswith('http') else 'http://' + url
+        self.username = user
+        self.password = password
+        self.ssl_verify = ssl_verify
+        self.debug = debug
+
+        url_params = urlparse(self.url)
+        self.host = url_params.hostname
+        self.scheme = url_params.scheme
+        self.port = url_params.port or {'http': 80, 'https': 443}[self.scheme]
+        self.context = context=None if self.ssl_verify else ssl._create_unverified_context()
+        self.tenant_id = '_ops'
+
+HawkHeartbeat = namedtuple("HawkHeartbeat", ["templates", "hostgroups"])

--- a/openshift_tools/monitoring/hawk_sender.py
+++ b/openshift_tools/monitoring/hawk_sender.py
@@ -11,11 +11,11 @@ Examples:
     from openshift_tools.monitoring.hawk_sender import HawkSender
     HOSTNAME = 'use-tower1.ops.rhcloud.com'
 
-    ZAGGCONN = HawkConnection(host='https://172.17.0.151', user='admin', password='pass')
+    ZAGGCONN = HawkConnection(url='https://172.17.0.151', user='admin', password='pass')
     ZAGGHEARTBEAT = HawkHeartbeat(templates=['template1', 'template2'], hostgroups=['hostgroup1', 'hostgroup2'])
 
     zs = HawkSender(host=HOSTNAME, hawk_connection=ZAGGCONN)
-    #zs.add_heartbeat(ZAGGHEARTBEAT) # add_heartbeat not supported yet
+    zs.add_heartbeat(ZAGGHEARTBEAT)
     zs.add_zabbix_keys({ 'test.key' : '1' })
     zs.send_metrics()
 """

--- a/openshift_tools/monitoring/hawk_sender.py
+++ b/openshift_tools/monitoring/hawk_sender.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# vim: expandtab:tabstop=4:shiftwidth=4
+"""
+Collect metrics and send metrics to Hawk.  The data
+being send to Hawk is done using REST API using the HawkClient
+module
+
+Examples:
+
+    from openshift_tools.monitoring.hawk_common import HawkConnection, HawkHeartbeat
+    from openshift_tools.monitoring.hawk_sender import HawkSender
+    HOSTNAME = 'use-tower1.ops.rhcloud.com'
+
+    ZAGGCONN = HawkConnection(host='https://172.17.0.151', user='admin', password='pass')
+    ZAGGHEARTBEAT = HawkHeartbeat(templates=['template1', 'template2'], hostgroups=['hostgroup1', 'hostgroup2'])
+
+    zs = HawkSender(host=HOSTNAME, hawk_connection=ZAGGCONN)
+    #zs.add_heartbeat(ZAGGHEARTBEAT) # add_heartbeat not supported yet
+    zs.add_zabbix_keys({ 'test.key' : '1' })
+    zs.send_metrics()
+"""
+
+from openshift_tools.monitoring.metricmanager import UniqueMetric
+from openshift_tools.monitoring.hawk_client import HawkClient
+from openshift_tools.monitoring.hawk_common import HawkConnection
+import json
+import os
+import yaml
+
+class HawkSenderException(Exception):
+    '''
+        HawkSenderException
+        Exists to propagate errors up from the api
+    '''
+    pass
+
+class HawkSender(object):
+    """
+    collect and create UniqueMetrics and send them to Hawk
+    """
+
+    def __init__(self, host=None, hawk_connection=None, verbose=False, debug=False):
+        """
+        set up the hawk client and unique_metrics
+        """
+        self.unique_metrics = []
+        self.config = None
+        self.config_file = '/etc/openshift_tools/hawk_client.yaml'
+        self.verbose = verbose
+        self.debug = debug
+
+        if not host:
+            host = self.get_default_host()
+
+        if not hawk_connection:
+            hawk_connection = self.get_default_hawk_connecton()
+
+        self.host = host
+        self.hawkclient = HawkClient(hawk_connection=hawk_connection)
+
+    def print_unique_metrics_key_value(self):
+        """
+        This function prints the key/value pairs the UniqueMetrics that HawkSender
+        currently has stored
+        """
+
+        print "\nHawkSender Key/Value pairs:"
+        print "=============================="
+        for unique_metric in self.unique_metrics:
+            print("%s:  %s") % (unique_metric.key, unique_metric.value)
+        print "==============================\n"
+
+    def print_unique_metrics(self):
+        """
+        This function prints all of the information of the UniqueMetrics that HawkSender
+        currently has stored
+        """
+
+        print "\nHawkSender UniqueMetrics:"
+        print "=============================="
+        for unique_metric in self.unique_metrics:
+            print unique_metric
+        print "==============================\n"
+
+    def parse_config(self):
+        """ parse default config file """
+
+        if not self.config:
+            if not os.path.exists(self.config_file):
+                raise HawkSenderException(self.config_file + " does not exist.")
+            self.config = yaml.load(file(self.config_file))
+
+    def get_default_host(self):
+        """ get the 'host' value from the config file """
+        self.parse_config()
+
+        return self.config['host']['name']
+
+    def get_default_hawk_connecton(self):
+        """ get the values and create a hawk_connection """
+
+        self.parse_config()
+        hawk_server = self.config['hawk']['url']
+        hawk_user = self.config['hawk']['user']
+        hawk_password = self.config['hawk']['pass']
+        hawk_ssl_verify = self.config['hawk'].get('ssl_verify', False)
+        hawk_debug = self.config['hawk'].get('debug', False)
+
+        if isinstance(hawk_ssl_verify, str):
+            hawk_ssl_verify = (hawk_ssl_verify == 'True')
+
+        if self.debug:
+            hawk_debug = self.debug
+        elif isinstance(hawk_debug, str):
+            hawk_debug = (hawk_debug == 'True')
+
+        hawk_connection = HawkConnection(url=hawk_server,
+                                         user=hawk_user,
+                                         password=hawk_password,
+                                         ssl_verify=hawk_ssl_verify,
+                                         debug=hawk_debug,
+                                        )
+
+        return hawk_connection
+
+    def add_heartbeat(self, heartbeat, host=None):
+        """ create a heartbeat unique metric to send to hawk """
+
+        if not host:
+            host = self.host
+
+        hb_metric = UniqueMetric.create_heartbeat(host,
+                                                  heartbeat.templates,
+                                                  heartbeat.hostgroups,
+                                                 )
+        self.unique_metrics.append(hb_metric)
+
+    def add_zabbix_keys(self, zabbix_keys, host=None, synthetic=False):
+        """ create unique metric from zabbix key value pair """
+
+        if synthetic and not host:
+            host = self.config['synthetic_clusterwide']['host']['name']
+        elif not host:
+            host = self.host
+
+        zabbix_metrics = []
+
+        for key, value in zabbix_keys.iteritems():
+            zabbix_metric = UniqueMetric(host, key, value)
+            zabbix_metrics.append(zabbix_metric)
+
+        self.unique_metrics += zabbix_metrics
+
+    # Allow for 6 arguments (including 'self')
+    # pylint: disable=too-many-arguments
+    def add_zabbix_dynamic_item(self, discovery_key, macro_string, macro_array, host=None, synthetic=False):
+        """
+        This creates a dynamic item prototype that is required
+        for low level discovery rules in Hawkular.
+        This requires:
+        - dicovery key
+        - macro string
+        - macro name
+
+        This will create a zabbix key value pair that looks like:
+
+        disovery_key = "{"data": [
+                          {"{#macro_string}":"macro_array[0]"},
+                          {"{#macro_string}":"macro_array[1]"},
+                        ]}"
+        """
+
+        if synthetic and not host:
+            host = self.config['synthetic_clusterwide']['host']['name']
+        elif not host:
+            host = self.host
+
+        data_array = [{'{%s}' % macro_string : i} for i in macro_array]
+        json_data = json.dumps({'data' : data_array})
+
+        zabbix_dynamic_item = UniqueMetric(host, discovery_key, json_data)
+
+        self.unique_metrics.append(zabbix_dynamic_item)
+
+    def send_metrics(self):
+        """
+        Send list of Unique Metrics to Hawk
+        clear self.unique_metrics
+        """
+        if self.verbose:
+            self.print_unique_metrics_key_value()
+
+        if self.debug:
+            self.print_unique_metrics()
+
+        self.hawkclient.add_metric(self.unique_metrics)
+        self.unique_metrics = []

--- a/scripts/monitoring/cron-event-watcher.py
+++ b/scripts/monitoring/cron-event-watcher.py
@@ -25,6 +25,7 @@
 
 import argparse
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 import json
 from Queue import Queue
 import re
@@ -68,10 +69,14 @@ class OpenshiftEventConsumer(object):
             if not self.args.dry_run:
                 zagg_sender = ZaggSender(verbose=self.args.verbose,
                                          debug=self.args.debug)
+                hawk_sender = HawkSender(verbose=self.args.verbose,
+                                         debug=self.args.debug)
                 for event in event_counts.keys():
                     key = ZBX_KEY + event.lower()
                     zagg_sender.add_zabbix_keys({key: event_counts[event]})
+                    hawk_sender.add_zabbix_keys({key: event_counts[event]})
                 zagg_sender.send_metrics()
+                hawk_sender.send_metrics()
 
             time.sleep(self.args.reporting_period)
 

--- a/scripts/monitoring/cron-fix-ovs-rules.py
+++ b/scripts/monitoring/cron-fix-ovs-rules.py
@@ -15,6 +15,7 @@ from subprocess import CalledProcessError
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 class OVS(object):
     ''' Class to hold details of finding and removing bad OVS rules '''
@@ -122,6 +123,7 @@ ZBX_KEY = "openshift.node.ovs.stray.rules"
 if __name__ == "__main__":
     ovs_fixer = OVS()
     zgs = ZaggSender()
+    hgs = HawkSender()
 
     # Dev says rules before ports since OpenShift will set up ports, then rules
     ovs_fixer.get_rule_list()
@@ -131,7 +133,9 @@ if __name__ == "__main__":
 
     # Report bad/stray rules count before removing
     zgs.add_zabbix_keys({ZBX_KEY: len(ovs_bad_rules)})
+    hgs.add_zabbix_keys({ZBX_KEY: len(ovs_bad_rules)})
     zgs.send_metrics()
+    hgs.send_metrics()
 
     print "Good ports: {0}".format(str(ovs_ports))
     print "Bad rules: {0}".format(str(ovs_bad_rules))
@@ -146,4 +150,6 @@ if __name__ == "__main__":
 
     # Report new bad/stray rule count after removal
     zgs.add_zabbix_keys({ZBX_KEY: len(ovs_bad_rules)})
+    hgs.add_zabbix_keys({ZBX_KEY: len(ovs_bad_rules)})
     zgs.send_metrics()
+    hgs.send_metrics()

--- a/scripts/monitoring/cron-haproxy-close-wait.py
+++ b/scripts/monitoring/cron-haproxy-close-wait.py
@@ -15,6 +15,7 @@ import time
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 ZABBIX_KEY = "openshift.haproxy.close-wait"
 
@@ -104,8 +105,11 @@ class HAProxy(object):
         print "Stopped {} haproxy processes".format(kill_count)
 
         zgs = ZaggSender()
+        hgs = HawkSender()
         zgs.add_zabbix_keys({ZABBIX_KEY : kill_count})
+        hgs.add_zabbix_keys({ZABBIX_KEY : kill_count})
         zgs.send_metrics()
+        hgs.send_metrics()
 
 if __name__ == '__main__':
     hap = HAProxy()

--- a/scripts/monitoring/cron-send-check-kubeconfig.py
+++ b/scripts/monitoring/cron-send-check-kubeconfig.py
@@ -27,6 +27,7 @@
 
 import argparse
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 import yaml
 
 class OpenshiftKubeconfigChecker(object):
@@ -35,19 +36,24 @@ class OpenshiftKubeconfigChecker(object):
     def __init__(self):
         self.args = None
         self.zagg_sender = None
+        self.hawk_sender = None
 
     def run(self):
         """  Main function to run the check """
 
         self.parse_args()
         self.zagg_sender = ZaggSender(verbose=self.args.verbose, debug=self.args.debug)
+        self.hawk_sender = HawkSender(verbose=self.args.verbose, debug=self.args.debug)
 
         status = self.parse_config()
 
         self.zagg_sender.add_zabbix_keys({
             "openshift.kubeconfig.status" : status})
+        self.hawk_sender.add_zabbix_keys({
+            "openshift.kubeconfig.status" : status})
 
         self.zagg_sender.send_metrics()
+        self.hawk_sender.send_metrics()
 
     def parse_config(self):
         """ Load the kubeconfig """

--- a/scripts/monitoring/cron-send-connection-count.py
+++ b/scripts/monitoring/cron-send-connection-count.py
@@ -13,6 +13,7 @@ import psutil
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 def parse_args():
     """ parse the args from the cli """
@@ -66,6 +67,9 @@ def main():
     zgs = ZaggSender(debug=argz.debug)
     zgs.add_zabbix_keys({'{0}'.format(argz.zabbix_key) : conn_count})
     zgs.send_metrics()
+    hgs = HawkSender(debug=argz.debug)
+    hgs.add_zabbix_keys({'{0}'.format(argz.zabbix_key) : conn_count})
+    hgs.send_metrics()
 
 if __name__ == '__main__':
     main()

--- a/scripts/monitoring/cron-send-cpu-mem-process.sh
+++ b/scripts/monitoring/cron-send-cpu-mem-process.sh
@@ -13,6 +13,8 @@ echo "the mem usage of openshift.node process is $MemUsagenode%"
 
 ops-zagg-client -k "openshift.nodeprocess.cpu" -o "$CpuUsagenode"
 ops-zagg-client -k "openshift.nodeprocess.mem" -o "$MemUsagenode"
+ops-hawk-client -k "openshift.nodeprocess.cpu" -o "$CpuUsagenode"
+ops-hawk-client -k "openshift.nodeprocess.mem" -o "$MemUsagenode"
 
 #the cpu use of master api process usage
 
@@ -31,6 +33,8 @@ then
 
     ops-zagg-client -k "openshift.master.api.cpu" -o "$CpuUsagenode"
     ops-zagg-client -k "openshift.master.api.mem" -o "$MemUsagenode"
+    ops-hawk-client -k "openshift.master.api.cpu" -o "$CpuUsagenode"
+    ops-hawk-client -k "openshift.master.api.mem" -o "$MemUsagenode"
 else
     echo 
 fi
@@ -52,6 +56,8 @@ then
 
     ops-zagg-client -k "openshift.etcd.cpu" -o "$CpuUsageetcd"
     ops-zagg-client -k "openshift.etcd.mem" -o "$MemUsageetcd"
+    ops-hawk-client -k "openshift.etcd.cpu" -o "$CpuUsageetcd"
+    ops-hawk-client -k "openshift.etcd.mem" -o "$MemUsageetcd"
 else
     echo 
 fi
@@ -71,5 +77,5 @@ echo "the mem usage of docker daemon is $MemUsagedocker%"
 
 ops-zagg-client -k "openshift.docker.daemon.cpu" -o "$CpuUsageetcd"
 ops-zagg-client -k "openshift.docker.daemon.mem" -o "$MemUsageetcd"
-
-
+ops-hawk-client -k "openshift.docker.daemon.cpu" -o "$CpuUsageetcd"
+ops-hawk-client -k "openshift.docker.daemon.mem" -o "$MemUsageetcd"

--- a/scripts/monitoring/cron-send-cpu-mem-stats.py
+++ b/scripts/monitoring/cron-send-cpu-mem-stats.py
@@ -23,6 +23,7 @@ import psutil
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 def parse_args():
     """ parse the args from the cli """
@@ -81,6 +82,9 @@ def main():
         zgs = ZaggSender(debug=argz.debug)
         zgs.add_zabbix_keys(zagg_data)
         zgs.send_metrics()
+        hgs = HawkSender(debug=argz.debug)
+        hgs.add_zabbix_keys(zagg_data)
+        hgs.send_metrics()
 
 if __name__ == '__main__':
     main()

--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -26,6 +26,7 @@ import sys
 # libs might exist
 #pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 # pylint: disable=bare-except
 def cleanup_file(inc_file):
@@ -248,17 +249,25 @@ def send_zagg_data(build_ran, create_app, http_code, run_time):
     ''' send data to Zagg'''
     zgs_time = time.time()
     zgs = ZaggSender()
+    hgs = HawkSender()
     print "Send data to Zagg"
     if build_ran == 1:
         zgs.add_zabbix_keys({'openshift.master.app.build.create': create_app})
         zgs.add_zabbix_keys({'openshift.master.app.build.create.code': http_code})
         zgs.add_zabbix_keys({'openshift.master.app.build.create.time': run_time})
+        hgs.add_zabbix_keys({'openshift.master.app.build.create': create_app})
+        hgs.add_zabbix_keys({'openshift.master.app.build.create.code': http_code})
+        hgs.add_zabbix_keys({'openshift.master.app.build.create.time': run_time})
     else:
         zgs.add_zabbix_keys({'openshift.master.app.create': create_app})
         zgs.add_zabbix_keys({'openshift.master.app.create.code': http_code})
         zgs.add_zabbix_keys({'openshift.master.app.create.time': run_time})
+        hgs.add_zabbix_keys({'openshift.master.app.create': create_app})
+        hgs.add_zabbix_keys({'openshift.master.app.create.code': http_code})
+        hgs.add_zabbix_keys({'openshift.master.app.create.time': run_time})
     try:
         zgs.send_metrics()
+        hgs.send_metrics()
     except:
         print "Error sending to Zagg: %s \n %s " % sys.exc_info()[0], sys.exc_info()[1]
     print "Data sent in %s seconds" % str(time.time() - zgs_time)

--- a/scripts/monitoring/cron-send-docker-containers-usage.py
+++ b/scripts/monitoring/cron-send-docker-containers-usage.py
@@ -14,6 +14,7 @@
 
 from docker import AutoVersionClient
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.monitoring.dockerutil import DockerUtil
 import os
 import yaml
@@ -53,6 +54,7 @@ class DockerContainerUsageCli(object):
         self.cli = AutoVersionClient(base_url='unix://var/run/docker.sock', timeout=120)
         self.docker_util = DockerUtil(self.cli)
         self.zagg_sender = ZaggSender(verbose=True)
+        self.hawk_sender = HawkSender(verbose=True)
 
     def parse_config(self):
         """ parse config file """
@@ -95,6 +97,7 @@ class DockerContainerUsageCli(object):
             # Add the container hostnames as macros for the dynamic item.
             self.zagg_sender.add_zabbix_dynamic_item(ZBX_DOCKER_DISC_KEY, ZBX_DOCKER_DISC_MACRO,
                                                      [formatted_ctr_name])
+            #TODO: implement self.hawk_sender.add_zabbix_dynamic_item                                         
             data = {
                 '%s[%s]' % (ZBX_CTR_CPU_USED_PCT_KEY, formatted_ctr_name): cpu_stats.used_pct,
                 '%s[%s]' % (ZBX_CTR_MEM_USED_KEY, formatted_ctr_name): mem_stats.used,
@@ -109,9 +112,11 @@ class DockerContainerUsageCli(object):
             print
 
             self.zagg_sender.add_zabbix_keys(data)
+            self.hawk_sender.add_zabbix_keys(data)
 
         # Actually send the metrics
         self.zagg_sender.send_metrics()
+        self.hawk_sender.send_metrics()
 
 
 if __name__ == "__main__":

--- a/scripts/monitoring/cron-send-docker-dns-resolution.py
+++ b/scripts/monitoring/cron-send-docker-dns-resolution.py
@@ -16,6 +16,7 @@ from docker.errors import APIError
 # Jenkins doesn't have our tools which results in import errors
 # pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 ZBX_KEY = "docker.container.dns.resolution"
 
@@ -35,9 +36,12 @@ if __name__ == "__main__":
             time.sleep(5)
 
     zs = ZaggSender()
+    hs = HawkSender()
     zs.add_zabbix_keys({ZBX_KEY: exit_code})
+    hs.add_zabbix_keys({ZBX_KEY: exit_code})
 
     print "Sending these metrics:"
     print ZBX_KEY + ": " + str(exit_code)
     zs.send_metrics()
+    hs.send_metrics()
     print "\nDone.\n"

--- a/scripts/monitoring/cron-send-docker-existing-dns-resolution.py
+++ b/scripts/monitoring/cron-send-docker-existing-dns-resolution.py
@@ -15,6 +15,7 @@
 from docker import AutoVersionClient
 from docker.errors import APIError
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 ZBX_KEY = "docker.container.existing.dns.resolution.failed"
 CMD_NOT_FOUND = -1
@@ -52,9 +53,12 @@ if __name__ == "__main__":
         print
 
     zs = ZaggSender()
+    hs = HawkSender()
     zs.add_zabbix_keys({ZBX_KEY: bad_dns_count})
+    hs.add_zabbix_keys({ZBX_KEY: bad_dns_count})
 
     print "Sending these metrics:"
     print ZBX_KEY + ": " + str(bad_dns_count)
     zs.send_metrics()
+    hs.send_metrics()
     print "\nDone.\n"

--- a/scripts/monitoring/cron-send-docker-metrics.py
+++ b/scripts/monitoring/cron-send-docker-metrics.py
@@ -13,6 +13,7 @@
 from docker import AutoVersionClient
 from docker.errors import DockerException
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.timeout import TimeoutException
 from openshift_tools.monitoring.dockerutil import DockerUtil
 import json
@@ -20,6 +21,7 @@ import json
 if __name__ == "__main__":
     keys = None
     zs = ZaggSender()
+    hs = ZaggSender()
     try:
         cli = AutoVersionClient(base_url='unix://var/run/docker.sock')
         du = DockerUtil(cli)
@@ -46,8 +48,10 @@ if __name__ == "__main__":
         }
 
     zs.add_zabbix_keys(keys)
+    hs.add_zabbix_keys(keys)
 
     print "Sending these metrics:"
     print json.dumps(keys, indent=4)
     zs.send_metrics()
+    hs.send_metrics()
     print "\nDone.\n"

--- a/scripts/monitoring/cron-send-docker-timer.py
+++ b/scripts/monitoring/cron-send-docker-timer.py
@@ -13,6 +13,7 @@
 from docker import AutoVersionClient
 from docker.errors import DockerException
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.timeout import TimeoutException
 from openshift_tools.monitoring.dockerutil import DockerUtil
 import json
@@ -21,6 +22,7 @@ import time
 if __name__ == "__main__":
     keys = None
     zs = ZaggSender()
+    hs = HawkSender()
     try:
         cli = AutoVersionClient(base_url='unix://var/run/docker.sock')
         du = DockerUtil(cli, max_wait=360)
@@ -41,8 +43,10 @@ if __name__ == "__main__":
         }
 
     zs.add_zabbix_keys(keys)
+    hs.add_zabbix_keys(keys)
 
     print "Sending these metrics:"
     print json.dumps(keys, indent=4)
     zs.send_metrics()
+    hs.send_metrics()
     print "\nDone.\n"

--- a/scripts/monitoring/cron-send-filesystem-metrics.py
+++ b/scripts/monitoring/cron-send-filesystem-metrics.py
@@ -23,6 +23,7 @@
 
 import argparse
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.monitoring import pminfo
 
 def parse_args():
@@ -47,6 +48,7 @@ def main():
 
     args = parse_args()
     zagg_sender = ZaggSender(verbose=args.verbose, debug=args.debug)
+    hawk_sender = HawkSender(verbose=args.verbose, debug=args.debug)
 
     filesys_full_metric = ['filesys.full']
     filesys_inode_derived_metrics = {'filesys.inodes.pused' :
@@ -66,8 +68,10 @@ def main():
     filtered_filesys_metrics = filter_out_docker_filesystems(filesys_full_metrics, 'filesys.full.')
 
     zagg_sender.add_zabbix_dynamic_item(discovery_key_fs, item_prototype_macro_fs, filtered_filesys_metrics.keys())
+    #TODO: implement zagg_sender.add_zabbix_dynamic_item
     for filesys_name, filesys_full in filtered_filesys_metrics.iteritems():
         zagg_sender.add_zabbix_keys({'%s[%s]' % (item_prototype_key_full, filesys_name): filesys_full})
+        hawk_sender.add_zabbix_keys({'%s[%s]' % (item_prototype_key_full, filesys_name): filesys_full})
 
 
     # Get filesytem inode metrics
@@ -76,9 +80,11 @@ def main():
     filtered_filesys_inode_metrics = filter_out_docker_filesystems(filesys_inode_metrics, 'filesys.inodes.pused.')
     for filesys_name, filesys_inodes in filtered_filesys_inode_metrics.iteritems():
         zagg_sender.add_zabbix_keys({'%s[%s]' % (item_prototype_key_inode, filesys_name): filesys_inodes})
+        hawk_sender.add_zabbix_keys({'%s[%s]' % (item_prototype_key_inode, filesys_name): filesys_inodes})
 
 
     zagg_sender.send_metrics()
+    hawk_sender.send_metrics()
 
 if __name__ == '__main__':
     main()

--- a/scripts/monitoring/cron-send-network-metrics.py
+++ b/scripts/monitoring/cron-send-network-metrics.py
@@ -24,6 +24,7 @@
 
 import argparse
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.monitoring import pminfo
 
 def parse_args():
@@ -49,6 +50,7 @@ def main():
 
     args = parse_args()
     zagg_sender = ZaggSender(verbose=args.verbose, debug=args.debug)
+    hawk_sender = HawkSender(verbose=args.verbose, debug=args.debug)
 
     discovery_key_network = 'disc.network'
     pcp_network_dev_metrics = ['network.interface.in.bytes', 'network.interface.out.bytes']
@@ -68,10 +70,12 @@ def main():
 
     # Add dynamic items
     zagg_sender.add_zabbix_dynamic_item(discovery_key_network, item_proto_macro_network, filtered_network_totals.keys())
+    #TODO: hawk_sender.add_zabbix_dynamic_item(discovery_key_network, item_proto_macro_network, filtered_network_totals.keys())
 
     # Report Network IN bytes; them to the ZaggSender
     for interface, total in filtered_network_totals.iteritems():
         zagg_sender.add_zabbix_keys({'%s[%s]' % (item_proto_key_in_bytes, interface): total})
+        hawk_sender.add_zabbix_keys({'%s[%s]' % (item_proto_key_in_bytes, interface): total})
 
     # Report Network OUT Bytes;  use network.interface.out.bytes
     filtered_network_totals = clean_up_metric_dict(pcp_metrics_divided[pcp_network_dev_metrics[1]],
@@ -81,8 +85,10 @@ def main():
     for interface, total in filtered_network_totals.iteritems():
 
         zagg_sender.add_zabbix_keys({'%s[%s]' % (item_proto_key_out_bytes, interface): total})
+        hawk_sender.add_zabbix_keys({'%s[%s]' % (item_proto_key_out_bytes, interface): total})
 
     zagg_sender.send_metrics()
+    hawk_sender.send_metrics()
 
 if __name__ == '__main__':
     main()

--- a/scripts/monitoring/cron-send-os-dnsmasq-checks.py
+++ b/scripts/monitoring/cron-send-os-dnsmasq-checks.py
@@ -35,6 +35,7 @@ import argparse
 from dns import resolver
 from dns import exception as dns_exception
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 import socket
 
 class DnsmasqZaggClient(object):
@@ -43,6 +44,7 @@ class DnsmasqZaggClient(object):
     def __init__(self):
         self.args = None
         self.zagg_sender = None
+        self.hawk_sender = None
         self.dns_host_ip = socket.gethostbyname(socket.gethostname())
         self.dns_port = 53
 
@@ -51,11 +53,13 @@ class DnsmasqZaggClient(object):
 
         self.parse_args()
         self.zagg_sender = ZaggSender(verbose=self.args.verbose, debug=self.args.debug)
+        self.hawk_sender = ZaggSender(verbose=self.args.verbose, debug=self.args.debug)
 
         if self.check_dns_port_alive():
             self.do_dns_check()
 
         self.zagg_sender.send_metrics()
+        self.hawk_sender.send_metrics()
 
     def parse_args(self):
         """ parse the args from the cli """
@@ -80,6 +84,7 @@ class DnsmasqZaggClient(object):
             print "\ndnsmasq host: %s, port: %s is OPEN" % (self.dns_host_ip, self.dns_port)
             print "================================================\n"
             self.zagg_sender.add_zabbix_keys({'dnsmasq.port.open' : 1})
+            self.hawk_sender.add_zabbix_keys({'dnsmasq.port.open' : 1})
 
             return True
 
@@ -88,6 +93,7 @@ class DnsmasqZaggClient(object):
             print "Python Error: %s" % e
             print "================================================\n"
             self.zagg_sender.add_zabbix_keys({'dnsmasq.port.open' : 0})
+            self.hawk_sender.add_zabbix_keys({'dnsmasq.port.open' : 0})
 
             return False
     def do_dns_check(self):
@@ -118,6 +124,7 @@ class DnsmasqZaggClient(object):
         print "================================================\n"
 
         self.zagg_sender.add_zabbix_keys({'dnsmasq.query' : dns_check})
+        self.hawk_sender.add_zabbix_keys({'dnsmasq.query' : dns_check})
 
 if __name__ == '__main__':
     ONDZC = DnsmasqZaggClient()

--- a/scripts/monitoring/cron-send-ovs-status.py
+++ b/scripts/monitoring/cron-send-ovs-status.py
@@ -8,6 +8,7 @@
 
 import subprocess
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 def get_vswitch_ports():
     ''' Get list of ports from ovs
@@ -50,9 +51,13 @@ def main():
     zs = ZaggSender()
     zs.add_zabbix_keys({'openshift.node.ovs.ports.count' : vswitch_ports_count})
     zs.add_zabbix_keys({'openshift.node.ovs.pids.count' : vswitch_pids_count})
+    hs = HawkSender()
+    hs.add_zabbix_keys({'openshift.node.ovs.ports.count' : vswitch_ports_count})
+    hs.add_zabbix_keys({'openshift.node.ovs.pids.count' : vswitch_pids_count})
 
     # Finally, sent them to zabbix
     zs.send_metrics()
+    hs.send_metrics()
 
 if __name__ == '__main__':
     main()

--- a/scripts/monitoring/cron-send-pcp-ping.sh
+++ b/scripts/monitoring/cron-send-pcp-ping.sh
@@ -14,3 +14,4 @@ fi
 
 # Send results to zabbix
 ops-zagg-client -k "pcp.ping" -o "$PING_RETURN"
+ops-hawk-client -k "pcp.ping" -o "$PING_RETURN"

--- a/scripts/monitoring/cron-send-pcp-sampled-metrics.py
+++ b/scripts/monitoring/cron-send-pcp-sampled-metrics.py
@@ -14,6 +14,7 @@ import argparse
 import collections
 from openshift_tools.monitoring import pminfo
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 def parse_args():
     '''Parse the arguments for this script'''
@@ -79,6 +80,9 @@ def main():
         zgs = ZaggSender(verbose=args.debug)
         zgs.add_zabbix_keys(zab_results)
         zgs.send_metrics()
+        hgs = HawkSender(verbose=args.debug)
+        hgs.add_zabbix_keys(zab_results)
+        hgs.send_metrics()
 
 
 if __name__ == '__main__':

--- a/scripts/monitoring/cron-send-pod-check.py
+++ b/scripts/monitoring/cron-send-pod-check.py
@@ -27,6 +27,7 @@
 
 import argparse
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.web.openshift_rest_api import OpenshiftRestApi
 import yaml
 
@@ -37,6 +38,7 @@ class OpenshiftPodChecker(object):
         self.args = None
         self.ora = None
         self.zagg_sender = None
+        self.hawk_sender = None
 
     def run(self):
         """  Main function to run the check """
@@ -44,6 +46,7 @@ class OpenshiftPodChecker(object):
         self.parse_args()
         self.ora = OpenshiftRestApi()
         self.zagg_sender = ZaggSender(verbose=self.args.verbose, debug=self.args.debug)
+        self.hawk_sender = HawkSender(verbose=self.args.verbose, debug=self.args.debug)
 
         try:
             self.get_pods()
@@ -52,6 +55,7 @@ class OpenshiftPodChecker(object):
             print "Problem retreiving pod data: %s " % ex.message
 
         self.zagg_sender.send_metrics()
+        self.hawk_sender.send_metrics()
 
     def get_pods(self):
         """ Gets pod data """
@@ -80,6 +84,8 @@ class OpenshiftPodChecker(object):
                 pass
 
         self.zagg_sender.add_zabbix_keys(
+            {"service.pod.{}.count".format(self.args.pod): pod_count})
+        self.hawk_sender.add_zabbix_keys(
             {"service.pod.{}.count".format(self.args.pod): pod_count})
 
 

--- a/scripts/monitoring/cron-send-process-count.sh
+++ b/scripts/monitoring/cron-send-process-count.sh
@@ -13,4 +13,5 @@ echo "Number of processes matching [$1]: $COUNT"
 echo
 echo "Running: ops-zagg-client -k '$2' -o '$COUNT'"
 ops-zagg-client -k "$2" -o "$COUNT"
+ops-hawk-client -k "$2" -o "$COUNT"
 echo

--- a/scripts/monitoring/cron-send-project-stats.py
+++ b/scripts/monitoring/cron-send-project-stats.py
@@ -25,6 +25,7 @@ import sys
 # libs might exist
 #pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 # pylint: disable=bare-except
 def cleanup_file(inc_file):
@@ -202,10 +203,13 @@ def send_zagg_data(keep_time):
     ''' send data to Zagg'''
     zgs_time = time.time()
     zgs = ZaggSender()
+    hgs = HawkSender()
     print "Send data to Zagg"
     zgs.add_zabbix_keys({'openshift.master.project.terminating.time': keep_time})
+    hgs.add_zabbix_keys({'openshift.master.project.terminating.time': keep_time})
     try:
         zgs.send_metrics()
+        hgs.send_metrics()
     except:
         print "Error sending to Zagg: %s \n %s " % sys.exc_info()[0], sys.exc_info()[1]
     print "Data sent in %s seconds" % str(time.time() - zgs_time)

--- a/scripts/monitoring/cron-send-registry-checks.py
+++ b/scripts/monitoring/cron-send-registry-checks.py
@@ -28,6 +28,7 @@
 import argparse
 import os
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.monitoring.ocutil import OCUtil
 import socket
 import urllib2
@@ -39,6 +40,7 @@ class OpenshiftDockerRegigtryChecker(object):
     def __init__(self):
         self.args = None
         self.zagg_sender = None
+        self.hawk_sender = None
 
         self.docker_hosts = []
         self.docker_port = None
@@ -70,6 +72,7 @@ class OpenshiftDockerRegigtryChecker(object):
         self.get_kubeconfig()
         ocutil = OCUtil(config_file=self.kubeconfig, verbose=self.args.verbose)
         self.zagg_sender = ZaggSender(verbose=self.args.verbose, debug=self.args.debug)
+        self.hawk_sender = HawkSender(verbose=self.args.verbose, debug=self.args.debug)
 
         try:
             oc_yaml = ocutil.get_service('docker-registry')
@@ -83,6 +86,7 @@ class OpenshiftDockerRegigtryChecker(object):
         self.registry_health_check()
 
         self.zagg_sender.send_metrics()
+        self.hawk_sender.send_metrics()
 
     def parse_args(self):
         """ parse the args from the cli """
@@ -174,6 +178,7 @@ class OpenshiftDockerRegigtryChecker(object):
         print "\nDocker Registry service status: {}".format(status)
 
         self.zagg_sender.add_zabbix_keys({'openshift.node.registry.service.ping' : status})
+        self.hawk_sender.add_zabbix_keys({'openshift.node.registry.service.ping' : status})
 
     def registry_health_check(self):
         """
@@ -197,6 +202,7 @@ class OpenshiftDockerRegigtryChecker(object):
                                                          len(self.docker_hosts))
 
         self.zagg_sender.add_zabbix_keys({'openshift.node.registry-pods.healthy_pct' : healthy_pct})
+        self.hawk_sender.add_zabbix_keys({'openshift.node.registry-pods.healthy_pct' : healthy_pct})
 
 if __name__ == '__main__':
     ODRC = OpenshiftDockerRegigtryChecker()

--- a/scripts/monitoring/cron-send-s3-metrics.py
+++ b/scripts/monitoring/cron-send-s3-metrics.py
@@ -27,6 +27,7 @@ import base64
 from openshift_tools.monitoring.awsutil import AWSUtil
 from openshift_tools.monitoring.ocutil import OCUtil
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 import sys
 import yaml
 
@@ -105,14 +106,19 @@ def main():
         print "Test-only. Received results: " + str(bucket_stats)
     else:
         zgs = ZaggSender(verbose=args.debug)
+        hgs = HawkSender(verbose=args.debug)
         zgs.add_zabbix_dynamic_item(discovery_key, discovery_macro, bucket_list)
+        #TODO: hgs.add_zabbix_dynamic_item(discovery_key, discovery_macro, bucket_list)
         for bucket in bucket_stats.keys():
             zab_key = "{}[{}]".format(prototype_s3_size, bucket)
             zgs.add_zabbix_keys({zab_key: int(round(bucket_stats[bucket]["size"]))})
+            hgs.add_zabbix_keys({zab_key: int(round(bucket_stats[bucket]["size"]))})
 
             zab_key = "{}[{}]".format(prototype_s3_count, bucket)
             zgs.add_zabbix_keys({zab_key: bucket_stats[bucket]["objects"]})
+            hgs.add_zabbix_keys({zab_key: bucket_stats[bucket]["objects"]})
         zgs.send_metrics()
+        hgs.send_metrics()
 
 if __name__ == '__main__':
     main()

--- a/scripts/monitoring/cron-send-saml-status.py
+++ b/scripts/monitoring/cron-send-saml-status.py
@@ -24,6 +24,7 @@ import argparse
 # libs might exist
 #pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 
 # pylint: disable=bare-except
 def cleanup_file(inc_file):
@@ -214,6 +215,9 @@ def send_zagg_data(key_zabbix, result):
     zgs = ZaggSender()
     zgs.add_zabbix_keys({key_zabbix: result})
     zgs.send_metrics()
+    hgs = HawkSender()
+    hgs.add_zabbix_keys({key_zabbix: result})
+    hgs.send_metrics()
 
 def handle_fail(run_time, oocmd, pod):
     ''' Print failure info '''

--- a/scripts/monitoring/cron-send-service-web-check.py
+++ b/scripts/monitoring/cron-send-service-web-check.py
@@ -27,6 +27,7 @@
 
 import argparse
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.web.openshift_rest_api import OpenshiftRestApi
 import yaml
 import urllib2
@@ -39,6 +40,7 @@ class OpenshiftWebServiceChecker(object):
         self.args = None
         self.ora = None
         self.zagg_sender = None
+        self.hawk_sender = None
         self.service_ip = None
         self.service_port = '443'
 
@@ -48,6 +50,7 @@ class OpenshiftWebServiceChecker(object):
         self.parse_args()
         self.ora = OpenshiftRestApi()
         self.zagg_sender = ZaggSender(verbose=self.args.verbose, debug=self.args.debug)
+        self.hawk_sender = HawkSender(verbose=self.args.verbose, debug=self.args.debug)
 
         try:
             self.get_service()
@@ -60,6 +63,11 @@ class OpenshiftWebServiceChecker(object):
             "openshift.webservice.{}.status".format(self.args.pod) : status})
 
         self.zagg_sender.send_metrics()
+
+        self.hawk_sender.add_zabbix_keys({
+            "openshift.webservice.{}.status".format(self.args.pod) : status})
+
+        self.hawk_sender.send_metrics()
 
     def get_service(self):
         """ Gets the service for a pod """

--- a/scripts/monitoring/hawk_client.yaml.example
+++ b/scripts/monitoring/hawk_client.yaml.example
@@ -1,0 +1,24 @@
+---
+host:
+    name: hostname.example.com
+hawk:
+    url: https://172.17.0.164
+    user: admin
+    pass: XXXXXX
+    verbose: False
+    debug: False
+pcp:
+    metrics:
+        - kernel.all
+        - swap.free
+        - swap.length
+        - swap.used
+heartbeat:
+    templates:
+        - template1
+        - template2
+        - template3
+    hostgroups:
+        - hostgroup1
+        - hostgroup2
+        - hostgroup3

--- a/scripts/monitoring/ops-hawk-client.py
+++ b/scripts/monitoring/ops-hawk-client.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+# vim: expandtab:tabstop=4:shiftwidth=4
+#This is not a module, but pylint thinks it is.  This is a command.
+#pylint: disable=invalid-name
+# pylint flaggs import errors, as the bot doesn't know have openshift-tools libs
+#pylint: disable=import-error
+"""
+ops-hawk-client: Script that sends metrics to hawk.
+
+This script will send metrics to Hawk.  This script will send:
+
+heartbeat (registration information)
+single zabbix keys.
+
+By default this script reads /etc/openshift_tools/hawk_client.yaml
+for information needed to send to hawk.  Some of the settings can be overridden
+from the cli.
+
+Examples
+# Send a heartbeat (looks in a config file for specifics)
+ops-hawk-client --send-heartbeat
+
+# Send a single metric (generic interface, send any adhoc metrics)
+ops-hawk-client -s hostname.example.com -k zbx.item.name -o someval
+
+# Send a dynamic low level discovery with macros
+# low level dynamic objects require:
+# - discovery key: This is what was setup and defined in Zabbix in the disovery rule
+# - macro string: This is the variable that will be used to setup the item and trigger
+# - macro name: This is the name of object.  This is a comma seperated list of names
+
+ops-hawk-client -s --discovery-key filesys --macro-string #FILESYS --macro-names /,/var,/home
+
+"""
+
+import argparse
+from openshift_tools.monitoring.hawk_sender import HawkSender
+from openshift_tools.monitoring.hawk_common import HawkConnection, HawkHeartbeat
+import yaml
+
+class OpsHawkClient(object):
+    """ class to send data to hawk """
+
+    def __init__(self):
+        self.hawk_sender = None
+        self.args = None
+        self.config = None
+        self.heartbeat = None
+
+    def run(self):
+        """ main function to run the script """
+
+        self.parse_args()
+        self.parse_config(self.args.config_file)
+        self.config_hawk_sender()
+
+        if self.args.send_heartbeat:
+            self.add_heartbeat()
+
+        if self.args.key and self.args.value:
+            self.add_zabbix_key()
+
+        if self.args.discovery_key and self.args.macro_string and self.args.macro_names:
+            self.add_zabbix_dynamic_item()
+
+        self.hawk_sender.send_metrics()
+
+    def parse_args(self):
+        """ parse the args from the cli """
+        parser = argparse.ArgumentParser(description='Hawk metric sender')
+        parser.add_argument('--send-heartbeat', help="send heartbeat metric to hawk", action="store_true")
+
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('-s', '--host',
+                           help='specify host name as registered in Zabbix')
+        group.add_argument('--synthetic', default=False, action='store_true',
+                           help='send as cluster-wide synthetic host')
+
+        parser.add_argument('-z', '--hawk-url', help='url of Hawk server')
+        parser.add_argument('--hawk-user', help='username of the Hawk server')
+        parser.add_argument('--hawk-pass', help='Password of the Hawk server')
+        parser.add_argument('--hawk-ssl-verify', default=None, help='Whether to verify ssl certificates.')
+        parser.add_argument('-v', '--verbose', action='store_true', default=None, help='Verbose?')
+        parser.add_argument('--debug', action='store_true', default=None, help='Debug?')
+        parser.add_argument('-c', '--config-file', help='ops-hawk-client config file',
+                            default='/etc/openshift_tools/hawk_client.yaml')
+
+        key_value_group = parser.add_argument_group('Sending a Key-Value Pair')
+        key_value_group.add_argument('-k', '--key', help='zabbix key')
+        key_value_group.add_argument('-o', '--value', help='zabbix value')
+
+        low_level_discovery_group = parser.add_argument_group('Sending a Low Level Discovery Item')
+        low_level_discovery_group.add_argument('--discovery-key', help='discovery key')
+        low_level_discovery_group.add_argument('--macro-string', help='macro string')
+        low_level_discovery_group.add_argument('--macro-names', help='comma separated list of macro names')
+
+        self.args = parser.parse_args()
+
+    def parse_config(self, config_file):
+        """ parse config file """
+        self.config = yaml.load(file(config_file))
+
+    def config_hawk_sender(self):
+        """ configure the hawk_sender """
+
+        hawk_url = self.args.hawk_url if self.args.hawk_url else self.config['hawk']['url']
+        hawk_user = self.args.hawk_user if self.args.hawk_user else self.config['hawk']['user']
+        hawk_password = self.args.hawk_pass if self.args.hawk_pass else self.config['hawk']['pass']
+        hawk_verbose = self.args.verbose if self.args.verbose else self.config['hawk']['verbose']
+        hawk_debug = self.args.debug if self.args.debug else self.config['hawk']['debug']
+        hawk_ssl_verify = self.args.hawk_ssl_verify if self.args.hawk_ssl_verify else self.config['hawk']['ssl_verify']
+        if self.args.host:
+            host = self.args.host
+        elif self.args.synthetic:
+            host = self.config['synthetic_clusterwide']['host']['name']
+        else:
+            host = self.config['host']['name']
+
+        if isinstance(hawk_verbose, str):
+            hawk_verbose = (hawk_verbose == 'True')
+
+        if isinstance(hawk_debug, str):
+            hawk_debug = (hawk_debug == 'True')
+
+        if isinstance(hawk_ssl_verify, str):
+            hawk_ssl_verify = (hawk_ssl_verify == 'True')
+
+        hawk_conn = HawkConnection(url=hawk_url,
+                                   user=hawk_user,
+                                   password=hawk_password,
+                                   ssl_verify=hawk_ssl_verify,
+                                   debug=hawk_debug,
+                                  )
+
+        self.hawk_sender = HawkSender(host, hawk_conn, hawk_verbose, hawk_debug)
+
+    def add_heartbeat(self):
+        """ crate a hearbeat metric """
+        if self.args.synthetic:
+            heartbeat = HawkHeartbeat(templates=self.config['synthetic_clusterwide']['heartbeat']['templates'],
+                                      hostgroups=self.config['heartbeat']['hostgroups'],
+                                     )
+        else:
+            heartbeat = HawkHeartbeat(templates=self.config['heartbeat']['templates'],
+                                      hostgroups=self.config['heartbeat']['hostgroups'],
+                                     )
+        self.hawk_sender.add_heartbeat(heartbeat)
+
+    def add_zabbix_key(self):
+        """ send zabbix key/value pair to hawk """
+
+        self.hawk_sender.add_zabbix_keys({self.args.key : self.args.value})
+
+    def add_zabbix_dynamic_item(self):
+        """ send zabbix low level discovery item to hawk """
+
+        #TODO: implement add_zabbix_dynamic_item
+        #self.hawk_sender.add_zabbix_dynamic_item(self.args.discovery_key,
+        #                                         self.args.macro_string,
+        #                                         self.args.macro_names.split(','),
+        #                                        )
+        pass
+
+if __name__ == "__main__":
+    OZC = OpsHawkClient()
+    OZC.run()

--- a/scripts/monitoring/ops-runner.py
+++ b/scripts/monitoring/ops-runner.py
@@ -25,6 +25,7 @@ import socket
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
 from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.hawk_sender import HawkSender
 from openshift_tools.timeout import timeout, TimeoutException
 
 
@@ -173,20 +174,24 @@ class OpsRunner(object):
     def report_to_zabbix(self, disc_key, disc_macro, item_proto_key, value):
         """ Sends the commands exit code to zabbix. """
         zs = ZaggSender()
+        hs = HawkSender()
 
 
         # Add the dynamic item
         self.verbose_print("Adding the dynamic item to Zabbix - %s, %s, [%s]" % \
                            (disc_key, disc_macro, self.args.name))
         zs.add_zabbix_dynamic_item(disc_key, disc_macro, [self.args.name])
+        #TODO: zs.add_zabbix_dynamic_item(disc_key, disc_macro, [self.args.name])
 
         # Send the value for the dynamic item
         self.verbose_print("Sending metric to Zabbix - %s[%s]: %s" % \
                            (item_proto_key, self.args.name, value))
         zs.add_zabbix_keys({'%s[%s]' % (item_proto_key, self.args.name): value})
+        hs.add_zabbix_keys({'%s[%s]' % (item_proto_key, self.args.name): value})
 
         # Actually send them
         zs.send_metrics()
+        hs.send_metrics()
 
     def parse_args(self):
         """ parse the args from the cli """

--- a/scripts/openshift-tools-scripts.spec
+++ b/scripts/openshift-tools-scripts.spec
@@ -20,6 +20,7 @@ OpenShift Tools Scripts
 # openshift-tools-scripts-monitoring install
 mkdir -p %{buildroot}/usr/bin
 cp -p monitoring/ops-zagg-client.py %{buildroot}/usr/bin/ops-zagg-client
+cp -p monitoring/ops-hawk-client.py %{buildroot}/usr/bin/ops-hawk-client
 cp -p monitoring/ops-zagg-pcp-client.py %{buildroot}/usr/bin/ops-zagg-pcp-client
 cp -p monitoring/ops-zagg-metric-processor.py %{buildroot}/usr/bin/ops-zagg-metric-processor
 cp -p monitoring/ops-zagg-heartbeat-processor.py %{buildroot}/usr/bin/ops-zagg-heartbeat-processor
@@ -63,6 +64,7 @@ cp -p monitoring/cron-certificate-expirations.py %{buildroot}/usr/bin/cron-certi
 
 mkdir -p %{buildroot}/etc/openshift_tools
 cp -p monitoring/zagg_client.yaml.example %{buildroot}/etc/openshift_tools/zagg_client.yaml
+cp -p monitoring/hawk_client.yaml.example %{buildroot}/etc/openshift_tools/hawk_client.yaml
 cp -p monitoring/zagg_server.yaml.example %{buildroot}/etc/openshift_tools/zagg_server.yaml
 cp -p remote-heal/remote_healer.conf.example %{buildroot}/etc/openshift_tools/remote_healer.conf
 


### PR DESCRIPTION
**About**
Currently numerical metrics are sent to Zabbix. 
This PR is POC for sending _numerical_ data to Hawkular.

**Description**
Add a wrapper around the python hawkular client to mimic the Zabbix client.
Make an example cron-send-xxx that send numeric metrics to Hawkular server.

**Links**
https://github.com/hawkular/hawkular-client-python/pull/12
