### PR TITLE
router DC changes for setting x_forwarded_for header

### DIFF
--- a/ansible/roles/openshift_secure_router/tasks/main.yml
+++ b/ansible/roles/openshift_secure_router/tasks/main.yml
@@ -8,6 +8,13 @@
   - "{{ ossr_default_router_keys }}"
   - "{{ ossr_default_router_cacert }}"
 
+- name: Include cloud-specific router edits
+  include_vars: "{{ ossr_cloud }}.yml"
+
+- name: Merge default and cloud-specific router edits
+  set_fact:
+    ossr_router_edits: "{{ ossr_default_router_edits | union(ossr_cloud_router_edits) }}"
+
 - name: create routers
   oadm_router:
     name: "{{ item.0.name }}"
@@ -21,7 +28,7 @@
     cert_file: "/etc/origin/master/named_certificates/{{ item.1 | basename }}"
     key_file: "/etc/origin/master/named_certificates/{{ item.2 | basename }}"
     cacert_file: "/etc/origin/master/named_certificates/{{ ossr_default_router_cacert | basename }}"
-    edits: "{{ item.0.router_edits | default([]) | union(ossr_default_router_edits) }}"
+    edits: "{{ ossr_router_edits | union(item.0.router_edits | default([])) }}"
   with_together:
   - "{{ ossr_routers }}" # item.0
   - "{{ ossr_default_router_certs }}" # item.1

--- a/ansible/roles/openshift_secure_router/vars/aws.yml
+++ b/ansible/roles/openshift_secure_router/vars/aws.yml
@@ -1,0 +1,9 @@
+---
+ossr_cloud_router_edits:
+  # needed to correspond with AWS ELB configuration that causes ELB to
+  # communicated with the proxy protocol
+  - key: spec.template.spec.containers[0].env
+    value:
+      name: ROUTER_USE_PROXY_PROTOCOL
+      value: 'true'
+    action: update

--- a/ansible/roles/openshift_secure_router/vars/gcp.yml
+++ b/ansible/roles/openshift_secure_router/vars/gcp.yml
@@ -1,0 +1,2 @@
+---
+ossr_cloud_router_edits: []


### PR DESCRIPTION
With OpenShift 3.3.1.11 and 3.4.1, the OpenShift router image accepts the environment var ROUTER_USE_PROXY_PROTOCOL to have the router pod use the PROXY protocol.

This allows propogation of the X-FORWARDED-FOR HTTP header showing the client IP address instead of the ELB's IP.

This will be the default setting going forward. This requires the AWS ELB to be configured to speak the PROXY protocol as well (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html).