### PR TITLE
Use stg branch for CI testing

### DIFF
--- a/jenkins/test/Dockerfile
+++ b/jenkins/test/Dockerfile
@@ -14,6 +14,7 @@ ADD whitelist/ /whitelist/
 RUN mkdir /validator && \
     git clone https://github.com/openshift/openshift-tools /validator/openshift-tools && \
     cd /validator/openshift-tools && \
+    git checkout stg && \
     git config user.name validator && \
     git config user.email validator@localhost && \
     /usr/bin/python /validator/openshift-tools/jenkins/test/run_tests.py


### PR DESCRIPTION
The default branch for openshift-tools recently changed. The stg branch needs to be specifically checked out now for CI purposes.

Alternatively, we can push all of the CI changes to the prod branch. It might be easier to leave it in stg for now to quickly iterate.