### PR TITLE
add Trigger for terminating project last long then 5 minutes

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_master.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_master.yml
@@ -246,6 +246,13 @@ g_template_openshift_master:
     applications:
     - Openshift Master
 
+  - key: openshift.master.project.terminating.time
+    description: Show how long the longest Terminating project is there
+    value_type: int
+    applications:
+    - Openshift Master
+
+
   - key: openshift.master.smal.status
     description: Show saml pod status 
     value_type: int
@@ -689,6 +696,12 @@ g_template_openshift_master:
     expression: '{Template Openshift Master:openshift.master.smal.status.last()}>1'
     url: 'https://github.com/openshift/ops-sop/blob/master/V3/Alerts/openshift_saml_status.asciidoc'
     priority: high
+
+  - name: 'Terminating project last more than 5 minutes on {HOST.NAME}'
+    expression: '{Template Openshift Master:openshift.master.project.terminating.time.last()}>300'
+    url: 'https://github.com/openshift/ops-sop/blob/master/V3/Alerts/openshift_master_project_terminating.asciidoc'
+    priority: warn
+
 
   - name: 'Openshift SAML pod is not running on {HOST.NAME}'
     expression: '{Template Openshift Master:openshift.master.smal.status.last()}<1'


### PR DESCRIPTION
https://trello.com/c/uRjKovuX/322-v3-monitoring-add-monitoring-for-all-the-project-that-in-terminating-status-for-a-long-time

andy said we might need this check until we fix this , this is a bug 
https://github.com/openshift/origin/issues/8176

and this issue keeps alerting for app create ,which will caused timeout issue to the app create ,this will not fix the app create alert ,but will let us know there some project in Terminating status longer than 5 minutes
