### PR TITLE
Vendor upgrade symlinks

### DIFF
--- a/openshift/installer/vendor-rpms.yml
+++ b/openshift/installer/vendor-rpms.yml
@@ -105,6 +105,29 @@
     - [ 'filter_plugins', 'lookup_plugins' ]
     - [ 'openshift-cluster', 'openshift-master', 'openshift-node']
 
+  # Each OpenShift release ships with 1-2 supported upgrade paths in a
+  # version specific directory like "v3_4". Search for anything that looks like
+  # one, and create the required symlinks within it.
+  - name: Lookup versioned upgrade directories
+    find:
+      paths: "{{ vendored_dir }}/playbooks/byo/openshift-cluster/upgrades/"
+      patterns: "v3_*"
+      file_type: directory
+    register: upgrade_versions
+
+  - fail:
+      msg: "No upgrade directories found."
+    when: upgrade_versions.files | length == 0
+
+  - name: Symlink the filter and lookup plugins (no longer shipped with rpm) for byo/openshift-cluster/upgrades
+    file:
+      state: link
+      src: "../../../../../{{ item[0] }}"
+      dest: "{{ vendored_dir }}/playbooks/byo/openshift-cluster/upgrades/{{ item[1].path | basename }}/{{ item[0] }}"
+    with_nested:
+    - [ 'filter_plugins', 'lookup_plugins' ]
+    - "{{ upgrade_versions.files }}"
+
   - name: Symlink the openshift version to the installer
     file:
       state: link

--- a/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_3/filter_plugins
+++ b/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_3/filter_plugins
@@ -1,0 +1,1 @@
+../../../../../filter_plugins

--- a/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_3/lookup_plugins
+++ b/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_3/lookup_plugins
@@ -1,0 +1,1 @@
+../../../../../lookup_plugins

--- a/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_4/filter_plugins
+++ b/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_4/filter_plugins
@@ -1,0 +1,1 @@
+../../../../../filter_plugins

--- a/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_4/lookup_plugins
+++ b/openshift/installer/vendored/openshift-ansible-3.5.2/playbooks/byo/openshift-cluster/upgrades/v3_4/lookup_plugins
@@ -1,0 +1,1 @@
+../../../../../lookup_plugins


### PR DESCRIPTION
Now that we're calling playbooks in the version specific openshift-ansible upgrade sub-directories, we need symlinks there as well.