### PR TITLE
Add OpenShift master audit config role.

### DIFF
--- a/ansible/roles/openshift_master_audit_config/README.md
+++ b/ansible/roles/openshift_master_audit_config/README.md
@@ -1,0 +1,66 @@
+openshift_master_audit
+=========
+
+Ansible role for configuring the audit capabilities on OpenShift masters.
+
+Optional parameters not defined will be removed from master-config.yaml if
+present.
+
+https://docs.openshift.org/latest/install_config/master_node_configuration.html#master-node-config-audit-config
+
+Requirements
+------------
+
+Ansible Modules:
+
+- tools_roles/lib_openshift_3.2
+- tools_roles/lib_yaml_editor
+
+
+Role Variables
+--------------
+
+### omac_enabled
+
+Enable/disable the OpenShift master audit log.
+
+Default: `False`
+
+### omac_auditConfig_auditFilePath
+
+File path where the requests should be logged to. If not set, logs will be printed to master logs.
+
+### omac_auditConfig_maximumFileRetentionDays
+
+Specifies maximum number of days to retain old audit log files based on the timestamp encoded in their filename.
+
+### omac_auditConfig_maximumRetainedFiles
+
+Specifies Maximum number of old audit log files to retain.
+
+### omac_auditConfig_maximumFileSizeMegabytes
+
+Specifies maximum size in megabytes of the log file before it gets rotated.
+
+Dependencies
+------------
+
+
+Example Playbook
+----------------
+  - role: tools_roles/openshift_master_audit
+    omac_auditConfig_enabled: False
+    omac_auditConfig_auditFilePath: "/var/log/openshift-master-audit.log"
+    omac_auditConfig_maximumFileRetentionDays: 30
+    omac_auditConfig_maximumRetainedFiles: 30
+    omac_auditConfig_maximumFileSizeMegabytes: 100
+
+License
+-------
+
+Apache 2.0
+
+Author Information
+------------------
+
+Openshift Operations

--- a/ansible/roles/openshift_master_audit_config/defaults/main.yml
+++ b/ansible/roles/openshift_master_audit_config/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+omac_auditConfig_enabled: False

--- a/ansible/roles/openshift_master_audit_config/handlers/main.yml
+++ b/ansible/roles/openshift_master_audit_config/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: restart openshift master services
+  service:
+    name: "{{ item[1] }}"
+    state: restarted
+  delegate_to: "{{ item[0] }}"
+  with_nested:
+  - "{{ ansible_play_hosts }}"
+  - [ 'atomic-openshift-master-api', 'atomic-openshift-master-controllers' ]
+  run_once: true
+

--- a/ansible/roles/openshift_master_audit_config/meta/main.yml
+++ b/ansible/roles/openshift_master_audit_config/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: OpenShift Ops
+  description: Openshift Operations Master Audit Config
+  company: Red Hat, Inc
+  license: ASL 2.0
+  min_ansible_version: 1.2
+  platforms:
+  - name: EL
+    versions:
+    - 7
+dependencies:
+- role: tools_roles/lib_openshift_3.2
+- role: tools_roles/lib_yaml_editor

--- a/ansible/roles/openshift_master_audit_config/tasks/main.yml
+++ b/ansible/roles/openshift_master_audit_config/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: "auditConfig.enabled"
+  yedit:
+    src: /etc/origin/master/master-config.yaml
+    key: auditConfig.enabled
+    value: "{{ omac_auditConfig_enabled }}"
+  notify: restart openshift master services
+
+- name: "deploy master audit config options"
+  yedit:
+    src: /etc/origin/master/master-config.yaml
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+    state: "{{ 'present' if item.value != '' else 'absent' }}"
+  notify: restart openshift master services
+  with_items:
+  - key: auditConfig.auditFilePath
+    value: "{{ omac_auditConfig_auditFilePath | default('') }}"
+  - key: auditConfig.maximumFileRetentionDays
+    value: "{{ omac_auditConfig_maximumFileRetentionDays | default('') }}"
+  - key: auditConfig.maximumRetainedFiles
+    value: "{{ omac_auditConfig_maximumRetainedFiles | default('') }}"
+  - key: auditConfig.maximumFileSizeMegabytes
+    value: "{{ omac_auditConfig_maximumFileSizeMegabytes | default('') }}"
+


### PR DESCRIPTION
Configures the settings in auditConfig section of master-config.yaml.

Variables left unset indicates property should be removed if present, we
assume that if calling this role, you intend to manage that section of
config and have passed appropriate vars.