### PR TITLE
Make centos pass the sanity checks in generate container ansible scripts

### DIFF
--- a/docker/oso-host-monitoring/generate-containers.yml
+++ b/docker/oso-host-monitoring/generate-containers.yml
@@ -8,8 +8,9 @@
     fail:
       msg: "Unsupported build environment"
     when: (ansible_distribution == "RedHat" and ansible_distribution_major_version < 7) or 
+          (ansible_distribution == "CentOS" and ansible_distribution_major_version < 7) or
           (ansible_distribution == "Fedora" and ansible_distribution_major_version < 22) or
-          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora")
+          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora" and ansible_distribution != "CentOS")
 
   roles:
   - role: "generate_containers"

--- a/docker/oso-ops-base/generate-containers.yml
+++ b/docker/oso-ops-base/generate-containers.yml
@@ -8,8 +8,9 @@
     fail:
       msg: "Unsupported build environment"
     when: (ansible_distribution == "RedHat" and ansible_distribution_major_version < 7) or 
+          (ansible_distribution == "CentOS" and ansible_distribution_major_version < 7) or
           (ansible_distribution == "Fedora" and ansible_distribution_major_version < 22) or
-          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora")
+          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora" and ansible_distribution != "CentOS")
 
   roles:
   - role: "generate_containers"

--- a/docker/oso-zagg-web/generate-containers.yml
+++ b/docker/oso-zagg-web/generate-containers.yml
@@ -8,8 +8,9 @@
     fail:
       msg: "Unsupported build environment"
     when: (ansible_distribution == "RedHat" and ansible_distribution_major_version < 7) or 
+          (ansible_distribution == "CentOS" and ansible_distribution_major_version < 7) or
           (ansible_distribution == "Fedora" and ansible_distribution_major_version < 22) or
-          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora")
+          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora" and ansible_distribution != "CentOS")
 
   roles:
   - role: "generate_containers"

--- a/docker/oso-zaio/generate-containers.yml
+++ b/docker/oso-zaio/generate-containers.yml
@@ -8,8 +8,9 @@
     fail:
       msg: "Unsupported build environment"
     when: (ansible_distribution == "RedHat" and ansible_distribution_major_version < 7) or 
+          (ansible_distribution == "CentOS" and ansible_distribution_major_version < 7) or
           (ansible_distribution == "Fedora" and ansible_distribution_major_version < 22) or
-          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora")
+          (ansible_distribution != "RedHat" and ansible_distribution != "Fedora" and ansible_distribution != "CentOS")
 
   roles:
   - role: "generate_containers"


### PR DESCRIPTION
Trying to run 
`openshift-tools/docker/build-local-setup-centos7.sh`
I got an error: `Unsupported build environment` because CentOS did not pass the sanity checks.
This PR make CentOS pass.
