### PR TITLE
Allow tests to be run for pull requests on-demand

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -2,22 +2,49 @@
 
 node {
     stage "Check PR Action"
+        // Parse json payload
+        def test_key = "[test]"
         def slurper = new groovy.json.JsonSlurper()
         def webhook = slurper.parseText(payload)
         def trigger = ""
+
         // The following are the actions we should test:
         // "opened", "reopened", "synchronize"
         // We should build if the action is "closed" and the "merged" flag is true
         // The "edited" action is when a comment is edited, we don't care about that.
-        echo webhook.action
-        if (webhook.action == "opened" || webhook.action == "reopened" || webhook.action == "synchronize") {
+
+        // Additionally, to support re-testing via a comment made on the PR, we should test
+        // on the following issue-only actions:
+        // created, edited
+        // These will requier some additional verification, as tests should only commence if
+        // the comment was made on an open pull request and includes a certain phrase.
+
+        def action = webhook.action
+        echo "Webhook payload action: ${action}"
+        if (action == "opened" || action == "reopened" || action == "synchronize") {
+            echo "Pull request has been opened or modified, testing..."
             trigger = "test"
-        } else if (webhook.action == "closed" && webhook.pull_request.merged) {
+        } else if (action == "closed" && webhook.pull_request.merged) {
+            echo "Pull request has been merged, running builds..."
             trigger = "build"
+        } else if (action == "created" || action == "edited") {
+            if (webhook.issue && webhook.issue.containsKey("pull_request")) {
+                body = webhook.comment.body
+                if (body.toLowerCase().contains(test_key)) {
+                    echo "Pull request comment contains '${test_key}', running tests..."
+                    trigger = "test"
+                } else {
+                    echo "Pull request comment does not contain '${test_key}'. Ignoring..."
+                }
+            } else {
+                echo "Comment made on issue, not pull request. Ignoring..."
+            }
         }
+        echo "Trigger: ${trigger}"
         // These variables must be nullified as they are not serializable
         // See http://stackoverflow.com/questions/37864542/jenkins-pipeline-notserializableexception-groovy-json-internal-lazymap
         slurper = null
+        webhook = null
 
     if (trigger != "") {
         if (trigger == "test") {
@@ -28,15 +55,15 @@ node {
             stage "Build RPMS"
                 echo "Starting Build"
                 // TODO this is not yet implemented
-						stage "Deploy Updates"
-								echo "Deploying updated RPMs"
+            stage "Deploy Updates"
+                echo "Deploying updated RPMs"
                 // TODO this is not yet implemented
         } else {
             echo "Trigger ${trigger} not recognized"
             currentBuild.result = 'FAILURE'
         }
     } else {
-        echo "Pull request action, ${webhook.action}, does not justify running any jobs."
+        echo "Webhook action, ${action}, does not justify running any jobs."
         currentBuild.result = 'SUCCESS'
     }
 }

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -3,7 +3,9 @@
 The files within this directory are used to set up automation around testing, building, and deploying changes to components in the openshift-tools repository.
 
 ### How it works
-When a pull request is submitted to the openshift-tools repository on github, a webhook starts a job on a persistent jenkins instance running in an openshift environment. The job is a simple jenkins pipeline using the `Jenkinsfile` in this directory. The pipeline determines the action to take based on the action in the webhook. When a test is necessary, the jenkins pipeline starts a build on the openshift environment titled `openshift-tools-test` and outputs the build logs to the pipeline's logs.
+When a pull request is submitted to the openshift-tools repository on github, a webhook starts a job on a persistent jenkins instance running in an openshift environment. The job is a simple jenkins pipeline using the `Jenkinsfile` in this directory. The pipeline determines the action to take based on the action and some other details in the webhook. When a test is necessary, the jenkins pipeline starts a build on the openshift environment titled `openshift-tools-test` and outputs the build logs to the pipeline's logs.
+
+Tests will be run whenever a pull request is opened, reopened, or "synchronized" (a commit is added, subtracted, or amended). Tests can also be manually performed by commenting on the pull request with the term '[test]' with a whitelisted user.
 
 The `openshift-tools-test` build is defined in the `openshift-tools-pr-automation-template.json` template. The build mounts a secret containing the github bot user credentials, then starts a docker build using the Dockerfile `test/Dockerfile`. This build runs from the oso-host-monitoring container and clones the openshift-tools repository. Once the environment is set up, the build runs the `test/run_tests.py` script. This script merges in the changes defined in the github webhook payload and defines several environment variables for consumption by a suite of validators. Each `.py` or .sh` file in `test/validators` is run with these environment varibles.
 
@@ -18,7 +20,7 @@ The script will then submit a comment to the pull request indiciating whether al
 ### Configuration
 1. In an openshift environment, deploy a persistent jenkins instance using the [jenkins-persistent template]( https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/jenkins-persistent-template.json). Pass the parameter `ENABLE_OAUTH=false` to disable OAUTH and set the default username and password to admin:password
 
-2. Deploy the builds and secrets in the openshift environment using the `openshift-tools-pr-automation-template.json` in this directory. A username and oauth token for a github user will be required.
+2. Deploy the builds and secrets in the openshift environment using the `openshift-tools-pr-automation-template.json` in this directory. A username and oauth token for a github user will be required. A comma-seperated list of github users will also be necessary for the whitelist.
 
 3. Log into the jenkins instance using the default credentials. Navigate to 'Manage Jenkins' > 'Manage Users' and click the 'config' icon for the admin user. Change the admin users password to something much more secure.
 

--- a/jenkins/test/run_tests.py
+++ b/jenkins/test/run_tests.py
@@ -131,7 +131,7 @@ def submit_pr_comment(text, pull_id, repo):
     """ Submit a comment on a pull request or issue in github """
     github_username, oauth_token = get_github_credentials()
     payload = {'body': text}
-    comment_url = "%s/repos/%s/issues/%s/comments" % (GITHUB_API_URL, repo, pull_id)
+    comment_url = "{0}/repos/{1}/issues/{2}/comments".format(GITHUB_API_URL, repo, pull_id)
     response = requests.post(comment_url, json=payload, auth=(github_username, oauth_token))
     # Raise an error if the request fails for some reason
     response.raise_for_status()
@@ -144,7 +144,7 @@ def submit_pr_status_update(state, text, remote_sha, repo):
                'description': text,
                'target_url': target_url,
                'context': "jenkins-ci"}
-    status_url = "%s/repos/%s/statuses/%s" % (GITHUB_API_URL, repo, remote_sha)
+    status_url = "{0}/repos/{1}/statuses/{2}".format(GITHUB_API_URL, repo, remote_sha)
     response = requests.post(status_url, json=payload, auth=(github_username, oauth_token))
     # Raise an error if the request fails for some reason
     response.raise_for_status()


### PR DESCRIPTION
These changes add the following features:

1) The pull request that is commented on is gathered from the pull_request data, rather than being hard coded. This doesn't cause any changes now, but will make it easier to use this code for other repositories in the future.

2) The string [test] can be added to any pull request by a white-listed user to run tests on-demand for that pull request. 

This change requires that the github webhook also send 'issueComment' events.