### PR TITLE
Fix typo in cron-send-docker-timer job

### DIFF
--- a/docker/oso-host-monitoring/centos7/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/centos7/container_setup/monitoring-config.yml
@@ -183,7 +183,7 @@ host_monitoring_cron:
 
 - name: run docker info timer
   minute: "*/10"
-  job: ops-runner -f -s 15 -n csdt.docker.timer /usr/bin/cron-send-docker-rimer
+  job: ops-runner -f -s 15 -n csdt.docker.timer /usr/bin/cron-send-docker-timer
 
 - name: run docker dns test on existing containers
   minute: "*/5"

--- a/docker/oso-host-monitoring/rhel7/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/rhel7/container_setup/monitoring-config.yml
@@ -183,7 +183,7 @@ host_monitoring_cron:
 
 - name: run docker info timer
   minute: "*/10"
-  job: ops-runner -f -s 15 -n csdt.docker.timer /usr/bin/cron-send-docker-rimer
+  job: ops-runner -f -s 15 -n csdt.docker.timer /usr/bin/cron-send-docker-timer
 
 - name: run docker dns test on existing containers
   minute: "*/5"

--- a/docker/oso-host-monitoring/src/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/src/container_setup/monitoring-config.yml
@@ -183,7 +183,7 @@ host_monitoring_cron:
 
 - name: run docker info timer
   minute: "*/10"
-  job: ops-runner -f -s 15 -n csdt.docker.timer /usr/bin/cron-send-docker-rimer
+  job: ops-runner -f -s 15 -n csdt.docker.timer /usr/bin/cron-send-docker-timer
 
 - name: run docker dns test on existing containers
   minute: "*/5"


### PR DESCRIPTION
typo in cron job setup. script doesn't execute. fixed.