### PR TITLE
cron-send-stuck-builds: use the creationTimestamp for new builds

### DIFF
--- a/scripts/monitoring/cron-send-stuck-builds.py
+++ b/scripts/monitoring/cron-send-stuck-builds.py
@@ -70,7 +70,7 @@ def get_stuck_build_count(age, build_state):
 
     # go template method - shiny!
     get_new_build_timestamps = ("get builds --all-namespaces -o go-template='{{range .items}}"
-                                "{{if eq .status.phase \"%s\"}}{{.status.startTimestamp}}"
+                                "{{if eq .status.phase \"%s\"}}{{.metadata.creationTimestamp}}"
                                 "{{print \"\\n\"}}{{end}}{{end}}'")
 
     all_ts = runOCcmd(get_new_build_timestamps % build_state).split()


### PR DESCRIPTION
Use _.metadata.creationTimestamp_ instead of _.status.startTimestamp_, which doesn't always exists.