### PR TITLE
app create v2

### DIFF
--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -9,28 +9,25 @@
 # main() function has a lot of setup and error handling
 # pylint: disable=too-many-statements
 
+# main() function raises a captured exception if there is one
+# pylint: disable=raising-bad-type
+
 # Adding the ignore because it does not like the naming of the script
 # to be different than the class name
 # pylint: disable=invalid-name
 
-import subprocess
-import json
-import time
-import re
-import urllib2
-import os
-import atexit
-import shutil
-import string
-import random
 import argparse
 import datetime
-import sys
+import random
+import string
+import time
+import urllib2
 
 # Our jenkins server does not include these rpms.
 # In the future we might move this to a container where these
 # libs might exist
 #pylint: disable=import-error
+from openshift_tools.monitoring.ocutil import OCUtil
 from openshift_tools.monitoring.zagg_sender import ZaggSender
 
 import logging
@@ -40,202 +37,19 @@ logging.basicConfig(
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-# pylint: disable=bare-except
-def cleanup_file(inc_file):
-    """ clean up """
-    try:
-        os.unlink(inc_file)
-    except:
-        pass
+ocutil = OCUtil()
 
-def copy_kubeconfig(config):
-    """ make a copy of the kubeconfig """
-    file_name = os.path.join('/tmp', ''.join(
-        random.choice(string.ascii_uppercase + string.digits) for _ in range(7)
-    ))
-    shutil.copy(config, file_name)
-    atexit.register(cleanup_file, file_name)
+commandDelay = 5 # seconds
 
-    return file_name
+def runOCcmd(cmd):
+    """ log commands through ocutil """
+    logger.info("oc " + cmd)
+    return ocutil.run_user_cmd(cmd)
 
-class OpenShiftOC(object):
-    """ Class to wrap the oc command line tools """
-    def __init__(self, namespace, kubeconfig, args, verbose=False):
-        """ Constructor for OpenShiftOC """
-        self.namespace = namespace
-        # used to delete the project ES index
-        self.run_date = datetime.datetime.now().strftime("%Y.%m.%d")
-        self.verbose = verbose
-        self.kubeconfig = kubeconfig
-        self.args = args
-
-    def get_pod(self):
-        """return a pod by name"""
-        pods = self.get_pods()
-        podname = pod_name(self.args.name)
-        # this will match on build pods but not deploy pods
-        regex = re.compile('%s-[0-9]-[a-z0-9]{5}$' % podname)
-        for pod in pods['items']:
-            results = regex.search(pod['metadata']['name'])
-            if results:
-                # only report on running build pods, we'll wait if build pod is pending
-                if "build" in pod['metadata']['name'] and pod['status']['phase'] != 'Running':
-                    continue
-                else: return pod
-
-    def get_pods(self):
-        """return all pods """
-        cmd = ['get', 'pods', '--no-headers', '-o', 'json', '-n', self.namespace]
-        results = self.oc_cmd(cmd)
-
-        return json.loads(results)
-
-    def new_app(self, path):
-        """run new-app """
-        cmd = ['new-app', path, '-n', self.namespace]
-        return self.oc_cmd(cmd)
-
-    def delete_project(self):
-        """delete project """
-        cmd = ['delete', 'project', self.namespace]
-        results = self.oc_cmd(cmd)
-        time.sleep(5)
-        return results
-
-    def new_project(self):
-        """create new project """
-        version = self.get_version()
-        cmd = ['new-project', self.namespace]
-        if "v3.2" in version:  ## remove this after BZ1333049 resolved in OSE
-            rval = self.oadm_cmd(cmd)
-        else:
-            rval = self.oc_cmd(cmd)
-        return rval
-
-    def get_logs(self):
-        """get all pod logs"""
-        pods = self.get_pods()
-        result = ""
-        for pod in pods['items']:
-            result = result + self.oc_cmd(['logs', pod['metadata']['name'], '-n', self.namespace])
-
-        if result == "":
-            return 'Could not get logs for pod.  Could not determine pod name.'
-
-        return result
-
-    def get_route(self):
-        """get route to check if app is running"""
-        cmd = ['get', 'route', '--no-headers', '-o', 'json', '-n', self.namespace]
-        results = self.oc_cmd(cmd)
-        return json.loads(results)
-
-    def get_service(self):
-        """get service to check if app is running"""
-        return json.loads(self.oc_cmd(
-            ['get', 'service', '--no-headers', '-n', self.namespace, '-o', 'json']
-        ))
-
-    def get_events(self):
-        """get all events"""
-        return self.oc_cmd(['get', 'events', '-n', self.namespace])
-
-
-    def get_projects(self):
-        """get all projects """
-        cmd = ['get', 'projects', '--no-headers']
-        results = [
-            proj.split()[0] for proj in self.oc_cmd(cmd).split('\n') if proj and len(proj) > 0
-        ]
-
-        return results
-
-    def get_version(self):
-        """get openshift version"""
-        return self.oc_cmd(['version'])
-
-    def oc_cmd(self, cmd):
-        """Base command for oc """
-        cmds = ['/usr/bin/oc']
-        cmds.extend(cmd)
-        logger.debug(' '.join(cmds))
-        proc = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE, \
-                                env={'KUBECONFIG': self.kubeconfig, \
-                                     'PATH': os.environ["PATH"]})
-        stdout, stderr = proc.communicate()
-        if proc.returncode == 0:
-            if self.verbose:
-                logger.debug("Stdout:")
-                logger.debug(stdout)
-                logger.debug("Stderr:")
-                logger.debug(stderr)
-            return stdout
-
-        return "Error: %s.  Return: %s" % (proc.returncode, stderr)
-
-    def oadm_cmd(self, cmd):
-        """Base command for oadm """
-        cmds = ['/usr/bin/oadm']
-        cmds.extend(cmd)
-        logger.debug(' '.join(cmds))
-        proc = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE, \
-                                env={'KUBECONFIG': self.kubeconfig, \
-                                     'PATH': os.environ["PATH"]})
-        stdout, stderr = proc.communicate()
-        if proc.returncode == 0:
-            if self.verbose:
-                logger.debug("Stdout:")
-                logger.debug(stdout)
-                logger.debug("Stderr:")
-                logger.debug(stderr)
-            return stdout
-
-        return "Error: %s.  Return: %s" % (proc.returncode, stderr)
-
-    def delete_es_index(self):
-        """ delete elasticsearch index """
-        # find project uuid
-        get_project_uid_cmd = ['get', 'project', '-o', 'json', self.namespace]
-        project = json.loads(self.oc_cmd(get_project_uid_cmd))
-        if project:
-            project_uid = project['metadata']['uid']
-        else:
-            logger.error("Failed finding project uid!")
-            return 0
-        # find logging pod
-        get_log_pods_cmd = ['get', 'pods', '-o', 'json', '-n', 'logging']
-        pods = json.loads(self.oc_cmd(get_log_pods_cmd))
-        regex = re.compile('logging-es-*')
-        for pod in pods['items']:
-            pod_found = regex.search(pod['metadata']['name'])
-            if pod_found:
-                project_es_uuid = self.namespace + "." + project_uid + "." + self.run_date
-                curl_cmd = ['curl', '-X', 'DELETE', \
-                    '--key', '/etc/elasticsearch/keys/admin-key', \
-                    '--cert', '/etc/elasticsearch/keys/admin-cert', \
-                    '--cacert', '/etc/elasticsearch/keys/admin-ca', \
-                    'https://localhost:9200/' + project_es_uuid]
-                delete_cmd = ['exec', pod['metadata']['name'], '-n', 'logging', '--'] + curl_cmd
-                delete_results = self.oc_cmd(delete_cmd)
-                if self.verbose:
-                    logger.debug(delete_results)
-                return delete_results
-        logger.error("Failed finding logging pod")
-        return 0
-
-def curl(ip_addr, port, timeout=30):
-    """ Open an http connection to the url and read """
-    url = 'http://%s:%s' % (ip_addr, port)
-    logger.debug("curl(%s timeout=%ss)", url, timeout)
-
-    code = 0
-    try:
-        code = urllib2.urlopen(url, timeout=timeout).getcode()
-    except urllib2.HTTPError, e:
-        code = e.fp.getcode()
-    except Exception as e:
-        logger.exception("Unknown error")
-    return code
+def runOCcmd_yaml(cmd):
+    """ log commands through ocutil """
+    logger.info("oc " + cmd)
+    return ocutil.run_user_cmd_yaml(cmd)
 
 def parse_args():
     """ parse the args from the cli """
@@ -243,25 +57,12 @@ def parse_args():
 
     parser = argparse.ArgumentParser(description='OpenShift app create end-to-end test')
     parser.add_argument('-v', '--verbose', action='store_true', default=None, help='Verbose?')
-    parser.add_argument('--name', default="openshift/hello-openshift:v1.0.6", help='app template')
-    parser.add_argument('--namespace', default="default", help='additional text for namespace')
+    parser.add_argument('--source', default="openshift/hello-openshift:v1.0.6",
+                        help='source application to use')
+    parser.add_argument('--basename', default="test", help='base name, added to via openshift')
+    parser.add_argument('--namespace', default="ops-health-monitoring",
+                        help='namespace (be careful of using existing namespaces)')
     return parser.parse_args()
-
-def pod_name(name):
-    """ strip pre/suffices from app name to get pod name """
-    logger.debug("pod_name()")
-
-    # for app deploy "https://github.com/openshift/hello-openshift:latest",
-    # pod name is hello-openshift
-    if 'http' in name:
-        name = name.rsplit('/')[-1]
-    if 'git' in name:
-        name = name.replace('.git', '')
-    if '/' in name:
-        name = name.split('/')[1]
-    if ':' in name:
-        name = name.split(':')[0]
-    return name
 
 def send_zagg_data(build_ran, create_app, http_code, run_time):
     """ send data to Zagg"""
@@ -280,11 +81,22 @@ def send_zagg_data(build_ran, create_app, http_code, run_time):
         zgs.add_zabbix_keys({'openshift.master.app.create.code': http_code})
         zgs.add_zabbix_keys({'openshift.master.app.create.time': run_time})
 
+    zgs.send_metrics()
+    logger.info("Data sent to Zagg in %s seconds", str(time.time() - zgs_time))
+
+def curl(ip_addr, port, timeout=30):
+    """ Open an http connection to the url and read """
+    url = 'http://%s:%s' % (ip_addr, port)
+    logger.debug("curl(%s timeout=%ss)", url, timeout)
+
     try:
-        zgs.send_metrics()
-        logger.info("Data sent to Zagg in %s seconds", str(time.time() - zgs_time))
-    except:
-        logger.error("Error sending data to Zagg: %s \n %s ", sys.exc_info()[0], sys.exc_info()[1])
+        return urllib2.urlopen(url, timeout=timeout).getcode()
+    except urllib2.HTTPError, e:
+        return e.fp.getcode()
+    except Exception as e:
+        logger.exception("Unknown error")
+
+    return 0
 
 def getPodStatus(pod):
     """ get pod status for display """
@@ -297,31 +109,56 @@ def getPodStatus(pod):
 
     return "%s %s" % (pod['metadata']['name'], pod['status']['phase'])
 
-def setup(config, oocmd=None,):
+def getPod(name):
+    """ get Pod from all possible pods """
+    pods = ocutil.get_pods()
+    for pod in pods['items']:
+        if pod and pod['metadata']['name'] and pod['metadata']['name'].startswith(name):
+            # only report on running build pods, we'll wait if build pod is pending
+            if pod['metadata']['name'].endswith("build") and pod['status']['phase'] != 'Running':
+                continue
+            else:
+                return pod
+
+def setup(config):
     """ global setup for tests """
     logger.info('setup()')
-    oocmd.delete_project()
-    time.sleep(5)
-    oocmd.new_project()
-    time.sleep(5)
+    logger.debug(config)
 
-    return config
+    project = None
 
-def test(config, oocmd=None,):
+    try:
+        project = runOCcmd_yaml("get project {}".format(config.namespace))
+        logger.debug(project)
+    except Exception:
+        pass # don't want exception if project not found
+
+    if not project:
+        try:
+            runOCcmd("new-project {}".format(config.namespace))
+            time.sleep(commandDelay)
+        except Exception:
+            logger.exception('error creating new project')
+
+    runOCcmd("new-app {} --name={} -n {}".format(
+        config.source,
+        config.podname,
+        config.namespace,
+    ))
+
+def test(config):
     """ run tests """
     logger.info('test()')
-
-    oocmd.new_app(config['applicationName'])
+    logger.debug(config)
 
     build_ran = 0
     pod = None
     lastKnownPod = None
     http_code = 0
 
-    # Now we wait until the pod comes up
     for loopCount in range(120):
-        time.sleep(5)
-        pod = oocmd.get_pod()
+        time.sleep(commandDelay)
+        pod = getPod(config.podname)
 
         if not pod:
             if not lastKnownPod and loopCount > 6:
@@ -339,26 +176,35 @@ def test(config, oocmd=None,):
 
         logger.info(getPodStatus(pod))
 
-        if pod['status'] and "build" in pod['metadata']['name']:
+        if pod['status']['phase']:
+            if pod['status']['phase'] == "Failed":
+                logger.error("Error with pod")
+                break
+
+        if pod['status'] and pod['metadata']['name'].endswith("build"):
             build_ran = 1
 
         if pod['status']['phase'] == 'Running' \
             and pod['status'].has_key('podIP') \
-            and not "build" in pod['metadata']['name']:
+            and not pod['metadata']['name'].endswith("build"):
 
+            # attempt retries
             for curlCount in range(10):
                 # introduce small delay to give time for route to establish
-                time.sleep(2)
+                time.sleep(commandDelay)
 
-                # test pods http capability
-                route = oocmd.get_route()
-                if route['items']:
-                    # FIXME: no port in the route object, is 80 a safe assumption?
-                    http_code = curl(route['items'][0]['spec']['host'], 80)
-                else:
-                    service = oocmd.get_service()
-                    http_code = curl(service['items'][0]['spec']['clusterIP'], \
-                        service['items'][0]['spec']['ports'][0]['port'])
+                service = ocutil.get_service(config.podname)
+
+                if service:
+                    logger.debug("service")
+                    logger.debug(service)
+
+                    http_code = curl(
+                        service['spec']['clusterIP'],
+                        service['spec']['ports'][0]['port']
+                    )
+
+                    logger.debug("http code %s", http_code)
 
                 if http_code == 200:
                     logger.debug("curl completed in %d tries", curlCount)
@@ -380,25 +226,21 @@ def test(config, oocmd=None,):
         'pod': pod,
     }
 
-
-def teardown(config, oocmd=None,):
+def teardown(config):
     """ clean up after testing """
     logger.info('teardown()')
+    logger.debug(config)
 
-    try:
-        oocmd.delete_es_index()
-    except Exception as e:
-        logger.critical(e)
-        logger.exception('problem with delete_es_index')
+    time.sleep(commandDelay)
 
-    time.sleep(5)
-
-    oocmd.delete_project()
-
-    return config
+    runOCcmd("delete all -l app={} -n {}".format(
+        config.podname,
+        config.namespace,
+    ))
 
 def main():
     """ setup / test / teardown with exceptions to ensure teardown """
+    exception = None
 
     logger.info('################################################################################')
     logger.info('  Starting App Create - %s', datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
@@ -410,34 +252,28 @@ def main():
     if args.verbose:
         logger.setLevel(logging.DEBUG)
 
-    kubeconfig = copy_kubeconfig('/tmp/admin.kubeconfig')
-    namespace = '-'.join([
-        'ops-health',
-        args.namespace,
-        pod_name(args.name),
-        os.environ['ZAGG_CLIENT_HOSTNAME'],
-    ])
+    ocutil.namespace = args.namespace
 
-    oocmd = OpenShiftOC(namespace, kubeconfig, args, verbose=False)
+    args.uid = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(2))
+    args.timestamp = datetime.datetime.utcnow().strftime("%m%d%H%Mz")
+    args.podname = '-'.join([args.basename, args.timestamp, args.uid]).lower()
 
-    config = {
-        'args': args,
-        'namespace': namespace,
-        'applicationName': args.name,
-    }
+    if len(args.podname) > 24:
+        raise ValueError("len(args.podname) cannot exceed 24, currently {}: {}".format(
+            len(args.podname), args.podname
+        ))
 
-    # delete project, make new project
-    setup(config, oocmd=oocmd,)
+    setup(args)
 
     # start time tracking
     start_time = time.time()
 
-    # run tests, collect results
     try:
-        test_response = test(config, oocmd=oocmd,)
+        test_response = test(args)
+        logger.debug(test_response)
     except Exception as e:
-        logger.critical('problem running test')
-        logger.critical(e)
+        logger.exception("error during test()")
+        exception = e
         test_response = {
             'build_ran': 0,
             'create_app': 1, # app create failed
@@ -445,12 +281,9 @@ def main():
             'failed': True,
             'pod': None,
         }
-    logger.debug("test_response")
-    logger.debug(test_response)
 
     # finish time tracking
     run_time = str(time.time() - start_time)
-
     logger.info('Test finished. Time to complete test only: %s', run_time)
 
     # send data to zabbix
@@ -462,33 +295,32 @@ def main():
             run_time
         )
     except Exception as e:
-        logger.critical('problem sending zabbix data')
-        logger.critical(e)
+        logger.exception("error sending zabbix data")
+        exception = e
 
     if test_response['failed']:
         try:
-            oocmd.verbose = True
+            ocutil.verbose = True
             logger.setLevel(logging.DEBUG)
             logger.critical('Deploy State: Fail')
-            logger.info('Fetching Events:')
-            logger.info(oocmd.get_events())
-            logger.info('Fetching Logs:')
-            logger.info(oocmd.get_logs())
             logger.info('Fetching Pod:')
             logger.info(test_response['pod'])
+            logger.info('Fetching Events:')
+            logger.info(runOCcmd('get events'))
+            if test_response['pod']:
+                logger.info('Fetching Logs:')
+                logger.info(ocutil.get_log(test_response['pod']['metadata']['name']))
         except Exception as e:
-            logger.critical('problem fetching additional error data')
-            logger.critical(e)
+            logger.exception("problem fetching additional error data")
+            exception = e
     else:
         logger.info('Deploy State: Success')
         logger.info('Service HTTP response code: %s', test_response['http_code'])
 
-    # cleanup project
-    try:
-        teardown(config, oocmd=oocmd,)
-    except Exception as e:
-        logger.critical('problem cleaning up project')
-        logger.critical(e)
+    teardown(args)
+
+    if exception:
+        raise exception
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
+1 from @dak1n1 on https://github.com/openshift/openshift-tools/pull/1575

Also discussed on mailing list.

=====

* use same project - unique podname
* use ocutil instead of custom oc wrapper
* exception management to allow teardown

Hoping to get a few comments and +1's here .. Its a big change! 

There is still a lot I want to do, but this should easily replace the existing code.

Need to be considerate with deployment, as the arguments have changed we need to sync this with config loop.

Yes it has been tested.

=====
 * we don't ever use routes in the tests
 * import cleanup
 * use ocutil instead of custom internal class
 * new command line arguments and defaults
 * pod_name no longer used
 * curl tidied
 * exception management
 * setup no longer deletes project
 * test no longer creates an app, thats in setup
 * getPod rebuilt
 * teardown should kill script if error
 * teardown deletes app, not project