### PR TITLE
Add tags to metric sender

### DIFF
--- a/openshift_tools/monitoring/generic_metric_sender.py
+++ b/openshift_tools/monitoring/generic_metric_sender.py
@@ -44,7 +44,7 @@ class GenericMetricSender(object):
         """ empty implementation overridden by derived classes """
         pass
 
-    def add_metric(self, metric, host=None, synthetic=False):
+    def add_metric(self, metric, host=None, synthetic=False, key_tags=None):
         """ empty implementation overridden by derived classes """
         pass
 

--- a/openshift_tools/monitoring/hawk_client.py
+++ b/openshift_tools/monitoring/hawk_client.py
@@ -85,5 +85,10 @@ class HawkClient(object):
 
             self.client.push(metric_type, key, value, clock)
 
+            # Update tags in Hawkular
+            if metric.tags != {}:
+                self.client.update_metric_tags(metric_type, key, **metric.tags)
+
         status, raw_response = None, None
         return (status, raw_response)
+

--- a/openshift_tools/monitoring/metric_sender.py
+++ b/openshift_tools/monitoring/metric_sender.py
@@ -77,10 +77,10 @@ class MetricSender(GenericMetricSender):
         for sender in self.active_senders:
             sender.add_dynamic_metric(discovery_key, macro_string, macro_array, host, synthetic)
 
-    def add_metric(self, metric, host=None, synthetic=False):
+    def add_metric(self, metric, host=None, synthetic=False, key_tags=None):
         ''' apply add_metric for each sender'''
         for sender in self.active_senders:
-            sender.add_metric(metric, host, synthetic)
+            sender.add_metric(metric, host, synthetic, key_tags)
 
     def add_heartbeat(self, heartbeat, host=None):
         ''' apply add_heartbit for each sender'''

--- a/openshift_tools/monitoring/metricmanager.py
+++ b/openshift_tools/monitoring/metricmanager.py
@@ -66,7 +66,7 @@ class UniqueMetric(zbxsend.Metric):
     #         data easily.
     # Status: permanently disabled.
     # pylint: disable=too-many-arguments
-    def __init__(self, host, key, value, clock=None, unique_id=None):
+    def __init__(self, host, key, value, clock=None, unique_id=None, tags=None):
         ''' Construct object
 
             Keyword arguments:
@@ -75,12 +75,14 @@ class UniqueMetric(zbxsend.Metric):
             value     -- the value that zabbix should put in for the key
             clock     -- the time the metric was taken (default: current time)
             unique_id -- the unique id of this metric (default: generate one)
+            tags      -- metadata tag values hash for key (e.g. {"units":"byte"}
         '''
 
         self.host = host
         self.key = key
         self.value = value
         self.clock = clock
+        self.tags = tags or {}
 
         if self.clock is None:
             self.clock = calendar.timegm(time.gmtime())

--- a/openshift_tools/monitoring/zagg_sender.py
+++ b/openshift_tools/monitoring/zagg_sender.py
@@ -101,7 +101,7 @@ class ZaggSender(GenericMetricSender):
                                                  )
         self.unique_metrics.append(hb_metric)
 
-    def add_metric(self, metrics, host=None, synthetic=False):
+    def add_metric(self, metrics, host=None, synthetic=False, key_tags=None):
         """ create unique metric from zabbix key value pair """
 
         if synthetic and not host:
@@ -112,7 +112,7 @@ class ZaggSender(GenericMetricSender):
         zabbix_metrics = []
 
         for key, value in metrics.iteritems():
-            zabbix_metric = UniqueMetric(host, key, value)
+            zabbix_metric = UniqueMetric(host, key, value, tags=key_tags)
             zabbix_metrics.append(zabbix_metric)
 
         self.unique_metrics += zabbix_metrics

--- a/scripts/monitoring/metric_sender.yaml.example
+++ b/scripts/monitoring/metric_sender.yaml.example
@@ -16,6 +16,13 @@ hawk:
     verbose: False
     debug: False
     ssl_verify: False
+metadata_rules:
+  - regex: .*memory.*
+    tags:
+      units: byte
+  - regex: .*version.*
+    tags:
+      descriptior_name: version
 pcp:
     metrics:
         - kernel.all


### PR DESCRIPTION
Add tags to MetricSender.
Tags can be set using regular expression in metric_sender.yaml or as parameter in add_metric method.

Depends on https://github.com/openshift/openshift-tools/pull/1511