### PR TITLE
add support for setting up multiple OpenShift routers

### DIFF
--- a/ansible/roles/lib_openshift_3.2/build/ansible/oadm_router.py
+++ b/ansible/roles/lib_openshift_3.2/build/ansible/oadm_router.py
@@ -43,7 +43,7 @@ def main():
             # extra
             cacert_file=dict(default=None, type='str'),
             # edits
-            edits=dict(default={}, type='dict'),
+            edits=dict(default=[], type='list'),
         ),
         mutually_exclusive=[["router_type", "images"]],
 

--- a/ansible/roles/lib_openshift_3.2/build/src/oadm_router.py
+++ b/ansible/roles/lib_openshift_3.2/build/src/oadm_router.py
@@ -28,7 +28,7 @@ class Router(OpenShiftCLI):
         self.verbose = verbose
         self.router_parts = [{'kind': 'dc', 'name': self.config.name},
                              {'kind': 'svc', 'name': self.config.name},
-                             {'kind': 'sa', 'name': self.config.name},
+                             {'kind': 'sa', 'name': self.config.config_options['service_account']['value']},
                              {'kind': 'secret', 'name': self.config.name + '-certs'},
                              {'kind': 'clusterrolebinding', 'name': 'router-' + self.config.name + '-role'},
                              #{'kind': 'endpoints', 'name': self.config.name},
@@ -155,8 +155,18 @@ class Router(OpenShiftCLI):
         # We want modifications in the form of edits coming in from the module.
         # Let's apply these here
         edit_results = []
-        for key, value in self.config.config_options['edits'].get('value', {}).items():
-            edit_results.append(deploymentconfig.put(key, value))
+        for edit in self.config.config_options['edits'].get('value', []):
+            if edit['action'] == 'put':
+                edit_results.append(deploymentconfig.put(edit['key'],
+                                                         edit['value']))
+            if edit['action'] == 'update':
+                edit_results.append(deploymentconfig.update(edit['key'],
+                                                            edit['value'],
+                                                            edit.get('index', None),
+                                                            edit.get('curr_value', None)))
+            if edit['action'] == 'append':
+                edit_results.append(deploymentconfig.append(edit['key'],
+                                                            edit['value']))
 
         if edit_results and not any([res[0] for res in edit_results]):
             return None

--- a/ansible/roles/lib_openshift_3.2/library/oadm_router.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_router.py
@@ -1841,7 +1841,7 @@ class Router(OpenShiftCLI):
         self.verbose = verbose
         self.router_parts = [{'kind': 'dc', 'name': self.config.name},
                              {'kind': 'svc', 'name': self.config.name},
-                             {'kind': 'sa', 'name': self.config.name},
+                             {'kind': 'sa', 'name': self.config.config_options['service_account']['value']},
                              {'kind': 'secret', 'name': self.config.name + '-certs'},
                              {'kind': 'clusterrolebinding', 'name': 'router-' + self.config.name + '-role'},
                              #{'kind': 'endpoints', 'name': self.config.name},
@@ -1968,8 +1968,18 @@ class Router(OpenShiftCLI):
         # We want modifications in the form of edits coming in from the module.
         # Let's apply these here
         edit_results = []
-        for key, value in self.config.config_options['edits'].get('value', {}).items():
-            edit_results.append(deploymentconfig.put(key, value))
+        for edit in self.config.config_options['edits'].get('value', []):
+            if edit['action'] == 'put':
+                edit_results.append(deploymentconfig.put(edit['key'],
+                                                         edit['value']))
+            if edit['action'] == 'update':
+                edit_results.append(deploymentconfig.update(edit['key'],
+                                                            edit['value'],
+                                                            edit.get('index', None),
+                                                            edit.get('curr_value', None)))
+            if edit['action'] == 'append':
+                edit_results.append(deploymentconfig.append(edit['key'],
+                                                            edit['value']))
 
         if edit_results and not any([res[0] for res in edit_results]):
             return None
@@ -2188,7 +2198,7 @@ def main():
             # extra
             cacert_file=dict(default=None, type='str'),
             # edits
-            edits=dict(default={}, type='dict'),
+            edits=dict(default=[], type='list'),
         ),
         mutually_exclusive=[["router_type", "images"]],
 

--- a/ansible/roles/openshift_secure_router/defaults/main.yml
+++ b/ansible/roles/openshift_secure_router/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+ossr_default_router_edits:
+  - key: spec.strategy.rollingParams
+    value:
+      intervalSeconds: 1
+      maxSurge: 50%
+      maxUnavailable: 50%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    action: put

--- a/ansible/roles/openshift_secure_router/filter_plugins/filters.py
+++ b/ansible/roles/openshift_secure_router/filter_plugins/filters.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# vim: expandtab:tabstop=4:shiftwidth=4
+'''
+Custom filters for use in openshift_secure_router
+'''
+
+class FilterModule(object):
+    ''' Custom ansible filters '''
+
+    @staticmethod
+    def ossr_create_port_list(port_list):
+        ''' given the routers' listeners list (elb port details),
+            build list of OpenShift router port mappings '''
+
+        router_port_list = []
+        for ports in port_list:
+            # instance port -> instance port mapping because the router
+            # uses host networking
+            inst_port = ports['instance_port']
+            router_port_list.append("{}:{}".format(inst_port, inst_port))
+
+        return router_port_list
+
+    def filters(self):
+        ''' returns a mapping of filters to methods '''
+        return {
+            "ossr_create_port_list": self.ossr_create_port_list,
+        }

--- a/ansible/roles/openshift_secure_router/tasks/main.yml
+++ b/ansible/roles/openshift_secure_router/tasks/main.yml
@@ -1,38 +1,33 @@
 ---
-- name: get cert's basename
-  set_fact:
-    cert_basename: "{{ ossr_default_router_cert | basename }}"
-    key_basename: "{{ ossr_default_router_key | basename }}"
-    cacert_basename: "{{ ossr_default_router_cacert | basename }}"
-
 - name: copy router certs to masters
   copy:
     src: "{{ item }}"
     dest: /etc/origin/master/named_certificates/
   with_items:
-  - "{{ ossr_default_router_cert }}"
-  - "{{ ossr_default_router_key }}"
+  - "{{ ossr_default_router_certs }}"
+  - "{{ ossr_default_router_keys }}"
   - "{{ ossr_default_router_cacert }}"
 
-- name: create secured router
+- name: create routers
   oadm_router:
+    name: "{{ item.0.name }}"
     service_account: router
-    replicas: 2
+    replicas: "{{ item.0.replicas | default(2) }}"
     namespace: default
     selector: type=infra
+    ports: "{{ item.0.listeners | default(g_elb_infra_listeners) | ossr_create_port_list() }}"
+    stats_port: "{{ item.0.stats_port | default(omit) }}"
     images: "registry.ops.openshift.com/openshift3/ose-${component}:${version}"
-    cert_file: "/etc/origin/master/named_certificates/{{ cert_basename }}"
-    key_file: "/etc/origin/master/named_certificates/{{ key_basename }}"
-    cacert_file: "/etc/origin/master/named_certificates/{{ cacert_basename }}"
-    edits:
-        spec.strategy.rollingParams:
-          intervalSeconds: 1
-          maxSurge: 50%
-          maxUnavailable: 50%
-          timeoutSeconds: 600
-          updatePeriodSeconds: 1
+    cert_file: "/etc/origin/master/named_certificates/{{ item.1 | basename }}"
+    key_file: "/etc/origin/master/named_certificates/{{ item.2 | basename }}"
+    cacert_file: "/etc/origin/master/named_certificates/{{ ossr_default_router_cacert | basename }}"
+    edits: "{{ item.0.router_edits | default([]) | union(ossr_default_router_edits) }}"
+  with_together:
+  - "{{ g_routers }}" # item.0
+  - "{{ ossr_default_router_certs }}" # item.1
+  - "{{ ossr_default_router_keys }}" # item.2
   register: router_out
-  run_once: true
+  run_once: True
 
 - debug:
     var: router_out


### PR DESCRIPTION
and fix up some incorrect ansible module parameters
create routers explicitly by the name passed into the ansible module
redefine the edits section to allow for more precise yaml editing
