### PR TITLE
Change pcp script

### DIFF
--- a/scripts/monitoring/cron-send-pcp-ping.sh
+++ b/scripts/monitoring/cron-send-pcp-ping.sh
@@ -13,4 +13,4 @@ if [ $? -ne 0 ] ; then
 fi
 
 # Send results to zabbix
-ops-zagg-client -k "pcp.ping" -o "$PING_RETURN"
+ops-metric-client -k "pcp.ping" -o "$PING_RETURN"


### PR DESCRIPTION
Change pcp-ping script to use ops-metric-sender instead of ops-zagg-sender
Depends on #1650 and #1747 