### PR TITLE
[ci] Handle pull requests with empty descriptions

### DIFF
--- a/jenkins/test/run_tests.py
+++ b/jenkins/test/run_tests.py
@@ -61,7 +61,8 @@ def assign_env(pull_request):
     '''Assign environment variables base don github webhook payload json data'''
     # Github environment variables
     os.environ["PRV_TITLE"] = pull_request["title"]
-    os.environ["PRV_BODY"] = pull_request["body"]
+    # Handle pull request body in case it is empty
+    os.environ["PRV_BODY"] = (pull_request["body"] if pull_request["body"] is not None else "")
     os.environ["PRV_PULL_ID"] = pull_request["number"]
     os.environ["PRV_URL"] = pull_request["url"]
 


### PR DESCRIPTION
Ensure that pull requests with empty descriptions do not cause a type-mismatch when setting environment variables. Previously, the PRV_BODY environment variables could be set to None instead of "" if the pull request description was empty.