### PR TITLE
Undo addition of broken parameter to SSO monitoring

### DIFF
--- a/ansible/roles/openshift_sso_app_zabbix/tasks/main.yml
+++ b/ansible/roles/openshift_sso_app_zabbix/tasks/main.yml
@@ -28,7 +28,6 @@
     interval: 900
     delta: 0
     units: ""
-    application: Ops SSO
   delegate_to: localhost 
   run_once: true
 


### PR DESCRIPTION
This should fix the config loop on ops-aws masters