### PR TITLE
Make ops-runner random sleeps deterministic by host

### DIFF
--- a/scripts/monitoring/ops-runner.py
+++ b/scripts/monitoring/ops-runner.py
@@ -43,6 +43,7 @@ class OpsRunner(object):
 
     def __init__(self):
         """ constructor """
+        self.args = None
         self.parse_args()
         self.tmp_file_handle = None
         self.lock_file_handle = None
@@ -86,7 +87,12 @@ class OpsRunner(object):
     def check_sleep(self):
         """ pause for a random number (bounded) of seconds if needed"""
         if self.args.random_sleep:
-            seconds = random.randrange(int(self.args.random_sleep))
+            rand = random.Random()
+            # seed the rng using the hostname and check name. That means that for each hostname/check,
+            # it will sleep the same amount every time for a given self.args.random_sleep
+            rand.seed(hash(socket.gethostname()+self.args.name))
+
+            seconds = rand.randrange(int(self.args.random_sleep))
             self.verbose_print("Sleeping %s seconds..." % seconds)
             time.sleep(seconds)
 


### PR DESCRIPTION
With this change, for a check that runs every hour on every host,
a random sleep of 3600 will evenly spread the run times out across
the environment while guaranteeing that each check will run with
the same interval for a single host.