### PR TITLE
Add a hawkular configuration, client and sender

### DIFF
--- a/openshift_tools/monitoring/hawk_client.py
+++ b/openshift_tools/monitoring/hawk_client.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python2
+# vim: expandtab:tabstop=4:shiftwidth=4
+"""
+HawkClient uses the openshift_tools.web/rest.py
+
+Example usage:
+
+    from openshift_tools.monitoring.metricmanager import UniqueMetric
+    from openshift_tools.monitoring.hawk_common import HawkConnection
+    from openshift_tools.monitoring.hawk_client import HawkClient
+
+    ml = []
+    # UniqueMetric from openshift_tools.monitoring.metricmanager
+    new_metric = UniqueMetric('example.com','cpu/usage',12.34)
+    ml.append(new_metric)
+    new_metric = UniqueMetric('example.org','cpu/usage',4.2)
+    ml.append(new_metric)
+
+    # No Auth
+    connection = HawkConnection(url='172.17.0.27:8000')
+
+    # Basic Auth
+    connection = HawkConnection(url='172.17.0.27:8000', user='user', passwd='password')
+
+    client = HawkClient(connection)
+    print client.add_metric(ml)
+"""
+#These are not installed on the buildbot, disabling this
+#pylint: disable=no-name-in-module,unused-import,import-error
+from openshift_tools.monitoring.metricmanager import UniqueMetric, MetricManager
+from openshift_tools.monitoring.hawk_common import HawkConnection
+
+# The hawkular client
+from hawkular.metrics import HawkularMetricsClient, MetricType, Availability
+
+#This class implements rest calls. We only have one rest call implemented
+# add-metric.  More could be added here
+#pylint: disable=too-few-public-methods
+class HawkClient(object):
+    """
+    wrappers class around hawkular client python so use can use it with UniqueMetric
+    """
+
+    def __init__(self, hawk_connection):
+        # pylint doesn't know where RestAPI is
+        #pylint: disable=undefined-variable
+        self.hawk_conn = hawk_connection
+        self.client = None
+
+        # Do not create a client if inactive
+        if not self.hawk_conn.active:
+            return
+
+        self.client = HawkularMetricsClient(host=self.hawk_conn.host,
+                                            port=self.hawk_conn.port,
+                                            scheme=self.hawk_conn.scheme,
+                                            username=self.hawk_conn.username,
+                                            password=self.hawk_conn.password,
+                                            context=self.hawk_conn.context,
+                                            tenant_id=self.hawk_conn.tenant_id,
+                                           )
+
+    def add_metric(self, unique_metric_list):
+        """
+        Add a list of UniqueMetrics (unique_metric_list) via hawkular client
+        """
+        # Do not run if inactive
+        if not self.hawk_conn.active:
+            return
+
+        # We do not support zabbix heartbeat in hawkular
+        metric_list = [m for m in unique_metric_list if m.key != 'heartbeat']
+
+        for metric in metric_list:
+            # Hawkular metrics support any numeric values
+            value = metric.value
+            # Hawkular metrics use milliseconds
+            clock = metric.clock * 1000
+            # Add the type and host to the key, this is needed because in hawkular,
+            # these need to be namespaced otherwise multiple hosts will be adding
+            # values to the same key. See common metrics keys proposal.
+            _type = 'node'
+            _id = metric.host
+            key = '{0}/{1}/{2}'.format(_type, _id, metric.key)
+            # Use MetricType.Gauge for numeric metrics data
+            metric_type = MetricType.Gauge
+            self.client.push(metric_type, key, value, clock)
+
+        status, raw_respons = None, None
+        return (status, raw_respons)

--- a/openshift_tools/monitoring/hawk_common.py
+++ b/openshift_tools/monitoring/hawk_common.py
@@ -1,0 +1,38 @@
+# vim: expandtab:tabstop=4:shiftwidth=4
+"""
+hawk_common contains common data structures and utils
+
+Example usage:
+    from openshift_tools.monitoring.hawk_common import HawkConnection, HawkHeartbeat
+
+    ZAGGCONN = HawkConnection(url='172.17.0.151', user='admin', password='pass')
+    ZAGGHEARTBEAT = HawkHeartbeat(templates=['template1', 'template2'], hostgroups=['hostgroup1', 'hostgroup2'])
+
+"""
+from collections import namedtuple
+from urlparse import urlparse
+import ssl
+
+# pylint: disable=too-few-public-methods,too-many-arguments,protected-access,too-many-instance-attributes
+# This is a DTO.  It needs to be a class because we need default values
+class HawkConnection(object):
+    ''' DTO for hawkular connection
+    '''
+    # pylint: disable=too-many-arguments
+    # This now supports ssl and need a couple of extra params
+    def __init__(self, url, user, password, ssl_verify=False, debug=False, active=True):
+        self.url = url if url.startswith('http') else 'http://' + url
+        self.username = user
+        self.password = password
+        self.ssl_verify = ssl_verify
+        self.debug = debug
+        self.active = active # We do not want this lib to work ansless explisitly activated
+
+        url_params = urlparse(self.url)
+        self.host = url_params.hostname
+        self.scheme = url_params.scheme
+        self.port = url_params.port or {'http': 80, 'https': 443}[self.scheme]
+        self.context = None if self.ssl_verify else ssl._create_unverified_context()
+        self.tenant_id = '_ops'
+
+HawkHeartbeat = namedtuple("HawkHeartbeat", ["templates", "hostgroups"])

--- a/openshift_tools/monitoring/hawk_sender.py
+++ b/openshift_tools/monitoring/hawk_sender.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+# vim: expandtab:tabstop=4:shiftwidth=4
+"""
+Collect metrics and send metrics to Hawk.  The data
+being send to Hawk is done using REST API using the HawkClient
+module
+
+Examples:
+
+    from openshift_tools.monitoring.hawk_common import HawkConnection, HawkHeartbeat
+    from openshift_tools.monitoring.hawk_sender import HawkSender
+    HOSTNAME = 'host.example.com'
+
+    ZAGGCONN = HawkConnection(url='https://172.17.0.151', user='admin', password='pass')
+    ZAGGHEARTBEAT = HawkHeartbeat(templates=['template1', 'template2'], hostgroups=['hostgroup1', 'hostgroup2'])
+
+    zs = HawkSender(host=HOSTNAME, hawk_connection=ZAGGCONN)
+    zs.add_heartbeat(ZAGGHEARTBEAT)
+    zs.add_zabbix_keys({ 'test.key' : '1' })
+    zs.send_metrics()
+"""
+
+from openshift_tools.monitoring.metricmanager import UniqueMetric
+from openshift_tools.monitoring.hawk_client import HawkClient
+from openshift_tools.monitoring.hawk_common import HawkConnection
+import os
+import yaml
+
+class HawkSenderException(Exception):
+    '''
+        HawkSenderException
+        Exists to propagate errors up from the api
+    '''
+    pass
+
+class HawkSender(object):
+    """
+    collect and create UniqueMetrics and send them to Hawk
+    """
+
+    def __init__(self, host=None, hawk_connection=None, verbose=False, debug=False):
+        """
+        set up the hawk client and unique_metrics
+        """
+        self.unique_metrics = []
+        self.config = None
+        self.config_file = '/etc/openshift_tools/hawk_client.yaml'
+        self.verbose = verbose
+        self.debug = debug
+
+        if not host:
+            host = self.get_default_host()
+
+        if not hawk_connection:
+            hawk_connection = self.get_default_hawk_connecton()
+
+        self.host = host
+        self.hawkclient = HawkClient(hawk_connection=hawk_connection)
+
+    def print_unique_metrics_key_value(self):
+        """
+        This function prints the key/value pairs the UniqueMetrics that HawkSender
+        currently has stored
+        """
+
+        print "\nHawkSender Key/Value pairs:"
+        print "=============================="
+        for unique_metric in self.unique_metrics:
+            print("%s:  %s") % (unique_metric.key, unique_metric.value)
+        print "==============================\n"
+
+    def print_unique_metrics(self):
+        """
+        This function prints all of the information of the UniqueMetrics that HawkSender
+        currently has stored
+        """
+
+        print "\nHawkSender UniqueMetrics:"
+        print "=============================="
+        for unique_metric in self.unique_metrics:
+            print unique_metric
+        print "==============================\n"
+
+    def parse_config(self):
+        """ parse default config file """
+
+        if not self.config:
+            if not os.path.exists(self.config_file):
+                raise HawkSenderException(self.config_file + " does not exist.")
+            self.config = yaml.load(file(self.config_file))
+
+    def get_default_host(self):
+        """ get the 'host' value from the config file """
+        self.parse_config()
+
+        return self.config['host']['name']
+
+    def get_default_hawk_connecton(self):
+        """ get the values and create a hawk_connection """
+
+        self.parse_config()
+        hawk_server = self.config['hawk']['url']
+        hawk_user = self.config['hawk']['user']
+        hawk_password = self.config['hawk']['pass']
+        hawk_ssl_verify = self.config['hawk'].get('ssl_verify', False)
+        hawk_debug = self.config['hawk'].get('debug', False)
+        hawk_active = self.config['hawk'].get('active', True)
+
+        if isinstance(hawk_ssl_verify, str):
+            hawk_ssl_verify = (hawk_ssl_verify == 'True')
+
+        if self.debug:
+            hawk_debug = self.debug
+        elif isinstance(hawk_debug, str):
+            hawk_debug = (hawk_debug == 'True')
+
+        hawk_connection = HawkConnection(url=hawk_server,
+                                         user=hawk_user,
+                                         password=hawk_password,
+                                         ssl_verify=hawk_ssl_verify,
+                                         debug=hawk_debug,
+                                         active=hawk_active,
+                                        )
+
+        return hawk_connection
+
+    def add_heartbeat(self, heartbeat, host=None):
+        """ create a heartbeat unique metric to send to hawk """
+
+        if not host:
+            host = self.host
+
+        hb_metric = UniqueMetric.create_heartbeat(host,
+                                                  heartbeat.templates,
+                                                  heartbeat.hostgroups,
+                                                 )
+        self.unique_metrics.append(hb_metric)
+
+    def add_zabbix_keys(self, zabbix_keys, host=None, synthetic=False):
+        """ create unique metric from zabbix key value pair """
+
+        if synthetic and not host:
+            host = self.config['synthetic_clusterwide']['host']['name']
+        elif not host:
+            host = self.host
+
+        zabbix_metrics = []
+
+        for key, value in zabbix_keys.iteritems():
+            zabbix_metric = UniqueMetric(host, key, value)
+            zabbix_metrics.append(zabbix_metric)
+
+        self.unique_metrics += zabbix_metrics
+
+    # Allow for 6 arguments (including 'self')
+    # pylint: disable=too-many-arguments
+    def add_zabbix_dynamic_item(self, discovery_key, macro_string, macro_array, host=None, synthetic=False):
+        """
+        This creates a dynamic item prototype that is required
+        for low level discovery rules in Hawkular.
+        This requires:
+        - dicovery key
+        - macro string
+        - macro name
+
+        This will create a zabbix key value pair that looks like:
+
+        disovery_key = "{"data": [
+                          {"{#macro_string}":"macro_array[0]"},
+                          {"{#macro_string}":"macro_array[1]"},
+                        ]}"
+        """
+
+        # Not implemented for Hawkular client
+        pass
+
+    def send_metrics(self):
+        """
+        Send list of Unique Metrics to Hawk
+        clear self.unique_metrics
+        """
+        if self.verbose:
+            self.print_unique_metrics_key_value()
+
+        if self.debug:
+            self.print_unique_metrics()
+
+        self.hawkclient.add_metric(self.unique_metrics)
+        self.unique_metrics = []

--- a/scripts/monitoring/hawk_client.yaml.example
+++ b/scripts/monitoring/hawk_client.yaml.example
@@ -1,0 +1,26 @@
+---
+host:
+    name: hostname.example.com
+hawk:
+    url: https://172.17.0.164
+    user: admin
+    pass: XXXXXX
+    verbose: False
+    debug: False
+    ssl_verify: False
+    active: False
+pcp:
+    metrics:
+        - kernel.all
+        - swap.free
+        - swap.length
+        - swap.used
+heartbeat:
+    templates:
+        - template1
+        - template2
+        - template3
+    hostgroups:
+        - hostgroup1
+        - hostgroup2
+        - hostgroup3

--- a/scripts/openshift-tools-scripts.spec
+++ b/scripts/openshift-tools-scripts.spec
@@ -66,6 +66,7 @@ cp -p monitoring/cron-certificate-expirations.py %{buildroot}/usr/bin/cron-certi
 
 mkdir -p %{buildroot}/etc/openshift_tools
 cp -p monitoring/zagg_client.yaml.example %{buildroot}/etc/openshift_tools/zagg_client.yaml
+cp -p monitoring/hawk_client.yaml.example %{buildroot}/etc/openshift_tools/hawk_client.yaml
 cp -p monitoring/zagg_server.yaml.example %{buildroot}/etc/openshift_tools/zagg_server.yaml
 cp -p remote-heal/remote_healer.conf.example %{buildroot}/etc/openshift_tools/remote_healer.conf
 


### PR DESCRIPTION
**Description**
Add a wrapper code around the python hawkular client to mimic the Zabbix client.
This PR addes the library functions for sending numerical data to Hawkular.

**Only adds a library, does not do anything**

| New Classes |  |
| --- | --- |
| HawkConnection | Connection information (if inactive is True, the hawkular client will do nothing silently) |
| HawkClient | A client for hawkualr metrics API ( mimic ZaggClient, can be a drop in replacment ) |
| HawkSender | High level interface for sending metrics to hawkular ( mimic ZaggSender, can be a drop in replacment ) |

| Requirements |  |
| --- | --- |
| zbxsend | for UniqueMetric (If we drop zabbix, we will need to re-implement UniqueMetric) |
| hawkular-client-python | for low level hawkular API support |
