### PR TITLE
Add tito and build deps to oso-host-monitoring container

### DIFF
--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -68,6 +68,11 @@ RUN yum clean metadata && \
         openvswitch \
         python-psutil \
         pylint \
+        tito \
+        python-devel \
+        libyaml-devel \
+        oso-simplesamlphp \
+        python-ruamel-yaml \
         python-pygithub \
         docker-python && \
     yum clean all

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -62,6 +62,11 @@ RUN yum clean metadata && \
         openvswitch \
         python-psutil \
         pylint \
+        tito \
+        python-devel \
+        libyaml-devel \
+        oso-simplesamlphp \
+        python-ruamel-yaml \
         python-pygithub \
         docker-python && \
     yum install -y gcloud --disablerepo="oso-rhui-rhel-server-releases-optional" && \

--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -66,6 +66,11 @@ RUN yum clean metadata && \
         openvswitch \
         python-psutil \
         pylint \
+        tito \
+        python-devel \
+        libyaml-devel \
+        oso-simplesamlphp \
+        python-ruamel-yaml \
         python-pygithub \
         docker-python && \
 {# This is installed for gsutil and calculating the size of the gcs #}


### PR DESCRIPTION
This commit modifies the Dockerifle of the oso-host-monitoring container
to install tito and the build dependencies necesary for building the
openshift tools rpms