### PR TITLE
If get fails, we exceeded API rate of amazon

### DIFF
--- a/scripts/monitoring/cron-send-elb-status.py
+++ b/scripts/monitoring/cron-send-elb-status.py
@@ -27,6 +27,7 @@
 # pylint: disable=pointless-string-statement
 # pylint: disable=deprecated-lambda
 # pylint: disable=bad-builtin
+# pylint: disable=bare-except
 
 from ConfigParser import SafeConfigParser
 from openshift_tools.monitoring.metric_sender import MetricSender

--- a/scripts/monitoring/cron-send-elb-status.py
+++ b/scripts/monitoring/cron-send-elb-status.py
@@ -105,7 +105,12 @@ def main():
 
     ''' Fetch the load balancers and make sure this instance is within them '''
 
-    elbs = elb.get_all_load_balancers()
+    try:
+        elbs = elb.get_all_load_balancers()
+    except:
+        print "Rate limit reached, skipping."
+        exit()
+
     instance_id = get_instance_id()
     instance_missing = 0
 


### PR DESCRIPTION
From time to time, we exceed API rate of amazon and we need to wait for the next run. This is fine, we just don't want an exception here.