### PR TITLE
Carry restart hosts fix from upstream until next vendoring.

### DIFF
--- a/openshift/installer/vendored/openshift-ansible-3.5.5/playbooks/common/openshift-master/restart_hosts.yml
+++ b/openshift/installer/vendored/openshift-ansible-3.5.5/playbooks/common/openshift-master/restart_hosts.yml
@@ -7,14 +7,26 @@
   ignore_errors: true
   become: yes
 
+# WARNING: This process is riddled with weird behavior.
+
+# Workaround for https://github.com/ansible/ansible/issues/21269
+- set_fact:
+    wait_for_host: "{{ ansible_host }}"
+
+# Ansible's blog documents this *without* the port, which appears to now
+# just wait until the timeout value and then proceed without checking anything.
+# port is now required.
+#
+# However neither ansible_ssh_port or ansible_port are reliably defined, likely
+# only if overridden. Assume a default of 22.
 - name: Wait for master to restart
   local_action:
     module: wait_for
-      host="{{ ansible_host }}"
+      host="{{ wait_for_host }}"
       state=started
       delay=10
       timeout=600
-      port="{{ ansible_ssh_port }}"
+      port="{{ ansible_port | default(ansible_ssh_port | default(22,boolean=True),boolean=True) }}"
   become: no
 
 # Now that ssh is back up we can wait for API on the remote system,
@@ -25,3 +37,4 @@
     state: started
     delay: 10
     port: "{{ openshift.master.api_port }}"
+


### PR DESCRIPTION
This is commit 781d2a1dc87bdc37f02ea6f1a3e83abb666f9c49 in
openshift-ansible.

It has been merged and will therefore be picked up next time we vendor
in a new version.