### PR TITLE
Fix logging deployer

### DIFF
--- a/ansible/roles/lib_openshift_3.2/build/ansible/oc_route.py
+++ b/ansible/roles/lib_openshift_3.2/build/ansible/oc_route.py
@@ -7,7 +7,7 @@ def get_cert_data(path, content):
 
     rval = None
     if path and os.path.exists(path) and os.access(path, os.R_OK):
-        rval = open(path).read()
+        rval = open(path, 'rU').read()
     elif content:
         rval = content
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_image.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_image.py
@@ -380,7 +380,7 @@ class Utils(object):
 
                 if not isinstance(user_def[key], list):
                     if debug:
-                        print 'user_def[key] is not a list'
+                        print 'user_def[key] is not a list key=[%s] user_def[key]=%s' % (key, user_def[key])
                     return False
 
                 if len(user_def[key]) != len(value):
@@ -391,9 +391,6 @@ class Utils(object):
                         print "value: %s" % value
                     return False
 
-
-                user_def[key].sort()
-                value.sort()
                 for values in zip(user_def[key], value):
                     if isinstance(values[0], dict) and isinstance(values[1], dict):
                         if debug:
@@ -653,6 +650,9 @@ class Yedit(object):
         tmp_filename = self.filename + '.yedit'
         try:
             with open(tmp_filename, 'w') as yfd:
+                # pylint: disable=no-member
+                if hasattr(self.yaml_dict, 'fa'):
+                    self.yaml_dict.fa.set_block_style()
                 yfd.write(yaml.dump(self.yaml_dict, Dumper=yaml.RoundTripDumper))
         except Exception as err:
             raise YeditException(err.message)
@@ -698,6 +698,9 @@ class Yedit(object):
         try:
             if content_type == 'yaml' and contents:
                 self.yaml_dict = yaml.load(contents, yaml.RoundTripLoader)
+                # pylint: disable=no-member
+                if hasattr(self.yaml_dict, 'fa'):
+                    self.yaml_dict.fa.set_block_style()
             elif content_type == 'json' and contents:
                 self.yaml_dict = json.loads(contents)
         except yaml.YAMLError as err:
@@ -862,8 +865,11 @@ class Yedit(object):
         if entry == value:
             return (False, self.yaml_dict)
 
-        # deepcopy didn't preserve copy comments
-        tmp_copy = yaml.load(yaml.dump(self.yaml_dict, Dumper=yaml.RoundTripDumper), yaml.RoundTripLoader)
+        # deepcopy didn't work
+        tmp_copy = yaml.load(yaml.round_trip_dump(self.yaml_dict, default_flow_style=False), yaml.RoundTripLoader)
+        # pylint: disable=no-member
+        if hasattr(self.yaml_dict, 'fa'):
+            tmp_copy.fa.set_block_style()
         result = Yedit.add_entry(tmp_copy, path, value, self.separator)
         if not result:
             return (False, self.yaml_dict)
@@ -875,8 +881,11 @@ class Yedit(object):
     def create(self, path, value):
         ''' create a yaml file '''
         if not self.file_exists():
-            # deepcopy didn't preserve copy comments
-            tmp_copy = yaml.load(yaml.dump(self.yaml_dict, Dumper=yaml.RoundTripDumper), yaml.RoundTripLoader)
+            # deepcopy didn't work
+            tmp_copy = yaml.load(yaml.round_trip_dump(self.yaml_dict, default_flow_style=False), yaml.RoundTripLoader)
+            # pylint: disable=no-member
+            if hasattr(self.yaml_dict, 'fa'):
+                tmp_copy.fa.set_block_style()
             result = Yedit.add_entry(tmp_copy, path, value, self.separator)
             if result:
                 self.yaml_dict = tmp_copy

--- a/ansible/roles/lib_openshift_3.2/library/oc_route.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_route.py
@@ -1062,7 +1062,7 @@ def get_cert_data(path, content):
 
     rval = None
     if path and os.path.exists(path) and os.access(path, os.R_OK):
-        rval = open(path).read()
+        rval = open(path, 'rU').read()
     elif content:
         rval = content
 

--- a/ansible/roles/openshift_logging/defaults/main.yml
+++ b/ansible/roles/openshift_logging/defaults/main.yml
@@ -1,2 +1,3 @@
 osalog_fluentd_nodes:
 - type=compute
+osalog_image_prefix: registry.access.redhat.com/openshift3/

--- a/ansible/roles/openshift_logging/tasks/main.yml
+++ b/ansible/roles/openshift_logging/tasks/main.yml
@@ -130,7 +130,7 @@
     create: True
     reconcile: False
     params:
-      IMAGE_PREFIX: registry.ops.openshift.com/openshift3/
+      IMAGE_PREFIX: "{{ osalog_image_prefix }}"
   register: processout
   run_once: true
 - debug: var=processout

--- a/ansible/roles/openshift_logging/tasks/main.yml
+++ b/ansible/roles/openshift_logging/tasks/main.yml
@@ -129,6 +129,8 @@
     template_name: logging-deployer-template
     create: True
     reconcile: False
+    params:
+      IMAGE_PREFIX: registry.ops.openshift.com/openshift3/
   register: processout
   run_once: true
 - debug: var=processout

--- a/ansible/roles/openshift_logging/tasks/main.yml
+++ b/ansible/roles/openshift_logging/tasks/main.yml
@@ -323,22 +323,19 @@
 - name: Redeploy kibana
   command: oc deploy dc/logging-kibana --latest -n logging
 
-#  We may need a reencrypt route in the future
-#  This was tested, but didn't quite work.
-#
-#- name: create route for the kibana
-#  oc_route:
-#    name: kibana
-#    namespace: logging
-#    tls_termination: reencrypt
-#    cert_path: "/etc/origin/master/named_certificates/{{ cert_basename }}"
-#    key_path: "/etc/origin/master/named_certificates/{{ key_basename }}"
-#    cacert_path: "/etc/origin/master/named_certificates/{{ cacert_basename }}"
-#    dest_cacert_path: "/etc/origin/master/named_certificates/{{ cacert_basename }}"
-#    service_name: logging-kibana
-#    host: "logs.{{ osalog_clusterid }}.openshift.com"
-#  register: routeout
-#  run_once: True
-#
-#- debug: var=routeout
-#  run_once: True
+- name: Configure certificates for reencrypt route
+  oc_route:
+    name: logging-kibana
+    namespace: logging
+    cert_path: "/etc/origin/master/named_certificates/{{ cert_basename }}"
+    key_path: "/etc/origin/master/named_certificates/{{ key_basename }}"
+    cacert_path: "/etc/origin/master/named_certificates/{{ cacert_basename }}"
+    dest_cacert_path: /etc/origin/master/ca.crt
+    service_name: logging-kibana
+    host: "logs.{{ osalog_clusterid }}.openshift.com"
+    tls_termination: reencrypt
+  register: routeout
+  run_once: true
+
+- debug: var=routeout
+  run_once: True


### PR DESCRIPTION
* Added reencrypt route to logging deployment.
* Added universal read mode to certificate import. (This allows certs to contain `\r\n` line breaks).
* Defined default image prefix for logging images.

Approved in PR #1875 