### PR TITLE
Adding 'unknown' build state to the count script

### DIFF
--- a/scripts/monitoring/cron-send-build-counts.py
+++ b/scripts/monitoring/cron-send-build-counts.py
@@ -62,6 +62,7 @@ def count_builds():
 
     for build_state in valid_build_states:
         build_counts[build_state] = 0
+    build_counts["unknown"] = 0
 
     get_builds = "get builds --all-namespaces -o jsonpath='{range .items[*]}{.status.phase}{\"\\n\"}{end}'"
 


### PR DESCRIPTION
The cron-send-build-counts script is returning non-zero exit codes on a lot of nodes because it doesn't currently set up an "unknown" key in the build_count dictionary it uses to track the current build states:

```python
Traceback (most recent call last):
  File "/usr/bin/cron-send-build-counts", line 102, in <module>
    main()
  File "/usr/bin/cron-send-build-counts", line 97, in main
    builds = count_builds()
  File "/usr/bin/cron-send-build-counts", line 78, in count_builds
    build_counts["unknown"] += 1
KeyError: 'unknown'
```

This PR simply adds the "unknown" key to that dictionary with a default value of 0. 
