### PR TITLE
Fix CI parent branch check

### DIFF
--- a/jenkins/test/github_helpers.py
+++ b/jenkins/test/github_helpers.py
@@ -72,3 +72,14 @@ def get_changed_files(repo, pr_num):
         filename = prfile.filename
         filename_list.append(filename)
     return filename_list
+
+# Takes a repo in the form 'org/repo-name' and a pr number string or int
+def get_commits(repo, pr_num):
+    """ Get list of commits for a pull request """
+    ghc = conn()
+    pull = ghc.get_repo(repo).get_pull(int(pr_num))
+    commit_list = []
+    for commit in pull.get_commits():
+        commit_sha = commit.sha
+        commit_list.append(commit_sha)
+    return commit_list

--- a/jenkins/test/run_tests.py
+++ b/jenkins/test/run_tests.py
@@ -29,7 +29,8 @@
 #    PRV_CURRENT_SHA   The SHA of the merge commit
 #
 #  Other info
-#    PRV_CHANGED_FILES List of files changed in a pull request
+#    PRV_CHANGED_FILES List of files changed in the pull request
+#    PRV_COMMITS       List of commits in the pull request
 #
 
 import os
@@ -89,8 +90,14 @@ def assign_env(pull_request):
     # Other helpful environment variables
     baserepo = base["repo"]["full_name"]
     prnum = pull_request["number"]
+
+    # List of changed files
     changed_files = github_helpers.get_changed_files(baserepo, prnum)
     os.environ["PRV_CHANGED_FILES"] = ",".join(changed_files)
+
+    # List of commits
+    commits = github_helpers.get_commits(baserepo, prnum)
+    os.environ["PRV_COMMITS"] = ",".join(commits)
 
 def merge_changes(pull_request):
     """ Merge changes into current repository """


### PR DESCRIPTION
Previously, the list of commits found by the parent check script was
incorrect, causing failures on pull requests submitted to the prod
branch. This change reaches out to github via the v3 api with an
authenticated request to gather the definitive list of commits for a
pull request and compare them against the commits in the stg branch
before merging to prod.