### PR TITLE
Move generated "secrets" to emptydir volume in SSO app

### DIFF
--- a/ansible/roles/openshift_sso_app/files/openshift_sso_app.yml
+++ b/ansible/roles/openshift_sso_app/files/openshift_sso_app.yml
@@ -310,6 +310,8 @@ objects:
           volumeMounts:
           - mountPath: /secrets
             name: oso-sso-secrets
+          - mountPath: /configdata
+            name: oso-sso-configdata
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
@@ -321,6 +323,12 @@ objects:
         - name: oso-sso-monitoring-secrets
           secret:
             secretName: oso-sso-monitoring-secrets
+        - name: oso-sso-configdata
+          emptyDir:
+            medium: Memory
+        - name: oso-sso-monitoring-configdata
+          emptyDir:
+            medium: Memory
     test: false
     triggers:
     - type: ConfigChange

--- a/docker/oso-saml-sso/centos7/root/config.yml
+++ b/docker/oso-saml-sso/centos7/root/config.yml
@@ -14,20 +14,19 @@
         file: /secrets/authdata.yml
 
   - file:
-      path: "/secrets/{{item}}"
+      path: "/configdata/{{item}}"
       state: directory
       mode: 0700
       owner: user
       group: group
     with_items:
     - ssh
-    - config
     - certs
 
   - name: populate templated config files
     template:
       src: "/root/templates/{{ item }}.j2"
-      dest: "/secrets/config/{{ item }}"
+      dest: "/configdata/{{ item }}"
       owner: user
       group: root
       mode: 0600
@@ -55,7 +54,7 @@
 
   - name: symlink to populated config files
     file:
-      src: "/secrets/config/{{ item.name }}"
+      src: "/configdata/{{ item.name }}"
       dest: "{{ item.path }}{{ item.name }}"
       state: link
     with_items:
@@ -73,7 +72,7 @@
   - name: install authorized_keys file
     copy:
       src: /secrets/authorized-keys
-      dest: /secrets/ssh/authorized_keys
+      dest: /configdata/ssh/authorized_keys
       owner: user
       group: group
       mode: 0600
@@ -81,7 +80,7 @@
   - name: install ssh host keys
     copy:
       content: "{{ item.value }}"
-      dest: "/secrets/ssh/{{ item.key }}"
+      dest: "/configdata/ssh/{{ item.key }}"
       owner: user
       group: root
       mode: 0400
@@ -89,14 +88,14 @@
     with_dict: "{{ saml2_sso_configdata.ssh_keys }}"
 
   - file:
-      src: /secrets/certs
+      src: /configdata/certs
       dest: "{{ saml2_sso_configdata.certdir | dirname }}"
       state: link
 
   - name: install IdP SSL Cert/Key
     copy:
       content: "{{ item.content }}"
-      dest: "/secrets/certs/{{ item.name }}"
+      dest: "/configdata/certs/{{ item.name }}"
       owner: user
       group: root
       mode: 0400

--- a/docker/oso-saml-sso/centos7/root/templates/authsources.php.j2
+++ b/docker/oso-saml-sso/centos7/root/templates/authsources.php.j2
@@ -3,6 +3,6 @@
 $config = array(
     'google' => array(
         'authgoogle:Google',
-        'AuthConfigFile' => '/secrets/config/google_api_client_secrets.json',
+        'AuthConfigFile' => '/configdata/google_api_client_secrets.json',
     ),
 );

--- a/docker/oso-saml-sso/centos7/sshd_config
+++ b/docker/oso-saml-sso/centos7/sshd_config
@@ -25,10 +25,10 @@ ListenAddress 127.0.0.1
 # HostKey for protocol version 1
 #HostKey /var/local/ssh/ssh_host_key
 # HostKeys for protocol version 2
-HostKey /secrets/ssh/ssh_host_rsa_key
-#HostKey /secrets/ssh/ssh_host_dsa_key
-HostKey /secrets/ssh/ssh_host_ecdsa_key
-HostKey /secrets/ssh/ssh_host_ed25519_key
+HostKey /configdata/ssh/ssh_host_rsa_key
+#HostKey /configdata/ssh/ssh_host_dsa_key
+HostKey /configdata/ssh/ssh_host_ecdsa_key
+HostKey /configdata/ssh/ssh_host_ed25519_key
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 1h
@@ -58,14 +58,14 @@ StrictModes no
 #RSAAuthentication yes
 #PubkeyAuthentication yes
 
-AuthorizedKeysFile /secrets/ssh/authorized_keys
+AuthorizedKeysFile /configdata/ssh/authorized_keys
 
 #AuthorizedPrincipalsFile none
 
 #AuthorizedKeysCommand none
 #AuthorizedKeysCommandUser nobody
 
-# For this to work you will also need host keys in /secrets/ssh/ssh_known_hosts
+# For this to work you will also need host keys in /configdata/ssh/ssh_known_hosts
 #RhostsRSAAuthentication no
 # similar for protocol version 2
 #HostbasedAuthentication no

--- a/docker/oso-saml-sso/rhel7/root/config.yml
+++ b/docker/oso-saml-sso/rhel7/root/config.yml
@@ -14,20 +14,19 @@
         file: /secrets/authdata.yml
 
   - file:
-      path: "/secrets/{{item}}"
+      path: "/configdata/{{item}}"
       state: directory
       mode: 0700
       owner: user
       group: group
     with_items:
     - ssh
-    - config
     - certs
 
   - name: populate templated config files
     template:
       src: "/root/templates/{{ item }}.j2"
-      dest: "/secrets/config/{{ item }}"
+      dest: "/configdata/{{ item }}"
       owner: user
       group: root
       mode: 0600
@@ -55,7 +54,7 @@
 
   - name: symlink to populated config files
     file:
-      src: "/secrets/config/{{ item.name }}"
+      src: "/configdata/{{ item.name }}"
       dest: "{{ item.path }}{{ item.name }}"
       state: link
     with_items:
@@ -73,7 +72,7 @@
   - name: install authorized_keys file
     copy:
       src: /secrets/authorized-keys
-      dest: /secrets/ssh/authorized_keys
+      dest: /configdata/ssh/authorized_keys
       owner: user
       group: group
       mode: 0600
@@ -81,7 +80,7 @@
   - name: install ssh host keys
     copy:
       content: "{{ item.value }}"
-      dest: "/secrets/ssh/{{ item.key }}"
+      dest: "/configdata/ssh/{{ item.key }}"
       owner: user
       group: root
       mode: 0400
@@ -89,14 +88,14 @@
     with_dict: "{{ saml2_sso_configdata.ssh_keys }}"
 
   - file:
-      src: /secrets/certs
+      src: /configdata/certs
       dest: "{{ saml2_sso_configdata.certdir | dirname }}"
       state: link
 
   - name: install IdP SSL Cert/Key
     copy:
       content: "{{ item.content }}"
-      dest: "/secrets/certs/{{ item.name }}"
+      dest: "/configdata/certs/{{ item.name }}"
       owner: user
       group: root
       mode: 0400

--- a/docker/oso-saml-sso/rhel7/root/templates/authsources.php.j2
+++ b/docker/oso-saml-sso/rhel7/root/templates/authsources.php.j2
@@ -3,6 +3,6 @@
 $config = array(
     'google' => array(
         'authgoogle:Google',
-        'AuthConfigFile' => '/secrets/config/google_api_client_secrets.json',
+        'AuthConfigFile' => '/configdata/google_api_client_secrets.json',
     ),
 );

--- a/docker/oso-saml-sso/rhel7/sshd_config
+++ b/docker/oso-saml-sso/rhel7/sshd_config
@@ -25,10 +25,10 @@ ListenAddress 127.0.0.1
 # HostKey for protocol version 1
 #HostKey /var/local/ssh/ssh_host_key
 # HostKeys for protocol version 2
-HostKey /secrets/ssh/ssh_host_rsa_key
-#HostKey /secrets/ssh/ssh_host_dsa_key
-HostKey /secrets/ssh/ssh_host_ecdsa_key
-HostKey /secrets/ssh/ssh_host_ed25519_key
+HostKey /configdata/ssh/ssh_host_rsa_key
+#HostKey /configdata/ssh/ssh_host_dsa_key
+HostKey /configdata/ssh/ssh_host_ecdsa_key
+HostKey /configdata/ssh/ssh_host_ed25519_key
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 1h
@@ -58,14 +58,14 @@ StrictModes no
 #RSAAuthentication yes
 #PubkeyAuthentication yes
 
-AuthorizedKeysFile /secrets/ssh/authorized_keys
+AuthorizedKeysFile /configdata/ssh/authorized_keys
 
 #AuthorizedPrincipalsFile none
 
 #AuthorizedKeysCommand none
 #AuthorizedKeysCommandUser nobody
 
-# For this to work you will also need host keys in /secrets/ssh/ssh_known_hosts
+# For this to work you will also need host keys in /configdata/ssh/ssh_known_hosts
 #RhostsRSAAuthentication no
 # similar for protocol version 2
 #HostbasedAuthentication no

--- a/docker/oso-saml-sso/src/root/config.yml
+++ b/docker/oso-saml-sso/src/root/config.yml
@@ -14,20 +14,19 @@
         file: /secrets/authdata.yml
 
   - file:
-      path: "/secrets/{{item}}"
+      path: "/configdata/{{item}}"
       state: directory
       mode: 0700
       owner: user
       group: group
     with_items:
     - ssh
-    - config
     - certs
 
   - name: populate templated config files
     template:
       src: "/root/templates/{{ item }}.j2"
-      dest: "/secrets/config/{{ item }}"
+      dest: "/configdata/{{ item }}"
       owner: user
       group: root
       mode: 0600
@@ -55,7 +54,7 @@
 
   - name: symlink to populated config files
     file:
-      src: "/secrets/config/{{ item.name }}"
+      src: "/configdata/{{ item.name }}"
       dest: "{{ item.path }}{{ item.name }}"
       state: link
     with_items:
@@ -73,7 +72,7 @@
   - name: install authorized_keys file
     copy:
       src: /secrets/authorized-keys
-      dest: /secrets/ssh/authorized_keys
+      dest: /configdata/ssh/authorized_keys
       owner: user
       group: group
       mode: 0600
@@ -81,7 +80,7 @@
   - name: install ssh host keys
     copy:
       content: "{{ item.value }}"
-      dest: "/secrets/ssh/{{ item.key }}"
+      dest: "/configdata/ssh/{{ item.key }}"
       owner: user
       group: root
       mode: 0400
@@ -89,14 +88,14 @@
     with_dict: "{{ saml2_sso_configdata.ssh_keys }}"
 
   - file:
-      src: /secrets/certs
+      src: /configdata/certs
       dest: "{{ saml2_sso_configdata.certdir | dirname }}"
       state: link
 
   - name: install IdP SSL Cert/Key
     copy:
       content: "{{ item.content }}"
-      dest: "/secrets/certs/{{ item.name }}"
+      dest: "/configdata/certs/{{ item.name }}"
       owner: user
       group: root
       mode: 0400

--- a/docker/oso-saml-sso/src/root/templates/authsources.php.j2
+++ b/docker/oso-saml-sso/src/root/templates/authsources.php.j2
@@ -3,6 +3,6 @@
 $config = array(
     'google' => array(
         'authgoogle:Google',
-        'AuthConfigFile' => '/secrets/config/google_api_client_secrets.json',
+        'AuthConfigFile' => '/configdata/google_api_client_secrets.json',
     ),
 );

--- a/docker/oso-saml-sso/src/sshd_config
+++ b/docker/oso-saml-sso/src/sshd_config
@@ -25,10 +25,10 @@ ListenAddress 127.0.0.1
 # HostKey for protocol version 1
 #HostKey /var/local/ssh/ssh_host_key
 # HostKeys for protocol version 2
-HostKey /secrets/ssh/ssh_host_rsa_key
-#HostKey /secrets/ssh/ssh_host_dsa_key
-HostKey /secrets/ssh/ssh_host_ecdsa_key
-HostKey /secrets/ssh/ssh_host_ed25519_key
+HostKey /configdata/ssh/ssh_host_rsa_key
+#HostKey /configdata/ssh/ssh_host_dsa_key
+HostKey /configdata/ssh/ssh_host_ecdsa_key
+HostKey /configdata/ssh/ssh_host_ed25519_key
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 1h
@@ -58,14 +58,14 @@ StrictModes no
 #RSAAuthentication yes
 #PubkeyAuthentication yes
 
-AuthorizedKeysFile /secrets/ssh/authorized_keys
+AuthorizedKeysFile /configdata/ssh/authorized_keys
 
 #AuthorizedPrincipalsFile none
 
 #AuthorizedKeysCommand none
 #AuthorizedKeysCommandUser nobody
 
-# For this to work you will also need host keys in /secrets/ssh/ssh_known_hosts
+# For this to work you will also need host keys in /configdata/ssh/ssh_known_hosts
 #RhostsRSAAuthentication no
 # similar for protocol version 2
 #HostbasedAuthentication no


### PR DESCRIPTION
This is required for the OpenShift 3.2->3.3 upgrade since
the secrets plugin nukes the secrets volume if any changes are made to it