### PR TITLE
Fix metrics route and image settings

### DIFF
--- a/ansible/roles/openshift_metrics/tasks/main.yml
+++ b/ansible/roles/openshift_metrics/tasks/main.yml
@@ -73,6 +73,16 @@
   run_once: true
 - debug: var=policyout
 
+- name: Set template path if running kube 1.4 or higher
+  set_fact:
+    metrics_deployer_template: "/usr/share/ansible/openshift-ansible/roles/openshift_hosted_templates/files/v{{ kube_version }}/enterprise/metrics-deployer.yaml"
+  when: "{{ kube_version|float }} >= 1.4"
+
+- name: Set template path if running kube 1.3 or lower
+  set_fact:
+    metrics_deployer_template: "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v{{ kube_version }}/infrastructure-templates/enterprise/metrics-deployer.yaml"
+  when: "{{ kube_version|float }} <= 1.3"
+
 - name: create metrics deployer template
   oc_obj:
     state: present
@@ -80,7 +90,7 @@
     name: metrics-deployer-template
     kind: template
     files:
-    - "/usr/share/ansible/openshift-ansible/roles/openshift_hosted_templates/files/v{{ kube_version }}/enterprise/metrics-deployer.yaml"
+    - "{{ metrics_deployer_template }}"
   register: templateout
   run_once: true
 

--- a/ansible/roles/openshift_metrics/tasks/main.yml
+++ b/ansible/roles/openshift_metrics/tasks/main.yml
@@ -73,16 +73,6 @@
   run_once: true
 - debug: var=policyout
 
-- name: Set template path if running kube 1.4 or higher
-  set_fact:
-    metrics_deployer_template: "/usr/share/ansible/openshift-ansible/roles/openshift_hosted_templates/files/v{{ kube_version }}/enterprise/metrics-deployer.yaml"
-  when: "{{ kube_version|float }} >= 1.4"
-
-- name: Set template path if running kube 1.3 or lower
-  set_fact:
-    metrics_deployer_template: "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v{{ kube_version }}/infrastructure-templates/enterprise/metrics-deployer.yaml"
-  when: "{{ kube_version|float }} <= 1.3"
-
 - name: create metrics deployer template
   oc_obj:
     state: present
@@ -90,7 +80,7 @@
     name: metrics-deployer-template
     kind: template
     files:
-    - "{{ metrics_deployer_template }}"
+    - "/usr/share/ansible/openshift-ansible/roles/openshift_hosted_templates/files/v{{ kube_version }}/enterprise/metrics-deployer.yaml"
   register: templateout
   run_once: true
 

--- a/ansible/roles/openshift_metrics/tasks/main.yml
+++ b/ansible/roles/openshift_metrics/tasks/main.yml
@@ -80,7 +80,7 @@
     name: metrics-deployer-template
     kind: template
     files:
-    - "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v{{ kube_version }}/infrastructure-templates/enterprise/metrics-deployer.yaml"
+    - "/usr/share/ansible/openshift-ansible/roles/openshift_hosted_templates/files/v{{ kube_version }}/enterprise/metrics-deployer.yaml"
   register: templateout
   run_once: true
 
@@ -93,6 +93,7 @@
       HAWKULAR_METRICS_HOSTNAME: "metrics.{{ osamet_clusterid }}.openshift.com"
       CASSANDRA_PV_SIZE: "{{ osamet_pv_size }}"
       CASSANDRA_NODES: "{{ osamet_cassandra_node }}"
+      IMAGE_PREFIX: registry.ops.openshift.com/openshift3/
     reconcile: False
   register: processout
   run_once: true
@@ -218,7 +219,7 @@
     namespace: openshift-infra
     cert_path: "/etc/origin/master/named_certificates/{{ cert_basename }}"
     key_path: "/etc/origin/master/named_certificates/{{ key_basename }}"
-    cacert_path: /etc/origin/master/ca.crt
+    cacert_path: "/etc/origin/master/named_certificates/{{ cacert_basename }}"
     dest_cacert_content: "{{ hawkout.results.decoded['hawkular-metrics-ca.certificate'] }}"
     service_name: hawkular-metrics
     host: "metrics.{{ osamet_clusterid }}.openshift.com"


### PR DESCRIPTION
Use the proper CA cert instead of master's self-signed cert.
Updated path to template.
Use registry.ops for metrics image.