### PR TITLE
enable extras repo in ops-base

### DIFF
--- a/docker/oso-ops-base/rhel7/Dockerfile
+++ b/docker/oso-ops-base/rhel7/Dockerfile
@@ -15,6 +15,8 @@ RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
 # setup yum repos
 ADD setup-yum.sh /usr/local/bin/setup-yum.sh
 RUN /usr/local/bin/setup-yum.sh
+RUN yum repolist --disablerepo=* && \
+    yum-config-manager --enable rhel-7-server-extras-rpms
 
 # creature comforts (make it feel like a normal linux environment)
 ENV LANG en_US.UTF-8

--- a/docker/oso-ops-base/src/Dockerfile.j2
+++ b/docker/oso-ops-base/src/Dockerfile.j2
@@ -12,6 +12,8 @@ RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
 # setup yum repos
 ADD setup-yum.sh /usr/local/bin/setup-yum.sh
 RUN /usr/local/bin/setup-yum.sh
+RUN yum repolist --disablerepo=* && \
+    yum-config-manager --enable rhel-7-server-extras-rpms
 {% elif base_os == "centos7" %}
 
 ADD copr-openshift-tools.repo /etc/yum.repos.d/


### PR DESCRIPTION
just because the host has a repo enabled, doesn't mean the container has it enabled. so explicitly enable it during build.