### PR TITLE
check for certs in /etc/origin/{master,node}

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -310,7 +310,7 @@ host_monitoring_cron:
 - name: "Report on certificate expiration dates"
   hour: "1"
   minute: "1"
-  job: ops-runner -f -s 30 -n ccexp.openshift.master.certificates /usr/bin/cron-certificate-expirations
+  job: ops-runner -f -s 30 -n ccexp.openshift.master.certificates /usr/bin/cron-certificate-expirations --cert-list=/etc/origin/master,/etc/origin/node
 
 {% if osohm_cloud == 'aws' %}
 - name: send S3 bucket metrics every day


### PR DESCRIPTION
really just want to ignore /etc/origin/generated-configs
