### PR TITLE
Fix hawk_client to properly send unicode string metrics

### DIFF
--- a/openshift_tools/monitoring/hawk_client.py
+++ b/openshift_tools/monitoring/hawk_client.py
@@ -76,7 +76,7 @@ class HawkClient(object):
             _id = metric.host
             key = '{0}/{1}/{2}'.format(_type, _id, metric.key)
 
-            if type(value) == str:
+            if isinstance(value, basestring):
                 # Use MetricType.String for string metrics data
                 metric_type = MetricType.String
             else:


### PR DESCRIPTION
use isinstance instead of checking type to include unicode type

https://github.com/openshift/openshift-tools/pull/1830 from stg

@twiest @joelddiaz 