### PR TITLE
Ocutil updates

### DIFF
--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -132,11 +132,7 @@ class OCUtil(object):
 
     def get_pods(self):
         ''' Get all the pods in the namespace '''
-
-        pods_cmd = "get pods -o yaml"
-        pods_yaml = self._run_cmd(pods_cmd)
-
-        return pods_yaml
+        return self._run_cmd_yaml("get pods")
 
     def get_projects(self):
         ''' Get all projects in the cluster '''

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -139,7 +139,7 @@ class OCUtil(object):
 
     def get_projects(self):
         ''' Get all projects in the cluster '''
-        return self._run_cmd("get projects -o yaml")
+        return self._run_cmd_yaml("get projects")
 
     def get_nodes(self):
         ''' Get all the nodes in the cluster '''

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -128,11 +128,7 @@ class OCUtil(object):
 
     def get_projects(self):
         ''' Get all projects in the cluster '''
-
-        nodes_cmd = "get projects -o yaml"
-        nodes_yaml = self._run_cmd(nodes_cmd)
-
-        return nodes_yaml
+        return self._run_cmd("get projects -o yaml")
 
     def get_nodes(self):
         ''' Get all the nodes in the cluster '''

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -83,7 +83,12 @@ class OCUtil(object):
         if self.verbose:
             print "Running command: {}".format(str(cmd))
 
-        return subprocess.check_output(cmd)
+        try:
+            return subprocess.check_output(cmd)
+        except Exception as e:
+            if self.logger:
+                self.logger.exception('Error from server')
+            raise e
 
     def _run_cmd_yaml(self, cmd, baseCmd='oc', yamlCmd='-o yaml', ):
         return yaml.safe_load(self._run_cmd(

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -84,6 +84,7 @@ class OCUtil(object):
             " ".join([cmd, yamlCmd]),
             baseCmd=baseCmd,
         ))
+
     def run_user_cmd(self, cmd, baseCmd='oc', ):
         ''' Runs a custom user command '''
         return self._run_cmd(
@@ -101,43 +102,23 @@ class OCUtil(object):
 
     def get_secrets(self, name):
         ''' Get secrets from object 'name' '''
-
-        secrets_cmd = "get secrets {} -o yaml".format(name)
-        secrets_yaml = self._run_cmd(secrets_cmd)
-
-        return secrets_yaml
+        return self._run_cmd_yaml("get secrets {}".format(name))
 
     def get_endpoint(self, name):
         ''' Get endpoint details '''
-
-        endpoint_cmd = "get endpoints {} -o yaml".format(name)
-        endpoint_yaml = self._run_cmd(endpoint_cmd)
-
-        return endpoint_yaml
+        return self._run_cmd_yaml("get endpoints {}".format(name))
 
     def get_service(self, name):
         ''' Get service details '''
-
-        service_cmd = "get service {} -o yaml".format(name)
-        service_yaml = self._run_cmd(service_cmd)
-
-        return service_yaml
+        return self._run_cmd_yaml("get service {}".format(name))
 
     def get_dc(self, name):
         ''' Get deployment config details '''
-
-        dc_cmd = "get dc {} -o yaml".format(name)
-        dc_yaml = self._run_cmd(dc_cmd)
-
-        return dc_yaml
+        return self._run_cmd_yaml("get dc {}".format(name))
 
     def get_route(self, name):
         ''' Get routes details '''
-
-        route_cmd = "get route {} -o yaml".format(name)
-        route_yaml = self._run_cmd(route_cmd)
-
-        return route_yaml
+        return self._run_cmd_yaml("get route {}".format(name))
 
     def get_pods(self):
         ''' Get all the pods in the namespace '''
@@ -153,8 +134,4 @@ class OCUtil(object):
 
     def get_log(self, name):
         ''' Gets the log for the specified container '''
-
-        log_cmd = "logs {}".format(name)
-        log_results = self._run_cmd(log_cmd)
-
-        return log_results
+        return self._run_cmd("logs {}".format(name))

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -129,7 +129,7 @@ class OCUtil(object):
     def get_projects(self):
         ''' Get all projects in the cluster '''
 
-        nodes_cmd = "oc get projects -o yaml"
+        nodes_cmd = "get projects -o yaml"
         nodes_yaml = self._run_cmd(nodes_cmd)
 
         return nodes_yaml

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -74,13 +74,14 @@ class OCUtil(object):
             '-n', self.namespace,
             cmd,
         ])
+
+        if self.logger:
+            self.logger.debug("ocutil._run_cmd( {} )".format(cmd))
+
         cmd = shlex.split(cmd)
 
         if self.verbose:
             print "Running command: {}".format(str(cmd))
-
-        if self.logger:
-            self.logger.debug("Running command: {}".format(str(cmd)))
 
         return subprocess.check_output(cmd)
 

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -77,17 +77,26 @@ class OCUtil(object):
         if self.verbose:
             print "Running command: {}".format(str(cmd))
 
-        results = subprocess.check_output(cmd)
+        return subprocess.check_output(cmd)
 
-        try:
-            return yaml.safe_load(results)
-        except:
-            return results
-
-    def _run_cmd_yaml(self, cmd, baseCmd='oc', yamlCmd='-o yaml'):
-        return self._run_cmd(
+    def _run_cmd_yaml(self, cmd, baseCmd='oc', yamlCmd='-o yaml', ):
+        return yaml.safe_load(self._run_cmd(
             " ".join([cmd, yamlCmd]),
             baseCmd=baseCmd,
+        ))
+    def run_user_cmd(self, cmd, baseCmd='oc', ):
+        ''' Runs a custom user command '''
+        return self._run_cmd(
+            cmd,
+            baseCmd=baseCmd,
+        )
+
+    def run_user_cmd_yaml(self, cmd, baseCmd='oc', yamlCmd='-o yaml', ):
+        ''' Runs a custom user command and expects yaml '''
+        return self._run_cmd_yaml(
+            cmd,
+            baseCmd=baseCmd,
+            yamlCmd=yamlCmd,
         )
 
     def get_secrets(self, name):
@@ -149,9 +158,3 @@ class OCUtil(object):
         log_results = self._run_cmd(log_cmd)
 
         return log_results
-
-    def run_user_cmd(self, command):
-        ''' Runs a custom user command '''
-
-        user_results = self._run_cmd(command)
-        return user_results

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -82,6 +82,12 @@ class OCUtil(object):
         except:
             return results
 
+    def _run_cmd_yaml(self, cmd, baseCmd='oc', yamlCmd='-o yaml'):
+        return self._run_cmd(
+            " ".join([cmd, yamlCmd]),
+            baseCmd=baseCmd,
+        )
+
     def get_secrets(self, name):
         ''' Get secrets from object 'name' '''
 

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -55,8 +55,10 @@ class OCUtil(object):
     def copy_kubeconfig(self):
         ''' make a copy of the kubeconfig '''
 
-        file_name = os.path.join('/tmp',
-                                 ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(7)))
+        file_name = os.path.join(
+            '/tmp',
+            ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(7))
+        )
         shutil.copy(self.config_file, file_name)
         atexit.register(cleanup_file, file_name)
 

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -62,10 +62,15 @@ class OCUtil(object):
 
         self.config_file = file_name
 
-    def _run_cmd(self, cmd):
+    def _run_cmd(self, cmd, baseCmd='oc', ):
         ''' Actually execute the command '''
 
-        cmd = 'oc --config ' + self.config_file + ' -n ' + self.namespace + ' ' + cmd
+        cmd = " ".join([
+            baseCmd,
+            '--config', self.config_file,
+            '-n', self.namespace,
+            cmd,
+        ])
         cmd = shlex.split(cmd)
         if self.verbose:
             print "Running command: {}".format(str(cmd))

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -93,7 +93,6 @@ class OCUtil(object):
     def get_secrets(self, name):
         ''' Get secrets from object 'name' '''
 
-
         secrets_cmd = "get secrets {} -o yaml".format(name)
         secrets_yaml = self._run_cmd(secrets_cmd)
 
@@ -145,11 +144,7 @@ class OCUtil(object):
 
     def get_nodes(self):
         ''' Get all the nodes in the cluster '''
-
-        nodes_cmd = "get nodes -o yaml"
-        nodes_yaml = self._run_cmd(nodes_cmd)
-
-        return nodes_yaml
+        return self._run_cmd_yaml("get nodes")
 
     def get_log(self, name):
         ''' Gets the log for the specified container '''

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -91,6 +91,7 @@ class OCUtil(object):
             raise e
 
     def _run_cmd_yaml(self, cmd, baseCmd='oc', yamlCmd='-o yaml', ):
+        ''' Actually execute the command and expects yaml '''
         return yaml.safe_load(self._run_cmd(
             " ".join([cmd, yamlCmd]),
             baseCmd=baseCmd,

--- a/openshift_tools/monitoring/ocutil.py
+++ b/openshift_tools/monitoring/ocutil.py
@@ -42,7 +42,8 @@ def cleanup_file(inc_file):
 class OCUtil(object):
     ''' Wrapper for interfacing with OpenShift 'oc' utility '''
 
-    def __init__(self, namespace='default', config_file='/tmp/admin.kubeconfig', verbose=False):
+    def __init__(self, namespace='default', config_file='/tmp/admin.kubeconfig',
+                 verbose=False, logger=None):
         '''
         Take initial values for running 'oc'
         Ensure to set non-default namespace if that is what is desired
@@ -51,6 +52,7 @@ class OCUtil(object):
         self.config_file = config_file
         self.verbose = verbose
         self.copy_kubeconfig()
+        self.logger = logger
 
     def copy_kubeconfig(self):
         ''' make a copy of the kubeconfig '''
@@ -66,7 +68,6 @@ class OCUtil(object):
 
     def _run_cmd(self, cmd, baseCmd='oc', ):
         ''' Actually execute the command '''
-
         cmd = " ".join([
             baseCmd,
             '--config', self.config_file,
@@ -74,8 +75,12 @@ class OCUtil(object):
             cmd,
         ])
         cmd = shlex.split(cmd)
+
         if self.verbose:
             print "Running command: {}".format(str(cmd))
+
+        if self.logger:
+            self.logger.debug("Running command: {}".format(str(cmd)))
 
         return subprocess.check_output(cmd)
 


### PR DESCRIPTION
+1 from @BlueShells on https://github.com/openshift/openshift-tools/pull/1442
# 
- removing code duplication and excess variables
- forcing yaml when yaml is requested, try/except removed allowing errors to show
- not using yaml on _run_cmd by default
- replaced string concat with array join to simplify spaces
- space for logging module (if logger: logger.debug())
- baseCmd to allow different commands to be used (oc, oadm)
- pylint

Tested on ops cluster by injecting the ocutil class and testing all functions with a simple script to run all commands.
