### PR TITLE
[ci] Use correct SHA for git diff comparisons

### DIFF
--- a/jenkins/test/validators/lint.py
+++ b/jenkins/test/validators/lint.py
@@ -12,10 +12,10 @@ LINT_EXCLUDE_PATTERN_LIST = [
     r'ansible/inventory/gce/hosts/gce.py'
     r'docs/*']
 
-def linter(base_sha, remote_sha):
+def linter(base_sha, current_sha):
     '''Use pylint to lint all python files changed in the pull request'''
     _, diff_output = common.run_cli_cmd(["/usr/bin/git", "diff", "--name-only", base_sha,
-                                         remote_sha, "--diff-filter=ACM"])
+                                         current_sha, "--diff-filter=ACM"])
     diff_file_list = diff_output.split('\n')
     file_list = []
 
@@ -51,34 +51,34 @@ def linter(base_sha, remote_sha):
 
 def usage():
     ''' Print usage '''
-    print """usage: python lint.py [[base_sha] [remote_sha]]
+    print """usage: python lint.py [[base_sha] [current_sha]]
     
-    base_sha:   The SHA of the current base branch being merged into
-    remote_sha: The SHA of the remote branch being merged
+    base_sha:    The SHA of the current base branch being merged into
+    current_sha: The SHA of the branch after merge (git rev-parse HEAD)
     
 Arguments can be provided through the following environment variables:
 
-    base_sha:   PRV_BASE_SHA
-    remote_sha: PRV_REMOTE_SHA"""
+    base_sha:    PRV_BASE_SHA
+    current_sha: PRV_CURRENT_SHA"""
 
 def main():
     ''' Get base and remote SHA from arguments and run linter '''
     if len(sys.argv) == 3:
         base_sha = sys.argv[1]
-        remote_sha = sys.argv[2]
+        current_sha = sys.argv[2]
     elif len(sys.argv) > 1:
         print len(sys.argv)-1, "arguments provided, expected 2."
         usage()
         sys.exit(2)
     else:
         base_sha = os.getenv("PRV_BASE_SHA", "")
-        remote_sha = os.getenv("PRV_REMOTE_SHA", "")
+        current_sha = os.getenv("PRV_CURRENT_SHA", "")
 
-    if base_sha == "" or remote_sha == "":
+    if base_sha == "" or current_sha == "":
         print "base and remote sha must be defined"
         usage()
         sys.exit(3)
-    success, error_message = linter(base_sha, remote_sha)
+    success, error_message = linter(base_sha, current_sha)
     if not success:
         print "Pylint failed:"
         print error_message

--- a/jenkins/test/validators/parent.py
+++ b/jenkins/test/validators/parent.py
@@ -43,15 +43,15 @@ def ensure_stg_contains(commit_id):
 
 def usage():
     ''' Print usage '''
-    print """usage: parent.py [[base_ref] [remote_sha]]
+    print """usage: parent.py [[base_ref] [current_sha]]
 
-    base_ref:    Git REF of the base branch being merged into
-    remote_sha:  The SHA of the remote branch being merged
+    base_ref:     Git REF of the base branch being merged into
+    current_sha:  The SHA of the remote branch after merge (git rev-parse HEAD)
 
 Arguments can be provided through the following environment variables:
 
-    base_ref:    PRV_BASE_REF
-    remote_sha:  PRV_REMOTE_SHA"""
+    base_ref:     PRV_BASE_REF
+    current_sha:  PRV_CURRENT_SHA"""
 
 def main():
     ''' Get git change information and check stg for commit '''

--- a/jenkins/test/validators/yaml_validation.py
+++ b/jenkins/test/validators/yaml_validation.py
@@ -38,15 +38,15 @@ def get_changes(oldrev, newrev, tempdir):
 
 def usage():
     ''' Print usage '''
-    print """usage: yaml_validation.py [[base_sha] [remote_sha]]
+    print """usage: yaml_validation.py [[base_sha] [current_sha]]
 
-    base_sha:    The SHA of the base branch being merged into
-    remote_sha:  The SHA of the remote branch being merged
+    base_sha:     The SHA of the base branch being merged into
+    current_sha:  The SHA of the remote branch after merge (git rev-parse HEAD)
 
 Arguments can be provided through the following environment variables:
 
-    base_sha:    PRV_BASE_SHA
-    remote_sha:  PRV_REMOTE_SHA"""
+    base_sha:     PRV_BASE_SHA
+    current_sha:  PRV_CURRENT_SHA"""
 
 def main():
     '''
@@ -54,15 +54,15 @@ def main():
     '''
     if len(sys.argv) == 3:
         base_sha = sys.argv[1]
-        remote_sha = sys.argv[2]
+        current_sha = sys.argv[2]
     elif len(sys.argv) > 1:
         print len(sys.argv)-1, "arguments provided, expected 2."
         usage()
         sys.exit(2)
     else:
         base_sha = os.getenv("PRV_BASE_SHA", "")
-        remote_sha = os.getenv("PRV_REMOTE_SHA", "")
-    if base_sha == "" or remote_sha == "":
+        current_sha = os.getenv("PRV_CURRENT_SHA", "")
+    if base_sha == "" or current_sha == "":
         print "Base SHA and remote SHA must be defined"
         usage()
         sys.exit(3)
@@ -71,7 +71,7 @@ def main():
     try:
         tmpdir = tempfile.mkdtemp(prefix='jenkins-git-')
         old = base_sha
-        new = remote_sha
+        new = current_sha
 
         for file_mod in get_changes(old, new, tmpdir):
 


### PR DESCRIPTION
Previously, the incorrect SHA was used to create git diff file lists for
use by the linter and yaml validator. This change enhances the way
changes for a pull request are locally gathered and corrects the SHA
used by the validators