### PR TITLE
almost-rebuild cron-send-create-app, phase 1

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -216,7 +216,7 @@ host_monitoring_cron:
 {# Openshift Master checks #}
 - name: run create app every 5 minutes
   minute: "*/5"
-  job: "export ZAGG_CLIENT_HOSTNAME={{ osohm_host_name }}; ops-runner -f -t 180 -s 60 -n csca.openshift.master.app.create /usr/bin/cron-send-create-app &>> /var/log/create_app.log"
+  job: "export ZAGG_CLIENT_HOSTNAME={{ osohm_host_name }}; ops-runner -f -t 180 -s 60 -n csca.openshift.master.app.create /usr/bin/cron-send-create-app --namespace registry --name openshift/hello-openshift:v1.0.6 &>> /var/log/create_app.log"
 
 - name: run Terminating status project every 5 minutes
   minute: "*/5"
@@ -224,7 +224,7 @@ host_monitoring_cron:
 
 - name: run create app with build process every 30 minutes
   minute: "*/30"
-  job: "export ZAGG_CLIENT_HOSTNAME={{ osohm_host_name }}; ops-runner -f -t 1200 -s 120 -n csca.openshift.master.app.build.create /usr/bin/cron-send-create-app --name https://github.com/openshift/nodejs-ex &>> /var/log/build_app.log"
+  job: "export ZAGG_CLIENT_HOSTNAME={{ osohm_host_name }}; ops-runner -f -t 1200 -s 120 -n csca.openshift.master.app.build.create /usr/bin/cron-send-create-app --namespace build --name https://github.com/openshift/nodejs-ex &>> /var/log/build_app.log"
 
 {% if osohm_master_ha|bool %}
 - name: send openshift-master process count

--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -431,8 +431,7 @@ def main():
     # finish time tracking
     run_time = str(time.time() - start_time)
 
-    logger.info('Finished.')
-    logger.info('Time: %s', run_time)
+    logger.info('Test finished. Time to complete test only: %s', run_time)
 
     # send data to zabbix
     try:

--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -251,6 +251,7 @@ def parse_args():
     parser.add_argument('-v', '--verbose', action='store_true', default=None, help='Verbose?')
     parser.add_argument('--debug', action='store_true', default=None, help='Debug?')
     parser.add_argument('--name', default="openshift/hello-openshift:v1.0.6", help='app template')
+    parser.add_argument('--namespace', default="default", help='additional text for namespace')
     return parser.parse_args()
 
 def pod_name(name):
@@ -396,7 +397,12 @@ def main():
         logger.setLevel(logging.DEBUG)
 
     kubeconfig = copy_kubeconfig('/tmp/admin.kubeconfig')
-    namespace = '-'.join(['ops-health', pod_name(args.name), os.environ['ZAGG_CLIENT_HOSTNAME'], ])
+    namespace = '-'.join([
+        'ops-health',
+        args.namespace,
+        pod_name(args.name),
+        os.environ['ZAGG_CLIENT_HOSTNAME'],
+    ])
 
     oocmd = OpenShiftOC(namespace, kubeconfig, args, verbose=False)
 
@@ -461,7 +467,6 @@ def main():
     else:
         logger.info('Deploy State: Success')
         logger.info('Service HTTP response code: %s', test_response['http_code'])
-
 
     # cleanup project
     try:


### PR DESCRIPTION
- convert print to logging
- rewrite build progress conditions in main wait loop
- cleaner namespace
- unit testing style functions: setup / test / teardown
- try/except to ensure project can be deleted even if error
- enable verbose flag

This is the first stages of a multi-step rebuild.

Still to do, in new PRs:
- use library for oc and oadm commands
- redo build step main wait loop
- track specific repo commits for consistency in app builds
- test PV related app builds
