### PR TITLE
ValueError: invalid literal for int() with base 10: '937500k'

### DIFF
--- a/openshift_tools/conversions.py
+++ b/openshift_tools/conversions.py
@@ -29,15 +29,12 @@ def to_bytes(num):
         num_bytes = int(num.rstrip(string.ascii_letters)) * (1000 ** 3)
     elif num.endswith('Mi'):
         num_bytes = int(num.rstrip(string.ascii_letters)) * 1024 * 1024
-    elif num.endswith('M'):
+    elif num.endswith('M') or num.endswith('m'):
         num_bytes = int(num.rstrip(string.ascii_letters)) * 1000 * 1000
     elif num.endswith('Ki'):
         num_bytes = int(num.rstrip(string.ascii_letters)) * 1024
-    elif num.endswith('K'):
+    elif num.endswith('K') or num.endswith('k'):
         num_bytes = int(num.rstrip(string.ascii_letters)) * 1000
-    elif num.endswith('m'):
-        # what's an 'm' value??
-        raise ConversionException("Found byte ending with 'm' value")
     else:
         num_bytes = int(num)
 

--- a/scripts/monitoring/cron-send-cluster-capacity.py
+++ b/scripts/monitoring/cron-send-cluster-capacity.py
@@ -128,18 +128,18 @@ class OpenshiftClusterCapacity(object):
 
         for container in containers:
             if 'limits' in container['resources']:
-                pod['cpu_limits'] = int(pod.get('cpu_limits', default=0)) \
-                    + int(to_milicores(container['resources']['limits'].get('cpu', default=0)))
+                pod['cpu_limits'] = int(pod.get('cpu_limits', 0)) \
+                    + int(to_milicores(container['resources']['limits'].get('cpu', 0)))
 
-                pod['memory_limits'] = int(pod.get('memory_limits', default=0)) \
-                    + int(to_bytes(container['resources']['limits'].get('memory', default=0)))
+                pod['memory_limits'] = int(pod.get('memory_limits', 0)) \
+                    + int(to_bytes(container['resources']['limits'].get('memory', 0)))
 
             if 'requests' in container['resources']:
-                pod['cpu_requests'] = int(pod.get('cpu_requests', default=0)) \
-                    + int(to_milicores(container['resources']['requests'].get('cpu', default=0)))
+                pod['cpu_requests'] = int(pod.get('cpu_requests', 0)) \
+                    + int(to_milicores(container['resources']['requests'].get('cpu', 0)))
 
-                pod['memory_requests'] = int(pod.get('memory_requests', default=0)) \
-                    + int(to_bytes(container['resources']['requests'].get('memory', default=0)))
+                pod['memory_requests'] = int(pod.get('memory_requests', 0)) \
+                    + int(to_bytes(container['resources']['requests'].get('memory', 0)))
 
     def load_pods(self):
         ''' put pod details into db '''

--- a/scripts/monitoring/cron-send-cluster-capacity.py
+++ b/scripts/monitoring/cron-send-cluster-capacity.py
@@ -128,30 +128,18 @@ class OpenshiftClusterCapacity(object):
 
         for container in containers:
             if 'limits' in container['resources']:
-                pod['cpu_limits'] = pod.get('cpu_limits', default=0) # in case below if is never true
-                cpu = container['resources']['limits'].get('cpu')
-                if cpu:
-                    pod['cpu_limits'] = pod.get('cpu_limits', 0) + \
-                                        to_milicores(cpu)
+                pod['cpu_limits'] = int(pod.get('cpu_limits', default=0)) \
+                    + int(to_milicores(container['resources']['limits'].get('cpu', default=0)))
 
-                pod['memory_limits'] = pod.get('memory_limits', default=0) # in case below if is never true
-                mem = container['resources']['limits'].get('memory')
-                if mem:
-                    pod['memory_limits'] = pod.get('memory_limits', 0) + \
-                                           to_bytes(mem)
+                pod['memory_limits'] = int(pod.get('memory_limits', default=0)) \
+                    + int(to_bytes(container['resources']['limits'].get('memory', default=0)))
 
             if 'requests' in container['resources']:
-                pod['cpu_requests'] = pod.get('cpu_requests', default=0) # in case below if is never true
-                cpu = container['resources']['requests'].get('cpu')
-                if cpu:
-                    pod['cpu_requests'] = pod.get('cpu_requests', 0) + \
-                                          to_milicores(cpu)
+                pod['cpu_requests'] = int(pod.get('cpu_requests', default=0)) \
+                    + int(to_milicores(container['resources']['requests'].get('cpu', default=0)))
 
-                pod['memory_requests'] = pod.get('memory_requests', default=0) # in case below if is never true
-                mem = container['resources']['requests'].get('memory')
-                if mem:
-                    pod['memory_requests'] = pod.get('memory_requests', 0) + \
-                                             to_bytes(mem)
+                pod['memory_requests'] = int(pod.get('memory_requests', default=0)) \
+                    + int(to_bytes(container['resources']['requests'].get('memory', default=0)))
 
     def load_pods(self):
         ''' put pod details into db '''

--- a/scripts/monitoring/cron-send-cluster-capacity.py
+++ b/scripts/monitoring/cron-send-cluster-capacity.py
@@ -128,18 +128,18 @@ class OpenshiftClusterCapacity(object):
 
         for container in containers:
             if 'limits' in container['resources']:
-                pod['cpu_limits'] = int(pod.get('cpu_limits', 0)) \
-                    + int(to_milicores(container['resources']['limits'].get('cpu', 0)))
+                pod['cpu_limits'] = int(pod.get('cpu_limits', '0')) \
+                    + int(to_milicores(container['resources']['limits'].get('cpu', '0')))
 
-                pod['memory_limits'] = int(pod.get('memory_limits', 0)) \
-                    + int(to_bytes(container['resources']['limits'].get('memory', 0)))
+                pod['memory_limits'] = int(pod.get('memory_limits', '0')) \
+                    + int(to_bytes(container['resources']['limits'].get('memory', '0')))
 
             if 'requests' in container['resources']:
-                pod['cpu_requests'] = int(pod.get('cpu_requests', 0)) \
-                    + int(to_milicores(container['resources']['requests'].get('cpu', 0)))
+                pod['cpu_requests'] = int(pod.get('cpu_requests', '0')) \
+                    + int(to_milicores(container['resources']['requests'].get('cpu', '0')))
 
-                pod['memory_requests'] = int(pod.get('memory_requests', 0)) \
-                    + int(to_bytes(container['resources']['requests'].get('memory', 0)))
+                pod['memory_requests'] = int(pod.get('memory_requests', '0')) \
+                    + int(to_bytes(container['resources']['requests'].get('memory', '0')))
 
     def load_pods(self):
         ''' put pod details into db '''

--- a/scripts/monitoring/cron-send-cluster-capacity.py
+++ b/scripts/monitoring/cron-send-cluster-capacity.py
@@ -208,7 +208,8 @@ class OpenshiftClusterCapacity(object):
 
         schedulable = 0
         for node in nodes.keys():
-            # TODO: Some containers from `oc get pods --all-namespaces -o json` don't have resources scheduled, causing memory_scheduled == 0
+            # TODO: Some containers from `oc get pods --all-namespaces -o json`
+            # don't have resources scheduled, causing memory_scheduled == 0
             available = nodes[node]['max_memory'] - \
                         nodes[node]['memory_scheduled']
             num = available / node_size

--- a/scripts/monitoring/cron-send-cluster-capacity.py
+++ b/scripts/monitoring/cron-send-cluster-capacity.py
@@ -128,17 +128,17 @@ class OpenshiftClusterCapacity(object):
 
         for container in containers:
             if 'limits' in container['resources']:
-                pod['cpu_limits'] = int(pod.get('cpu_limits', '0')) \
+                pod['cpu_limits'] = int(pod.get('cpu_limits', 0)) \
                     + int(to_milicores(container['resources']['limits'].get('cpu', '0')))
 
-                pod['memory_limits'] = int(pod.get('memory_limits', '0')) \
+                pod['memory_limits'] = int(pod.get('memory_limits', 0)) \
                     + int(to_bytes(container['resources']['limits'].get('memory', '0')))
 
             if 'requests' in container['resources']:
-                pod['cpu_requests'] = int(pod.get('cpu_requests', '0')) \
+                pod['cpu_requests'] = int(pod.get('cpu_requests', 0)) \
                     + int(to_milicores(container['resources']['requests'].get('cpu', '0')))
 
-                pod['memory_requests'] = int(pod.get('memory_requests', '0')) \
+                pod['memory_requests'] = int(pod.get('memory_requests', 0)) \
                     + int(to_bytes(container['resources']['requests'].get('memory', '0')))
 
     def load_pods(self):

--- a/scripts/monitoring/cron-send-cluster-capacity.py
+++ b/scripts/monitoring/cron-send-cluster-capacity.py
@@ -128,22 +128,26 @@ class OpenshiftClusterCapacity(object):
 
         for container in containers:
             if 'limits' in container['resources']:
+                pod['cpu_limits'] = pod.get('cpu_limits', default=0) # in case below if is never true
                 cpu = container['resources']['limits'].get('cpu')
                 if cpu:
                     pod['cpu_limits'] = pod.get('cpu_limits', 0) + \
                                         to_milicores(cpu)
 
+                pod['memory_limits'] = pod.get('memory_limits', default=0) # in case below if is never true
                 mem = container['resources']['limits'].get('memory')
                 if mem:
                     pod['memory_limits'] = pod.get('memory_limits', 0) + \
                                            to_bytes(mem)
 
             if 'requests' in container['resources']:
+                pod['cpu_requests'] = pod.get('cpu_requests', default=0) # in case below if is never true
                 cpu = container['resources']['requests'].get('cpu')
                 if cpu:
                     pod['cpu_requests'] = pod.get('cpu_requests', 0) + \
                                           to_milicores(cpu)
 
+                pod['memory_requests'] = pod.get('memory_requests', default=0) # in case below if is never true
                 mem = container['resources']['requests'].get('memory')
                 if mem:
                     pod['memory_requests'] = pod.get('memory_requests', 0) + \
@@ -216,6 +220,7 @@ class OpenshiftClusterCapacity(object):
 
         schedulable = 0
         for node in nodes.keys():
+            # TODO: Some containers from `oc get pods --all-namespaces -o json` don't have resources scheduled, causing memory_scheduled == 0
             available = nodes[node]['max_memory'] - \
                         nodes[node]['memory_scheduled']
             num = available / node_size


### PR DESCRIPTION
Trello: https://trello.com/c/xCnPsxEe/326-bug-invalid-literal-for-int-with-base-10-937500k-openshift-tools-usr-bin-cron-send-cluster-capacity

Noticed from zabbix: Average    PROBLEM ops-runner[cscc.openshift.master.capacity]: non-zero exit code on xxxxxxxxxx-master-xxxxx

```
oc get pods --all-namespaces -o json | grep '"memory"' | sort | uniq -c
    xxx                                 "memory": "125M"
    xxx                                 "memory": "128Mi"
    xxx                                 "memory": "1G"
    xxx                                 "memory": "2G"
    xxx                                 "memory": "3750M"
    xxx                                 "memory": "512Mi"
    xxx                                 "memory": "7500M"
    xxx                                 "memory": "937500k"
```

937500k was tripping up to_bytes.

```
[CTR][root@321ba7b38069 ~]$ ops-runner -f -s 120 -n cscc.openshift.master.capacity /usr/bin/cron-send-cluster-capacity
Traceback (most recent call last):
  File "/usr/bin/cron-send-cluster-capacity", line 414, in <module>
    OCC.run()
  File "/usr/bin/cron-send-cluster-capacity", line 56, in run
    self.cluster_capacity()
  File "/usr/bin/cron-send-cluster-capacity", line 398, in cluster_capacity
    self.load_pods()
  File "/usr/bin/cron-send-cluster-capacity", line 171, in load_pods
    self.load_container_limits(pod, new_pod['spec']['containers'])
  File "/usr/bin/cron-send-cluster-capacity", line 150, in load_container_limits
    to_bytes(mem)
  File "/usr/lib/python2.7/site-packages/openshift_tools/conversions.py", line 42, in to_bytes
    num_bytes = int(num)
ValueError: invalid literal for int() with base 10: '937500k'
```

After fixing this, the following happened:

```
Traceback (most recent call last):
  File "/usr/bin/cron-send-cluster-capacity", line 427, in <module>
    OCC.run()
  File "/usr/bin/cron-send-cluster-capacity", line 56, in run
    self.cluster_capacity()
  File "/usr/bin/cron-send-cluster-capacity", line 421, in cluster_capacity
    schedulable = self.how_many_schedulable(largest)
  File "/usr/bin/cron-send-cluster-capacity", line 233, in how_many_schedulable
    nodes[node]['memory_scheduled']
TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
```

Some pods don't have scheduled resources so were returning with None type. Simple defaults worked for this case.
