### PR TITLE
Get hawkular creds expects to have the deployers pod name

### DIFF
--- a/scripts/monitoring/cron-send-metrics-checks.py
+++ b/scripts/monitoring/cron-send-metrics-checks.py
@@ -217,8 +217,8 @@ class OpenshiftMetricsStatus(object):
 
         self.oc = OCUtil(namespace='openshift-infra', config_file=self.kubeconfig, verbose=self.args.verbose)
 
-        self.get_hawkular_creds()
         pod_report = self.check_pods()
+        self.get_hawkular_creds()
         metrics_report = self.check_node_metrics()
 
         self.report_to_zabbix(pod_report, metrics_report)


### PR DESCRIPTION
The deployer pod name is set in check_pods

Reviewed by @blrm in #1630 