### PR TITLE
[WIP]clean the old monitor project

### DIFF
--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -114,8 +114,8 @@ class OpenShiftOC(object):
             match = pattern.match(pro)
             #print 'start comapre the name with',namespace_front 
             if match:
-                print 'found old monitor project ****:',pro
-                print 'deleting the project',pro
+                print 'found old monitor project ****:', pro
+                print 'deleting the project', pro
                 self.delete_project_with_givename(pro)
 
     def get_logs(self):
@@ -308,7 +308,7 @@ def main():
     namespace = 'ops-' + pod_name(args.name) + '-' + os.environ['ZAGG_CLIENT_HOSTNAME'] \
         + '-' + ''.join(random.choice(string.lowercase) for i in range(6))
     namespace_front = 'ops-' + pod_name(args.name) + '-' + os.environ['ZAGG_CLIENT_HOSTNAME'] \
-        + '-' 
+        + '-'
     oocmd = OpenShiftOC(namespace, kubeconfig, args, verbose=False)
     app = args.name
 

--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -107,10 +107,10 @@ class OpenShiftOC(object):
 
 
     def clean_project(self, namespace_front):
-	'''clean all the project before run the check '''
-	cmd = ['get', 'projects', '--no-headers']
-	projects = [proj.split()[0] for proj in self.oc_cmd(cmd).split('\n') if proj and len(proj) > 0]
-	for pro in projects:
+        '''clean all the project before run the check '''
+        cmd = ['get', 'projects', '--no-headers']
+        projects = [proj.split()[0] for proj in self.oc_cmd(cmd).split('\n') if proj and len(proj) > 0]
+        for pro in projects:
             pattern = re.compile(r'^'+namespace_front)
             match = pattern.match(pro)
             if match:

--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -88,7 +88,7 @@ class OpenShiftOC(object):
         time.sleep(5)
         return results
 
-    def delete_project_with_givename(self,projectname):
+    def delete_project_with_givename(self, projectname):
         '''delete project '''
         cmd = ['delete', 'project', projectname]
         results = self.oc_cmd(cmd)
@@ -104,15 +104,15 @@ class OpenShiftOC(object):
         else:
             rval = self.oc_cmd(cmd)
         return rval
-	
-    def clean_project(self,namespace_front):
+
+
+    def clean_project(self, namespace_front):
 	'''clean all the project before run the check '''
 	cmd = ['get', 'projects', '--no-headers']
 	projects = [proj.split()[0] for proj in self.oc_cmd(cmd).split('\n') if proj and len(proj) > 0]
 	for pro in projects:
             pattern = re.compile(r'^'+namespace_front)
             match = pattern.match(pro)
-            #print 'start comapre the name with',namespace_front 
             if match:
                 print 'found old monitor project ****:', pro
                 print 'deleting the project', pro


### PR DESCRIPTION
this will fix the problem that the app create check create too many project on our cluster ,this will clean the check project before run the check using "re"

I have tested this on dev-preview-int and dev-preview-stg , seems works fine 

because this need to delete project ,so I think I might need you guys review this code 

@a13m @stenwt @kwoodson @mwoodson 
