### PR TITLE
Build, install, and run unit tests on test rpms during CI

### DIFF
--- a/jenkins/test/run_unit_tests.sh
+++ b/jenkins/test/run_unit_tests.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+# All unit tests should be run through this script to be included in CI
+
+# TODO this is a placeholder until unit tests are created.
+
+echo "Unit tests pass"
+exit 0

--- a/jenkins/test/validators/common.py
+++ b/jenkins/test/validators/common.py
@@ -5,7 +5,7 @@ import sys
 # Run cli command. By default, exit when an error occurs
 def run_cli_cmd(cmd, exit_on_fail=True):
     '''Run a command and return its output'''
-    print "Running system command: " + " ".join(cmd)
+    print "> " + " ".join(cmd)
     proc = subprocess.Popen(cmd, bufsize=-1, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=False)
     stdout, stderr = proc.communicate()
     if proc.returncode != 0:


### PR DESCRIPTION
This change adds two steps to the PR validation process. After validation scripts (pylint, yaml validation, etc) are successful, test versions of the openshift-tools rpms are built and installed. If successful, unit tests will then be run against the installed rpms.

This change should validate that rpms can be built and installed with the changes included in a pull request.