### PR TITLE
raise exception when walking through object path

### DIFF
--- a/ansible/roles/lib_yaml_editor/build/src/yedit.py
+++ b/ansible/roles/lib_yaml_editor/build/src/yedit.py
@@ -113,7 +113,8 @@ class Yedit(object):
                     continue
 
                 elif data and not isinstance(data, dict):
-                    return None
+                    raise YeditException("Unexpected item type found while going through key " +
+                                         "path: {} (at key: {})".format(key, dict_key))
 
                 data[dict_key] = {}
                 data = data[dict_key]
@@ -121,7 +122,7 @@ class Yedit(object):
             elif arr_ind and isinstance(data, list) and int(arr_ind) <= len(data) - 1:
                 data = data[int(arr_ind)]
             else:
-                return None
+                raise YeditException("Unexpected item type found while going through key path: {}".format(key))
 
         if key == '':
             data = item
@@ -134,6 +135,12 @@ class Yedit(object):
         # expected dict entry
         elif key_indexes[-1][1] and isinstance(data, dict):
             data[key_indexes[-1][1]] = item
+
+        # didn't add/update to an existing list, nor add/update key to a dict
+        # so we must have been provided some syntax like a.b.c[<int>] = "data" for a
+        # non-existent array
+        else:
+            raise YeditException("Error adding data to object at path: {}".format(key))
 
         return data
 

--- a/ansible/roles/lib_yaml_editor/library/yedit.py
+++ b/ansible/roles/lib_yaml_editor/library/yedit.py
@@ -278,7 +278,8 @@ class Yedit(object):
                     continue
 
                 elif data and not isinstance(data, dict):
-                    return None
+                    raise YeditException("Unexpected item type found while going through key " +
+                                         "path: {} (at key: {})".format(key, dict_key))
 
                 data[dict_key] = {}
                 data = data[dict_key]
@@ -286,7 +287,7 @@ class Yedit(object):
             elif arr_ind and isinstance(data, list) and int(arr_ind) <= len(data) - 1:
                 data = data[int(arr_ind)]
             else:
-                return None
+                raise YeditException("Unexpected item type found while going through key path: {}".format(key))
 
         if key == '':
             data = item
@@ -299,6 +300,12 @@ class Yedit(object):
         # expected dict entry
         elif key_indexes[-1][1] and isinstance(data, dict):
             data[key_indexes[-1][1]] = item
+
+        # didn't add/update to an existing list, nor add/update key to a dict
+        # so we must have been provided some syntax like a.b.c[<int>] = "data" for a
+        # non-existent array
+        else:
+            raise YeditException("Error adding data to object at path: {}".format(key))
 
         return data
 


### PR DESCRIPTION
if we're given path a.b.c and the existing object is:
    a:
     b:
      - item1
    raise an exception due to unexpected objects found while traversing the path
    
also, add_entry assumes new dicts for each sub element when creating elements besides the final assignment value.
doing something like a.b.c[0] = 12 where 'c' doesn't exist raises an exception
    
add test cases to cover:
 access path that differs from existing object
 create new objects with an embedded list in the path
 create new object with a list at the end (define the end list in the passed in 'value' to avoid this exception)