### PR TITLE
Update Tito Website links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ itself.
 Code here may be under heavy development, and none of these scripts are
 officially supported by Red Hat.  Use at your own risk.
 
-The repository layout is designed for use with http://rm-rf.ca/tito/[Tito]
+The repository layout is designed for use with https://github.com/dgoodwin/tito[Tito]
 
 See our https://github.com/openshift/openshift-tools/blob/prod/docs/build.adoc[Build instructions] for more information.
 

--- a/docs/build.adoc
+++ b/docs/build.adoc
@@ -10,7 +10,7 @@ toc::[]
 == Description
 This repository uses tito to make building and tracking revisions easy.
 
-For more information on tito, please see the http://rm-rf.ca/tito[Tito home page]
+For more information on tito, please see the https://github.com/dgoodwin/tito[Tito home page]
 
 == One Time Setup
 To build the python-openshift-tools-* and openshift-tools-* rpms, we use http://rm-rf.ca/tito[Tito]


### PR DESCRIPTION
rm-rf.ca/tito is no longer available,
updated all links to point to Tito Github Repo.