### PR TITLE
Minor fixes to openshift-tools-scripts-iam-tools RPM

### DIFF
--- a/scripts/iam-tools/aws_api_key_manager.py
+++ b/scripts/iam-tools/aws_api_key_manager.py
@@ -10,14 +10,14 @@
  Usage:
 
  For individual accounts:
- aws_api_key_manager.py -p ded-stage-aws -p ded-int-aws -p <some-other-account>
+ aws_api_key_manager -p ded-stage-aws -p ded-int-aws -p <some-other-account>
 
 
  For all accounts found in /etc/openshift_tools/aws_accounts.txt:
- aws_api_key_manager.py --all
+ aws_api_key_manager --all
 
  To manage keys for another user, use the '-u' option:
- aws_api_key_manager.py -u <some-other-user> -p ded-stage-aws
+ aws_api_key_manager -u <some-other-user> -p ded-stage-aws
 """
 
 from __future__ import print_function
@@ -36,7 +36,7 @@ import yaml
 import boto3
 import botocore
 
-import saml_aws_creds
+from openshift_tools import saml_aws_creds
 
 
 class ManageKeys(object):
@@ -150,7 +150,7 @@ class ManageKeys(object):
 
         client.add_user_to_group(GroupName='admin', UserName=user_name)
         print("A new user account was added.\n"
-              "Use change_iam_password.py -p %s to set your password" % aws_account.split(':')[0])
+              "Use change_iam_password -p %s to set your password" % aws_account.split(':')[0])
 
         return True
 

--- a/scripts/iam-tools/delete_iam_account.py
+++ b/scripts/iam-tools/delete_iam_account.py
@@ -8,11 +8,11 @@
  Usage:
 
  For individual accounts:
- delete_iam_account.py -u <user-to-delete> -p ded-stage-aws -p ded-int-aws -p <some-other-account>
+ delete_iam_account -u <user-to-delete> -p ded-stage-aws -p ded-int-aws -p <some-other-account>
 
 
  For all accounts found in /etc/openshift_tools/aws_accounts.txt:
- delete_iam_account.py -u <user-to-delete> --all
+ delete_iam_account -u <user-to-delete> --all
 """
 
 from __future__ import print_function
@@ -26,7 +26,7 @@ import yaml
 import boto3
 import botocore
 
-import saml_aws_creds
+from openshift_tools import saml_aws_creds
 
 
 class DeleteUser(object):

--- a/scripts/iam-tools/saml_aws_creds.py
+++ b/scripts/iam-tools/saml_aws_creds.py
@@ -35,7 +35,7 @@ def get_temp_credentials(metadata_id, idp_host, ssh_args=None):
     Use SAML SSO to get a set of credentials that can be used for API access to an AWS account.
 
     Example:
-      import saml_aws_creds
+      from openshift_tools import saml_aws_creds
       creds = saml_aws_creds.get_temp_credentials(
           metadata_id='urn:amazon:webservices:123456789012',
           idp_host='login.saml.example.com',

--- a/scripts/openshift-tools-scripts.spec
+++ b/scripts/openshift-tools-scripts.spec
@@ -85,12 +85,14 @@ cp -p inventory-clients/openshift_tools.conf.example %{buildroot}/etc/openshift_
 
 # openshift-tools-scripts-iam-tools install
 mkdir -p %{buildroot}/usr/local/bin
-install -m 755 iam-tools/aws_api_key_manager.py %{buildroot}/usr/local/bin
-install -m 755 iam-tools/change_iam_password.py %{buildroot}/usr/local/bin
-install -m 755 iam-tools/delete_iam_account.py %{buildroot}/usr/local/bin
-install -m 755 iam-tools/saml_aws_creds.py %{buildroot}/usr/local/bin
-install -m 755 iam-tools/check_sso_service.py %{buildroot}/usr/local/bin
-install -m 755 iam-tools/check_sso_http_status.py %{buildroot}/usr/local/bin
+install -m 755 iam-tools/aws_api_key_manager.py %{buildroot}/usr/local/bin/aws_api_key_manager
+install -m 755 iam-tools/change_iam_password.py %{buildroot}/usr/local/bin/change_iam_password
+install -m 755 iam-tools/delete_iam_account.py %{buildroot}/usr/local/bin/delete_iam_account
+install -m 755 iam-tools/check_sso_service.py %{buildroot}/usr/local/bin/check_sso_service
+install -m 755 iam-tools/check_sso_http_status.py %{buildroot}/usr/local/bin/check_sso_http_status
+mkdir -p %{buildroot}%{python_sitelib}/openshift_tools
+install -m 755 iam-tools/saml_aws_creds.py %{buildroot}%{python_sitelib}/openshift_tools/
+ln -sf %{python_sitelib}/openshift_tools/saml_aws_creds.py %{buildroot}/usr/local/bin/saml_aws_creds
 
 # ----------------------------------------------------------------------------------
 # openshift-tools-scripts-inventory-clients subpackage
@@ -349,12 +351,13 @@ BuildArch:     noarch
 OpenShift Tools IAM specific scripts
 
 %files iam-tools
-/usr/local/bin/aws_api_key_manager.py
-/usr/local/bin/change_iam_password.py
-/usr/local/bin/delete_iam_account.py
-/usr/local/bin/saml_aws_creds.py
-/usr/local/bin/check_sso_service.py
-/usr/local/bin/check_sso_http_status.py
+/usr/local/bin/aws_api_key_manager
+/usr/local/bin/change_iam_password
+/usr/local/bin/delete_iam_account
+/usr/local/bin/saml_aws_creds
+/usr/local/bin/check_sso_service
+/usr/local/bin/check_sso_http_status
+%{python_sitelib}/openshift_tools/saml_aws_creds*
 
 %changelog
 * Mon Nov 14 2016 Zhiming Zhang <zhizhang@redhat.com> 0.0.173-1


### PR DESCRIPTION
* Hide extensions for scripts installed to /usr/local/bin
* Put python module in python module directory
* When run in container, have check_sso_service.py use ssh key from secrets