### PR TITLE
update event watcher with regex ability

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -395,3 +395,16 @@ host_monitoring_cron:
 
 {# end if host master #}
 {% endif %}
+
+event_watcher_config:
+  # EventName:
+  #   - pattern: 'regex pattern to match on the event's 'message' value'
+  #     zbx_key: <zabbix key to report this 'event' on>
+  #   - pattern: 'regex for a different event subtype'
+  #     zbx_key: <zabbix key for event subtype>
+  # OtherEvent:
+  #   - pattern: 'regex for OtherEvent'
+  #     zbx_key: <zabbix key to report>
+  FailedScheduling:
+    - pattern: failed to fit in any node
+      zbx_key: openshift.master.cluster.event.failedscheduling

--- a/scripts/monitoring/cron-event-watcher.py
+++ b/scripts/monitoring/cron-event-watcher.py
@@ -31,16 +31,16 @@ import re
 import subprocess
 import threading
 import time
-
-ZBX_KEY = "openshift.master.cluster.event."
+import yaml
 
 #pylint: disable=too-few-public-methods
 class OpenshiftEventConsumer(object):
     ''' Submits events to Zabbix '''
 
-    def __init__(self, args, queue):
+    def __init__(self, args, queue, zbx_keys):
         self.queue = queue
         self.args = args
+        self.zbx_keys = zbx_keys
 
     def run(self):
         ''' main function '''
@@ -56,9 +56,10 @@ class OpenshiftEventConsumer(object):
             # initialize event counts so that we send '0' events
             # in the case where no events were received
             event_counts = {}
-            for event_type in self.args.watch_for:
-                event_counts[event_type] = 0
+            for zbx_key in self.zbx_keys:
+                event_counts[zbx_key] = 0
 
+            # add up each distinct event
             for event in event_list:
                 event_counts[event] += 1
 
@@ -68,9 +69,8 @@ class OpenshiftEventConsumer(object):
             if not self.args.dry_run:
                 zagg_sender = ZaggSender(verbose=self.args.verbose,
                                          debug=self.args.debug)
-                for event in event_counts.keys():
-                    key = ZBX_KEY + event.lower()
-                    zagg_sender.add_zabbix_keys({key: event_counts[event]})
+                for event, count in event_counts.iteritems():
+                    zagg_sender.add_zabbix_keys({event: count})
                 zagg_sender.send_metrics()
 
             time.sleep(self.args.reporting_period)
@@ -91,24 +91,25 @@ class OpenshiftEventWatcher(object):
         self.event_watch_loop()
 
     def watch_list_setup(self):
-        ''' create list of events/reasons to watch for '''
-        self.args.watch_for = self.args.watch_for.split(',')
+        ''' create dict of events/reasons to watch for
+            plus a regex to further filter events'''
+        with open(self.args.config, 'r') as config:
+            self.args.watch_for = yaml.load(config)['event_watcher_config']
 
     def parse_args(self):
         ''' parse the args from the cli '''
 
         parser = argparse.ArgumentParser(description='OpenShift event watcher')
-        parser.add_argument('--config', default='/etc/origin/master/admin.kubeconfig',
+        parser.add_argument('--kubeconfig', default='/etc/origin/master/admin.kubeconfig',
                             help='Location of OpenShift kubeconfig file')
+        parser.add_argument('--config', default='/container_setup/monitoring-config.yml',
+                            help='Config file for event watcher script')
         parser.add_argument('-v', '--verbose', action='store_true',
                             default=None, help='Verbose?')
         parser.add_argument('--debug', action='store_true',
                             default=None, help='Debug?')
         parser.add_argument('--dry-run', action='store_true', default=False,
                             help='Do not send results to Zabbix')
-        parser.add_argument('--watch-for', required=True,
-                            help='Comma-separated list of case-sensitive events ' + \
-                                 'to match.')
         parser.add_argument('--reporting-period', default=60, type=int,
                             help='How many seconds between each reporting period')
 
@@ -116,13 +117,41 @@ class OpenshiftEventWatcher(object):
 
         self.watch_list_setup()
 
+    def check_event(self, event):
+        ''' If an event is something we're looking for
+            return the key it should be reported as '''
+
+        # Most events aren't something we will care about
+        # so catch that case and return early
+        if event['reason'] not in self.args.watch_for.keys():
+            return None
+
+        regex_list = self.args.watch_for[event['reason']]
+        for regex in regex_list:
+            if re.search(regex['pattern'], event['message']):
+                return regex['zbx_key']
+
+        # If we made it here, then there was no regex match
+        # so the event is not something we will report to zabbix
+        return None
+
+    def get_zbx_keys(self):
+        ''' return list of zbx keys config file says to report on '''
+
+        zbx_keys = []
+        for _, regex_list in self.args.watch_for.iteritems():
+            for regex in regex_list:
+                zbx_keys.append(regex['zbx_key'])
+
+        return zbx_keys
+
     def event_watch_loop(self):
         ''' Loop to read/process OpenShift events '''
 
         while True:
             popen = subprocess.Popen(['oc', 'get', 'events', '--all-namespaces',
                                       '-o', 'json', '--config',
-                                      self.args.config, '--watch-only'],
+                                      self.args.kubeconfig, '--watch-only'],
                                      bufsize=1, stdout=subprocess.PIPE)
 
             json_str = ""
@@ -135,17 +164,16 @@ class OpenshiftEventWatcher(object):
 
                 if re.match("}", line): # '}' signals end of json object
                     json_obj = json.loads(json_str)
-                    if self.args.verbose or self.args.debug:
-                        print "Event type: " + json_obj['reason']
-
                     if self.args.debug:
-                        print "Received event: "
+                        print "Event type: " + json_obj['reason']
                         print json.dumps(json_obj, sort_keys=True, indent=4)
 
-                    if json_obj['reason'] in self.args.watch_for:
+                    result = self.check_event(json_obj)
+                    if result:
                         if self.args.verbose:
-                            print "Matched event: " + json_obj['reason']
-                        self.queue.put(json_obj['reason'])
+                            print "Matched event: " + json_obj['reason'] + \
+                                  " " + json_obj['message']
+                        self.queue.put(result)
                     json_str = ""
 
             # Never should get here
@@ -154,9 +182,10 @@ if __name__ == '__main__':
     event_queue = Queue()
 
     OEW = OpenshiftEventWatcher(event_queue)
+    zbx_key_list = OEW.get_zbx_keys()
     watch_thread = threading.Thread(target=OEW.run)
     watch_thread.start()
 
-    OEC = OpenshiftEventConsumer(OEW.args, event_queue)
+    OEC = OpenshiftEventConsumer(OEW.args, event_queue, zbx_key_list)
     event_consumer = threading.Thread(target=OEC.run)
     event_consumer.start()


### PR DESCRIPTION
old event watcher only looked at the event 'reason'
to further be able to subcategorize events, allow passing a regex (and associated zabbix key to report the event under)
