### PR TITLE
Add python-pygithub to host monitoring container

### DIFF
--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -72,6 +72,7 @@ RUN yum clean metadata && \
         openvswitch \
         python-psutil \
         pylint \
+        python-pygithub \
         docker-python && \
     yum -y update && \
     yum clean all


### PR DESCRIPTION
This change will add the 'python-pygithub' rpm to the oso-host-monitoring image. The rpm is available through the li repo.