### PR TITLE
Allow OO_PAUSE_ON_{START,BUILD} pauses to be cancelled

### DIFF
--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -10,7 +10,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # PCP
 ##################

--- a/docker/oso-host-monitoring/centos7/start.sh
+++ b/docker/oso-host-monitoring/centos7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -10,7 +10,7 @@ FROM oso-rhel7-ops-base:latest
 
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # PCP
 ##################

--- a/docker/oso-host-monitoring/rhel7/start.sh
+++ b/docker/oso-host-monitoring/rhel7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -6,7 +6,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 {{ generated_header }}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # PCP
 ##################

--- a/docker/oso-host-monitoring/src/start.sh
+++ b/docker/oso-host-monitoring/src/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-memcached-sso/centos7/Dockerfile
+++ b/docker/oso-memcached-sso/centos7/Dockerfile
@@ -3,7 +3,7 @@
 FROM openshifttools/oso-centos7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # Install memcached
 RUN yum -y install memcached && \

--- a/docker/oso-memcached-sso/centos7/start.sh
+++ b/docker/oso-memcached-sso/centos7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-memcached-sso/rhel7/Dockerfile
+++ b/docker/oso-memcached-sso/rhel7/Dockerfile
@@ -3,7 +3,7 @@
 FROM oso-rhel7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # Install memcached
 RUN yum -y install memcached && \

--- a/docker/oso-memcached-sso/rhel7/start.sh
+++ b/docker/oso-memcached-sso/rhel7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-memcached-sso/src/Dockerfile.j2
+++ b/docker/oso-memcached-sso/src/Dockerfile.j2
@@ -7,7 +7,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 {% endif %}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # Install memcached
 RUN yum -y install memcached && \

--- a/docker/oso-memcached-sso/src/start.sh
+++ b/docker/oso-memcached-sso/src/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-ops-base/centos7/Dockerfile
+++ b/docker/oso-ops-base/centos7/Dockerfile
@@ -10,7 +10,7 @@
 FROM centos:centos7
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 
 ADD copr-openshift-tools.repo /etc/yum.repos.d/

--- a/docker/oso-ops-base/rhel7/Dockerfile
+++ b/docker/oso-ops-base/rhel7/Dockerfile
@@ -10,7 +10,7 @@
 FROM rhel7:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # setup yum repos
 ADD setup-yum.sh /usr/local/bin/setup-yum.sh

--- a/docker/oso-ops-base/src/Dockerfile.j2
+++ b/docker/oso-ops-base/src/Dockerfile.j2
@@ -6,7 +6,7 @@ FROM centos:centos7
 {% endif %}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 {% if base_os == "rhel7" %}
 # setup yum repos

--- a/docker/oso-saml-sso/centos7/Dockerfile
+++ b/docker/oso-saml-sso/centos7/Dockerfile
@@ -14,7 +14,7 @@
 FROM openshifttools/oso-centos7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 8443
 

--- a/docker/oso-saml-sso/centos7/start.sh
+++ b/docker/oso-saml-sso/centos7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-saml-sso/rhel7/Dockerfile
+++ b/docker/oso-saml-sso/rhel7/Dockerfile
@@ -14,7 +14,7 @@
 FROM oso-rhel7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 8443
 

--- a/docker/oso-saml-sso/rhel7/start.sh
+++ b/docker/oso-saml-sso/rhel7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-saml-sso/src/Dockerfile.j2
+++ b/docker/oso-saml-sso/src/Dockerfile.j2
@@ -10,7 +10,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 {% endif %}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 8443
 

--- a/docker/oso-saml-sso/src/start.sh
+++ b/docker/oso-saml-sso/src/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zabbix-server/centos7/Dockerfile
+++ b/docker/oso-zabbix-server/centos7/Dockerfile
@@ -15,7 +15,7 @@
 FROM openshifttools/oso-centos7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 10050 10051
 

--- a/docker/oso-zabbix-server/centos7/start.sh
+++ b/docker/oso-zabbix-server/centos7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zabbix-server/rhel7/Dockerfile
+++ b/docker/oso-zabbix-server/rhel7/Dockerfile
@@ -15,7 +15,7 @@
 FROM oso-rhel7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 10050 10051
 

--- a/docker/oso-zabbix-server/rhel7/start.sh
+++ b/docker/oso-zabbix-server/rhel7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zabbix-server/src/Dockerfile.j2
+++ b/docker/oso-zabbix-server/src/Dockerfile.j2
@@ -11,7 +11,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 {% endif %}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 10050 10051
 

--- a/docker/oso-zabbix-server/src/start.sh
+++ b/docker/oso-zabbix-server/src/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zabbix-web/centos7/Dockerfile
+++ b/docker/oso-zabbix-web/centos7/Dockerfile
@@ -15,7 +15,7 @@
 FROM openshifttools/oso-centos7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 8000
 

--- a/docker/oso-zabbix-web/centos7/start.sh
+++ b/docker/oso-zabbix-web/centos7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zabbix-web/rhel7/Dockerfile
+++ b/docker/oso-zabbix-web/rhel7/Dockerfile
@@ -15,7 +15,7 @@
 FROM oso-rhel7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 8000
 

--- a/docker/oso-zabbix-web/rhel7/start.sh
+++ b/docker/oso-zabbix-web/rhel7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zabbix-web/src/Dockerfile.j2
+++ b/docker/oso-zabbix-web/src/Dockerfile.j2
@@ -11,7 +11,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 {% endif %}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 EXPOSE 8000
 

--- a/docker/oso-zabbix-web/src/start.sh
+++ b/docker/oso-zabbix-web/src/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zagg-web/centos7/Dockerfile
+++ b/docker/oso-zagg-web/centos7/Dockerfile
@@ -15,7 +15,7 @@
 FROM openshifttools/oso-centos7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 RUN yum clean metadata && \
     yum install -y iproute iputils pylint \

--- a/docker/oso-zagg-web/centos7/start.sh
+++ b/docker/oso-zagg-web/centos7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zagg-web/rhel7/Dockerfile
+++ b/docker/oso-zagg-web/rhel7/Dockerfile
@@ -15,7 +15,7 @@
 FROM oso-rhel7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 RUN yum clean metadata && \
     yum install -y iproute iputils pylint \

--- a/docker/oso-zagg-web/rhel7/start.sh
+++ b/docker/oso-zagg-web/rhel7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zagg-web/src/Dockerfile.j2
+++ b/docker/oso-zagg-web/src/Dockerfile.j2
@@ -11,7 +11,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 {% endif %}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 RUN yum clean metadata && \
     yum install -y iproute iputils pylint \

--- a/docker/oso-zagg-web/src/start.sh
+++ b/docker/oso-zagg-web/src/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zaio/centos7/Dockerfile
+++ b/docker/oso-zaio/centos7/Dockerfile
@@ -15,7 +15,7 @@
 FROM openshifttools/oso-centos7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 ADD zabbix.repo /etc/yum.repos.d/
 

--- a/docker/oso-zaio/centos7/start.sh
+++ b/docker/oso-zaio/centos7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zaio/rhel7/Dockerfile
+++ b/docker/oso-zaio/rhel7/Dockerfile
@@ -15,7 +15,7 @@
 FROM oso-rhel7-ops-base:latest
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 ADD zabbix.repo /etc/yum.repos.d/
 

--- a/docker/oso-zaio/rhel7/start.sh
+++ b/docker/oso-zaio/rhel7/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 

--- a/docker/oso-zaio/src/Dockerfile.j2
+++ b/docker/oso-zaio/src/Dockerfile.j2
@@ -11,7 +11,7 @@ FROM openshifttools/oso-centos7-ops-base:latest
 {% endif %}
 
 # Pause indefinitely if asked to do so.
-RUN test "$OO_PAUSE_ON_BUILD" = "true" && while true ; do sleep 10 ; done || :
+RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 ADD zabbix.repo /etc/yum.repos.d/
 

--- a/docker/oso-zaio/src/start.sh
+++ b/docker/oso-zaio/src/start.sh
@@ -6,8 +6,8 @@ if [ "$OO_PAUSE_ON_START" = "true" ] ; then
   echo
   echo "This container's startup has been paused indefinitely because OO_PAUSE_ON_START has been set."
   echo
-  while true ; do
-    sleep 10
+  while sleep 10; do
+    true
   done
 fi
 


### PR DESCRIPTION
With the "sleep 10" becoming the while condition, one can kill the
sleep to cause the container or build to resume.