### PR TITLE
ansible 2.2 task naming

### DIFF
--- a/ansible/roles/oso_host_monitoring/handlers/main.yml
+++ b/ansible/roles/oso_host_monitoring/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Restart the {{ osohm_host_monitoring }} service"
+- name: "Restart the host monitoring service"
   service:
     name: "{{ osohm_host_monitoring }}"
     state: restarted

--- a/ansible/roles/oso_host_monitoring/tasks/main.yml
+++ b/ansible/roles/oso_host_monitoring/tasks/main.yml
@@ -52,7 +52,7 @@
     group: root
     mode: 0644
   notify:
-  - "Restart the {{ osohm_host_monitoring }} service"
+  - "Restart the host monitoring service"
 
 - name: "Copy etcd metrics config file"
   copy:
@@ -62,7 +62,7 @@
     group: root
     mode: 0644
   notify:
-  - "Restart the {{ osohm_host_monitoring }} service"
+  - "Restart the host monitoring service"
 
 - name: "Copy container metrics config file"
   copy:
@@ -72,7 +72,7 @@
     group: root
     mode: 0644
   notify:
-  - "Restart the {{ osohm_host_monitoring }} service"
+  - "Restart the host monitoring service"
 
 - name: "Copy {{ osohm_host_monitoring }} systemd file"
   template:
@@ -82,7 +82,7 @@
     group: root
     mode: 0644
   notify:
-  - "Restart the {{ osohm_host_monitoring }} service"
+  - "Restart the host monitoring service"
   register: systemd_host_monitoring
 
 - name: reload systemd


### PR DESCRIPTION
ansible says there's no such handler named "Restart the oso-rhel7-host-monitoring.service service"
simplify the naming of the handler to not include variable names
