### PR TITLE
fix bug for Terminating project last for -1 days

### DIFF
--- a/scripts/monitoring/cron-send-project-stats.py
+++ b/scripts/monitoring/cron-send-project-stats.py
@@ -253,9 +253,11 @@ def main():
                 current_time = datetime.datetime.now()
                 time_keeps = current_time - old_time
                 print 'the project in Terminating status for %s' % time_keeps
-
-                time_keeps_max = max(time_keeps_max, (current_time - old_time).seconds)
-
+                if current_time > old_time:
+                    time_keeps_max = max(time_keeps_max, (current_time - old_time).seconds)
+                else:
+                    print 'something wrong , the pod said its been terminating before created'
+                    #time_keeps_max = -((current_time - old_time).seconds)
                 print time_keeps_max
 
     except ValueError, e:

--- a/scripts/monitoring/cron-send-project-stats.py
+++ b/scripts/monitoring/cron-send-project-stats.py
@@ -248,8 +248,7 @@ def main():
                 print pro['metadata']['deletionTimestamp']
                 temp_t = pro['metadata']['deletionTimestamp'].replace('T', ' ').replace('Z', '')
                 old_time = datetime.datetime.strptime(temp_t, '%Y-%m-%d %H:%M:%S')
-                #current_time = datetime.datetime.strptime(time.strftime('%Y-%m-%d %H:%M:%S'),'%Y-%m-%d %H:%M:%S')
-                #current_time = datetime.datetime.strptime(time.strftime('%Y-%m-%d %H:%M:%S'),'%Y-%m-%d %H:%M:%S')
+
                 current_time = datetime.datetime.now()
                 time_keeps = current_time - old_time
                 print 'the project in Terminating status for %s' % time_keeps
@@ -257,7 +256,6 @@ def main():
                     time_keeps_max = max(time_keeps_max, (current_time - old_time).seconds)
                 else:
                     print 'something wrong , the pod said its been terminating before created'
-                    #time_keeps_max = -((current_time - old_time).seconds)
                 print time_keeps_max
 
     except ValueError, e:


### PR DESCRIPTION
found that sometimes the project in Terminating project have a time early than create, that's why we keep seeing alert said that some project last for 70k s 
