### PR TITLE
Use base SHA when using git diff to list modified files

### DIFF
--- a/jenkins/test/run_tests.py
+++ b/jenkins/test/run_tests.py
@@ -98,6 +98,14 @@ def merge_changes(pull_request):
 
 def run_validators():
     """ Run all test validators """
+    # First, add the validator direcotry to the python path to allow
+    # modules to be loaded by pylint
+    pypath = os.getenv("PYTHONPATH", "")
+    if pypath != "":
+        os.environ["PYTHONPATH"] = VALIDATOR_PATH + os.pathsep + pypath
+    else:
+        os.environ["PYTHONPATH"] = VALIDATOR_PATH
+
     failure_occured = False
     validators = [validator for validator in os.listdir(VALIDATOR_PATH) if
                   os.path.isfile(os.path.join(VALIDATOR_PATH, validator))]

--- a/jenkins/test/validators/parent.py
+++ b/jenkins/test/validators/parent.py
@@ -30,8 +30,8 @@ def ensure_stg_contains(commit_id):
             continue
         # remove the first char '>'
         commit = commit[1:]
-        success, branches = common.run_cli_cmd(['/usr/bin/git', 'branch', '-q', '-r', '--contains', commit],
-                                               exit_on_fail=False)
+        parent_cmd = ['/usr/bin/git', 'branch', '-q', '-r', '--contains', commit]
+        success, branches = common.run_cli_cmd(parent_cmd, exit_on_fail=False)
         if success and len(branches) == 0:
             continue
         if 'origin/stg/' not in branches:
@@ -43,15 +43,15 @@ def ensure_stg_contains(commit_id):
 
 def usage():
     ''' Print usage '''
-    print """usage: parent.py [[base_ref] [current_sha]]
+    print """usage: parent.py [[base_ref] [remote_sha]]
 
-    base_ref:     Git REF of the base branch being merged into
-    current_sha:  The SHA of the remote branch after merge (git rev-parse HEAD)
+    base_ref:    Git REF of the base branch being merged into
+    remote_sha:  The SHA of the remote branch after merge (git rev-parse HEAD)
 
 Arguments can be provided through the following environment variables:
 
-    base_ref:     PRV_BASE_REF
-    current_sha:  PRV_CURRENT_SHA"""
+    base_ref:    PRV_BASE_REF
+    remote_sha:  PRV_REMOTE_SHA"""
 
 def main():
     ''' Get git change information and check stg for commit '''

--- a/jenkins/test/validators/yaml_validation.py
+++ b/jenkins/test/validators/yaml_validation.py
@@ -38,15 +38,15 @@ def get_changes(oldrev, newrev, tempdir):
 
 def usage():
     ''' Print usage '''
-    print """usage: yaml_validation.py [[base_sha] [current_sha]]
+    print """usage: yaml_validation.py [[base_sha] [remote_sha]]
 
-    base_sha:     The SHA of the base branch being merged into
-    current_sha:  The SHA of the remote branch after merge (git rev-parse HEAD)
+    base_sha:    The SHA of the base branch being merged into
+    remote_sha:  The SHA of the remote branch after merge (git rev-parse HEAD)
 
 Arguments can be provided through the following environment variables:
 
-    base_sha:     PRV_BASE_SHA
-    current_sha:  PRV_CURRENT_SHA"""
+    base_sha:    PRV_BASE_SHA
+    remote_sha:  PRV_REMOTE_SHA"""
 
 def main():
     '''
@@ -54,15 +54,15 @@ def main():
     '''
     if len(sys.argv) == 3:
         base_sha = sys.argv[1]
-        current_sha = sys.argv[2]
+        remote_sha = sys.argv[2]
     elif len(sys.argv) > 1:
         print len(sys.argv)-1, "arguments provided, expected 2."
         usage()
         sys.exit(2)
     else:
         base_sha = os.getenv("PRV_BASE_SHA", "")
-        current_sha = os.getenv("PRV_CURRENT_SHA", "")
-    if base_sha == "" or current_sha == "":
+        remote_sha = os.getenv("PRV_REMOTE_SHA", "")
+    if base_sha == "" or remote_sha == "":
         print "Base SHA and remote SHA must be defined"
         usage()
         sys.exit(3)
@@ -71,7 +71,7 @@ def main():
     try:
         tmpdir = tempfile.mkdtemp(prefix='jenkins-git-')
         old = base_sha
-        new = current_sha
+        new = remote_sha
 
         for file_mod in get_changes(old, new, tmpdir):
 


### PR DESCRIPTION
Previously, the SHA of the working merge branch was comapred with the
SHA of the base branch to determine the list of files that were changed
in a particular pull request. This ended up also included any merged
changes to the base branch since the pull request was made.

Using the remote branch SHA will ensure that only the files with changes
that the remote branch includes will be returned from git diff commands.