### PR TITLE
Resolve git issues in ci

### DIFF
--- a/jenkins/test/run_tests.py
+++ b/jenkins/test/run_tests.py
@@ -87,10 +87,11 @@ def merge_changes(pull_request):
 
     run_cli_cmd(['/usr/bin/git', 'fetch', "--tags", "origin", "+refs/head/*:refs/remotes/origin/*",
                  "+refs/pull/*:refs/remotes/origin/pr/*"])
-    _, current_rev = run_cli_cmd(['/usr/bin/git', 'rev-parse',
-                                  'refs/remotes/origin/pr/'+pull_id+'/merge^{commit}'])
-    run_cli_cmd(['/usr/bin/git', 'config', 'core.sparsecheckout'])
-    run_cli_cmd(['/usr/bin/git', 'fetch', '-f', current_rev])
+    _, output = run_cli_cmd(['/usr/bin/git', 'rev-parse',
+                             'refs/remotes/origin/pr/'+pull_id+'/merge^{commit}'])
+    current_rev = output.rstrip()
+    run_cli_cmd(['/usr/bin/git', 'config', 'core.sparsecheckout'], exit_on_fail=False)
+    run_cli_cmd(['/usr/bin/git', 'checkout', '-f', current_rev])
     os.environ["PRV_CURRENT_SHA"] = current_rev
 
 def run_validators():


### PR DESCRIPTION
Properly use 'git checkout' and do not exit if running 'git config' returns a non-zero exit code. Additionally, ensure the rev returned by `rev-parse` doesn't include a trailing newline.