### PR TITLE
Don't use oc import-image. It breaks some tags.

### DIFF
--- a/ansible/roles/openshift_install_templates/tasks/main.yml
+++ b/ansible/roles/openshift_install_templates/tasks/main.yml
@@ -31,17 +31,3 @@
   - "/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v{{ kube_version }}/xpaas*"
   ignore_errors: yes
   run_once: yes
-
-- name: get list of image streams
-  oc_obj:
-    state: list
-    kind: imagestreams
-    namespace: openshift
-  register: imagestreams_out
-  run_once: yes
-
-- name: Import the image stream images
-  command: "/usr/bin/oc --config /etc/origin/master/admin.kubeconfig -n openshift import-image {{ item }}"
-  with_items: "{{ imagestreams_out.results.results[0]['items'] | map(attribute='metadata') | map(attribute='name') | list }}"
-  ignore_errors: yes
-  run_once: yes


### PR DESCRIPTION
This is the bug where we learned we've been importing images incorrectly. https://bugzilla.redhat.com/show_bug.cgi?id=1401794#c20
The oc import command is not needed here, and actually causes issues with importing some tags. Auto-import will handle this as soon as the image streams are defined via 'oc replace'.