### PR TITLE
use metric_sender.yaml as default config file for zagg_sender

### DIFF
--- a/openshift_tools/monitoring/zagg_sender.py
+++ b/openshift_tools/monitoring/zagg_sender.py
@@ -40,7 +40,7 @@ class ZaggSender(GenericMetricSender):
         super(ZaggSender, self).__init__()
 
         if not config_file:
-            config_file = '/etc/openshift_tools/zagg_client.yaml'
+            config_file = '/etc/openshift_tools/metric_sender.yaml'
 
         self.config_file = config_file
         self.unique_metrics = []


### PR DESCRIPTION
@twiest I think we still want zagg_sender to use the metric_sender config file by default.
Currently it is not called directly by any script and all scripts access it via metric_sender anyway.
I think it's safer to maintain the same file, even if we choose to leave the zagg_client.yaml for alternative configuration.