### PR TITLE
Use ops-metric-client instead of zagg on image startup

### DIFF
--- a/ansible/roles/ansible_inventory/files/inventory.sh
+++ b/ansible/roles/ansible_inventory/files/inventory.sh
@@ -13,5 +13,5 @@ else
   err_count=0
 fi
 
-# Send to zabbix
-ops-zagg-client -s $host -k multi_inventory.account.refresh -o $err_count
+# Send metrics
+ops-metric-client -s $host -k multi_inventory.account.refresh -o $err_count

--- a/docker/oso-host-monitoring/centos7/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/centos7/container_setup/monitoring-config.yml
@@ -140,7 +140,7 @@ host_monitoring_cron:
 
 - name: run pcp checks every 5 minutes
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozpc.send.pcp /usr/bin/ops-zagg-pcp-client
+  job: ops-runner -f -s 15 -n ozpc.send.pcp /usr/bin/ops-metric-pcp-client
 
 - name: run pcp sampler every 5 minutes
   minute: "*/5"
@@ -149,20 +149,20 @@ host_monitoring_cron:
 - name: Do a full heartbeat
   minute: "10"
   hour: "*"
-  job: ops-runner -f -s 15 -s 3600 -n ozc.send.heartbeat.full /usr/bin/ops-zagg-client --send-heartbeat
+  job: ops-runner -f -s 15 -s 3600 -n ozc.send.heartbeat.full /usr/bin/ops-metric-client --send-heartbeat
 
 - name: Do a full heartbeat for synthetic host
   minute: "10"
   hour: "*"
-  job: ops-runner -f -s 15 -s 3600 -n ozc.send.synthetic.heartbeat.full /usr/bin/ops-zagg-client --send-heartbeat --synthetic
+  job: ops-runner -f -s 15 -s 3600 -n ozc.send.synthetic.heartbeat.full /usr/bin/ops-metric-client --send-heartbeat --synthetic
 
 - name: Do a quick heartbeat
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozc.send.heartbeat.quick /usr/bin/ops-zagg-client -k heartbeat.ping -o 1
+  job: ops-runner -f -s 15 -n ozc.send.heartbeat.quick /usr/bin/ops-metric-client -k heartbeat.ping -o 1
 
 - name: Do a quick heartbeat for synthetic host
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozc.send.synthetic.heartbeat.quick /usr/bin/ops-zagg-client -k heartbeat.ping -o 1 --synthetic
+  job: ops-runner -f -s 15 -n ozc.send.synthetic.heartbeat.quick /usr/bin/ops-metric-client -k heartbeat.ping -o 1 --synthetic
 
 - name: run filesystem space checks every 10 minutes
   minute: "*/10"

--- a/docker/oso-host-monitoring/rhel7/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/rhel7/container_setup/monitoring-config.yml
@@ -140,7 +140,7 @@ host_monitoring_cron:
 
 - name: run pcp checks every 5 minutes
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozpc.send.pcp /usr/bin/ops-zagg-pcp-client
+  job: ops-runner -f -s 15 -n ozpc.send.pcp /usr/bin/ops-metric-pcp-client
 
 - name: run pcp sampler every 5 minutes
   minute: "*/5"
@@ -149,20 +149,20 @@ host_monitoring_cron:
 - name: Do a full heartbeat
   minute: "10"
   hour: "*"
-  job: ops-runner -f -s 15 -s 3600 -n ozc.send.heartbeat.full /usr/bin/ops-zagg-client --send-heartbeat
+  job: ops-runner -f -s 15 -s 3600 -n ozc.send.heartbeat.full /usr/bin/ops-metric-client --send-heartbeat
 
 - name: Do a full heartbeat for synthetic host
   minute: "10"
   hour: "*"
-  job: ops-runner -f -s 15 -s 3600 -n ozc.send.synthetic.heartbeat.full /usr/bin/ops-zagg-client --send-heartbeat --synthetic
+  job: ops-runner -f -s 15 -s 3600 -n ozc.send.synthetic.heartbeat.full /usr/bin/ops-metric-client --send-heartbeat --synthetic
 
 - name: Do a quick heartbeat
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozc.send.heartbeat.quick /usr/bin/ops-zagg-client -k heartbeat.ping -o 1
+  job: ops-runner -f -s 15 -n ozc.send.heartbeat.quick /usr/bin/ops-metric-client -k heartbeat.ping -o 1
 
 - name: Do a quick heartbeat for synthetic host
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozc.send.synthetic.heartbeat.quick /usr/bin/ops-zagg-client -k heartbeat.ping -o 1 --synthetic
+  job: ops-runner -f -s 15 -n ozc.send.synthetic.heartbeat.quick /usr/bin/ops-metric-client -k heartbeat.ping -o 1 --synthetic
 
 - name: run filesystem space checks every 10 minutes
   minute: "*/10"

--- a/docker/oso-host-monitoring/src/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/src/container_setup/monitoring-config.yml
@@ -140,7 +140,7 @@ host_monitoring_cron:
 
 - name: run pcp checks every 5 minutes
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozpc.send.pcp /usr/bin/ops-zagg-pcp-client
+  job: ops-runner -f -s 15 -n ozpc.send.pcp /usr/bin/ops-metric-pcp-client
 
 - name: run pcp sampler every 5 minutes
   minute: "*/5"
@@ -149,20 +149,20 @@ host_monitoring_cron:
 - name: Do a full heartbeat
   minute: "10"
   hour: "*"
-  job: ops-runner -f -s 15 -s 3600 -n ozc.send.heartbeat.full /usr/bin/ops-zagg-client --send-heartbeat
+  job: ops-runner -f -s 15 -s 3600 -n ozc.send.heartbeat.full /usr/bin/ops-metric-client --send-heartbeat
 
 - name: Do a full heartbeat for synthetic host
   minute: "10"
   hour: "*"
-  job: ops-runner -f -s 15 -s 3600 -n ozc.send.synthetic.heartbeat.full /usr/bin/ops-zagg-client --send-heartbeat --synthetic
+  job: ops-runner -f -s 15 -s 3600 -n ozc.send.synthetic.heartbeat.full /usr/bin/ops-metric-client --send-heartbeat --synthetic
 
 - name: Do a quick heartbeat
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozc.send.heartbeat.quick /usr/bin/ops-zagg-client -k heartbeat.ping -o 1
+  job: ops-runner -f -s 15 -n ozc.send.heartbeat.quick /usr/bin/ops-metric-client -k heartbeat.ping -o 1
 
 - name: Do a quick heartbeat for synthetic host
   minute: "*/5"
-  job: ops-runner -f -s 15 -n ozc.send.synthetic.heartbeat.quick /usr/bin/ops-zagg-client -k heartbeat.ping -o 1 --synthetic
+  job: ops-runner -f -s 15 -n ozc.send.synthetic.heartbeat.quick /usr/bin/ops-metric-client -k heartbeat.ping -o 1 --synthetic
 
 - name: run filesystem space checks every 10 minutes
   minute: "*/10"


### PR DESCRIPTION
use ops-metric-client to send heartbeat and set cron jobs when image starts