### PR TITLE
Change cloud scripts to use MetricSender instead of ZaggSender

### DIFF
--- a/scripts/cloud/aws/ops-ec2-snapshot-ebs-volumes.py
+++ b/scripts/cloud/aws/ops-ec2-snapshot-ebs-volumes.py
@@ -26,7 +26,7 @@ import argparse
 # Reason: disable pylint import-error because our libs aren't loaded on jenkins.
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
-from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.metric_sender import MetricSender
 from openshift_tools.cloud.aws import ebs_snapshotter
 
 
@@ -109,28 +109,28 @@ class SnapshotterCli(object):
 
     def report_to_zabbix(self, total_snapshottable_vols, total_snapshots_created, total_snapshot_creation_errors):
         """ Sends the commands exit code to zabbix. """
-        zs = ZaggSender(verbose=True)
+        mts = MetricSender(verbose=True)
 
 
         # Populate EBS_SNAPSHOTTER_DISC_SCHEDULE_MACRO with the schedule
-        zs.add_zabbix_dynamic_item(EBS_SNAPSHOTTER_DISC_KEY, EBS_SNAPSHOTTER_DISC_SCHEDULE_MACRO, \
+        mts.add_dynamic_metric(EBS_SNAPSHOTTER_DISC_KEY, EBS_SNAPSHOTTER_DISC_SCHEDULE_MACRO, \
                                    [self.args.with_schedule])
 
         # Send total_snapshottable_vols prototype item key and value
-        zs.add_zabbix_keys({'%s[%s]' % (EBS_SNAPSHOTTER_SNAPSHOTTABLE_VOLUMES_KEY, self.args.with_schedule): \
+        mts.add_metric({'%s[%s]' % (EBS_SNAPSHOTTER_SNAPSHOTTABLE_VOLUMES_KEY, self.args.with_schedule): \
                            total_snapshottable_vols})
 
         # Send total_snapshots_created prototype item key and value
-        zs.add_zabbix_keys({'%s[%s]' % (EBS_SNAPSHOTTER_SNAPSHOTS_CREATED_KEY, self.args.with_schedule): \
+        mts.add_metric({'%s[%s]' % (EBS_SNAPSHOTTER_SNAPSHOTS_CREATED_KEY, self.args.with_schedule): \
                            total_snapshots_created})
 
         # Send total_snapshot_creation_errors prototype item key and value
-        zs.add_zabbix_keys({'%s[%s]' % (EBS_SNAPSHOTTER_SNAPSHOT_CREATION_ERRORS_KEY, self.args.with_schedule): \
+        mts.add_metric({'%s[%s]' % (EBS_SNAPSHOTTER_SNAPSHOT_CREATION_ERRORS_KEY, self.args.with_schedule): \
                            total_snapshot_creation_errors})
 
 
         # Actually send them
-        zs.send_metrics()
+        mts.send_metrics()
 
 
 if __name__ == "__main__":

--- a/scripts/cloud/aws/ops-ec2-trim-ebs-snapshots.py
+++ b/scripts/cloud/aws/ops-ec2-trim-ebs-snapshots.py
@@ -18,7 +18,7 @@
 
 """
 # Ignoring module name
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,import-error
 
 import os
 import argparse
@@ -27,7 +27,7 @@ from openshift_tools.cloud.aws import ebs_snapshotter
 # Reason: disable pylint import-error because our libs aren't loaded on jenkins.
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
-from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.metric_sender import MetricSender
 
 EXPIRED_SNAPSHOTS_KEY = 'aws.ebs.snapshotter.expired_snapshots'
 DELETED_SNAPSHOTS_KEY = 'aws.ebs.snapshotter.deleted_snapshots'
@@ -110,15 +110,15 @@ class TrimmerCli(object):
     @staticmethod
     def report_to_zabbix(total_expired_snapshots, total_deleted_snapshots, total_deletion_errors):
         """ Sends the commands exit code to zabbix. """
-        zs = ZaggSender(verbose=True)
+        mts = MetricSender(verbose=True)
 
-        zs.add_zabbix_keys({
+        mts.add_metric({
             EXPIRED_SNAPSHOTS_KEY: total_expired_snapshots,
             DELETED_SNAPSHOTS_KEY: total_deleted_snapshots,
             DELETION_ERRORS_KEY: total_deletion_errors
         })
 
-        zs.send_metrics()
+        mts.send_metrics()
 
 if __name__ == "__main__":
     TrimmerCli().main()

--- a/scripts/cloud/gcp/ops-gcp-snapshot-pd-volumes.py
+++ b/scripts/cloud/gcp/ops-gcp-snapshot-pd-volumes.py
@@ -24,7 +24,7 @@ from openshift_tools.cloud.gcp import gcp_snapshotter
 # Reason: disable pylint import-error because our libs aren't loaded on jenkins.
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
-from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.metric_sender import MetricSender
 
 
 PD_SNAPSHOTTER_DISC_KEY = 'disc.gcp.pd.snapshotter'
@@ -102,28 +102,28 @@ class SnapshotterCli(object):
 
     def report_to_zabbix(self, total_snapshottable_vols, total_snapshots_created, total_snapshot_creation_errors):
         """ Sends the commands exit code to zabbix. """
-        zs = ZaggSender(verbose=True)
+        mts = MetricSender(verbose=True)
 
 
         # Populate PD_SNAPSHOTTER_DISC_SCHEDULE_MACRO with the schedule
-        zs.add_zabbix_dynamic_item(PD_SNAPSHOTTER_DISC_KEY, PD_SNAPSHOTTER_DISC_SCHEDULE_MACRO, \
+        mts.add_dynamic_metric(PD_SNAPSHOTTER_DISC_KEY, PD_SNAPSHOTTER_DISC_SCHEDULE_MACRO, \
                                    [self.args.with_schedule])
 
         # Send total_snapshottable_vols prototype item key and value
-        zs.add_zabbix_keys({'%s[%s]' % (PD_SNAPSHOTTER_SNAPSHOTTABLE_VOLUMES_KEY, self.args.with_schedule): \
+        mts.add_metric({'%s[%s]' % (PD_SNAPSHOTTER_SNAPSHOTTABLE_VOLUMES_KEY, self.args.with_schedule): \
                            total_snapshottable_vols})
 
         # Send total_snapshots_created prototype item key and value
-        zs.add_zabbix_keys({'%s[%s]' % (PD_SNAPSHOTTER_SNAPSHOTS_CREATED_KEY, self.args.with_schedule): \
+        mts.add_metric({'%s[%s]' % (PD_SNAPSHOTTER_SNAPSHOTS_CREATED_KEY, self.args.with_schedule): \
                            total_snapshots_created})
 
         # Send total_snapshot_creation_errors prototype item key and value
-        zs.add_zabbix_keys({'%s[%s]' % (PD_SNAPSHOTTER_SNAPSHOT_CREATION_ERRORS_KEY, self.args.with_schedule): \
+        mts.add_metric({'%s[%s]' % (PD_SNAPSHOTTER_SNAPSHOT_CREATION_ERRORS_KEY, self.args.with_schedule): \
                            total_snapshot_creation_errors})
 
 
         # Actually send them
-        zs.send_metrics()
+        mts.send_metrics()
 
 
 if __name__ == "__main__":

--- a/scripts/cloud/gcp/ops-gcp-trim-pd-snapshots.py
+++ b/scripts/cloud/gcp/ops-gcp-trim-pd-snapshots.py
@@ -14,7 +14,7 @@
 
 """
 # Ignoring module name
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,import-error
 
 import json
 import argparse
@@ -23,7 +23,7 @@ from openshift_tools.cloud.gcp import gcp_snapshotter
 # Reason: disable pylint import-error because our libs aren't loaded on jenkins.
 # Status: temporary until we start testing in a container where our stuff is installed.
 # pylint: disable=import-error
-from openshift_tools.monitoring.zagg_sender import ZaggSender
+from openshift_tools.monitoring.metric_sender import MetricSender
 
 EXPIRED_SNAPSHOTS_KEY = 'gcp.pd.snapshotter.expired_snapshots'
 DELETED_SNAPSHOTS_KEY = 'gcp.pd.snapshotter.deleted_snapshots'
@@ -108,15 +108,15 @@ class TrimmerCli(object):
     @staticmethod
     def report_to_zabbix(total_expired_snapshots, total_deleted_snapshots, total_deletion_errors):
         """ Sends the commands exit code to zabbix. """
-        zs = ZaggSender(verbose=True)
+        mts = MetricSender(verbose=True)
 
-        zs.add_zabbix_keys({
+        mts.add_metric({
             EXPIRED_SNAPSHOTS_KEY: total_expired_snapshots,
             DELETED_SNAPSHOTS_KEY: total_deleted_snapshots,
             DELETION_ERRORS_KEY: total_deletion_errors
         })
 
-        zs.send_metrics()
+        mts.send_metrics()
 
 if __name__ == "__main__":
     TrimmerCli().main()


### PR DESCRIPTION
Use MetricSender instead of ZaggSender in monitoring scripts

depends on #1747 