### PR TITLE
host-monitoring: Have docker mount needed paths for hostpkg checks

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
+++ b/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
@@ -54,6 +54,15 @@ ExecStart=/usr/bin/docker run --name {{ osohm_host_monitoring }}                
            -v /usr/bin/oc:/usr/bin/oc                                                               \
            -v /usr/bin/oadm:/usr/bin/oadm                                                           \
            -v /var/lib/rpm:/host/var/lib/rpm:ro                                                     \
+           -v /etc/rhsm/ca:/host/etc/rhsm/ca:ro                                                     \
+           -v /etc/openshift_tools:/host/etc/openshift_tools:ro                                     \
+           -v /etc/pki/entitlement:/host/etc/pki/entitlement:ro                                     \
+           -v /etc/pki/rpm-gpg:/host/etc/pki/rpm-gpg:ro                                             \
+           -v /etc/yum:/host/etc/yum:ro                                                             \
+           -v /etc/yum.conf:/host/etc/yum.conf:ro                                                   \
+           -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro                                             \
+           -v /var/lib/yum:/host/var/lib/yum:ro                                                     \
+           -v /var/cache/yum:/host/var/cache/yum:rw                                                 \
            -v /etc/openshift_tools:/container_setup:ro                                              \
            {{ osohm_docker_registry_url }}{{ osohm_host_monitoring }}:{{ osohm_environment }}
 

--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -66,6 +66,7 @@ RUN yum clean metadata && \
         python-httplib2 python-oauth2client \
         python-pyasn1 python-pyasn1-modules python-rsa \
         openvswitch \
+        python-configobj \
         python-psutil \
         pylint \
         tito \
@@ -85,6 +86,26 @@ RUN yum install -y patch && yum clean all && cd /usr/lib/python2.7/site-packages
 
 # Add copr repo for python-hawkular-client rpm
 RUN cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/g/Hawkular/python-hawkular-client/repo/epel-7/group_Hawkular-python-hawkular-client-epel-7.repo
+
+# make mount points for security update count check, and make a circular symlink because yum is dumb about its root
+RUN mkdir -p /host/etc/openshift_tools \
+             /host/etc/rpm \
+             /host/etc/pki/entitlement \
+             /host/etc/pki/rpm-gpg \
+             /host/etc/rhsm/ca \
+             /host/etc/yum \
+             /host/etc/yum.repos.d \
+             /host/var/lib/rpm \
+             /host/var/lib/yum \
+             /host/var/cache/yum \
+             /var/local/hostpkg/etc/rhsm/ca \
+             /var/local/hostpkg/etc/rpm \
+             /var/local/hostpkg/etc/pki/entitlement \
+             /var/local/hostpkg/etc/pki/rpm-gpg \
+             /var/local/hostpkg/var/local \
+             /var/local/hostpkg/var/cache/yum \
+             /var/local/hostpkg/var/lib/yum && \
+    ln -s /var/local/hostpkg /var/local/hostpkg/var/local/hostpkg
 
 # Install python-hawkular-client
 RUN yum install -y python-hawkular-client && yum clean all

--- a/docker/oso-host-monitoring/centos7/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/centos7/container_setup/monitoring-config.yml
@@ -192,3 +192,9 @@ host_monitoring_cron:
 - name: run docker conatiner usage collector
   minute: "*"
   job: ops-runner -f -s 15 -n csdcu.disc.docker.container /usr/bin/cron-send-docker-containers-usage
+
+- name: check for pending security updates once per day
+  minute: "0"
+  hour:   "10"
+  # 43200 is 12 hours. Spread the checks out across a half day
+  job: ops-runner -f -s 43200 -n cssuc.security.updates.count /usr/bin/cron-send-security-updates-count

--- a/docker/oso-host-monitoring/centos7/root/config.yml
+++ b/docker/oso-host-monitoring/centos7/root/config.yml
@@ -1,6 +1,14 @@
 ---
 - hosts: localhost
   gather_facts: no
+  vars:
+    hostpkg_bindmnt_dirs:
+    - /etc/rhsm/ca
+    - /etc/pki/entitlement
+    - /etc/pki/rpm-gpg
+    - /etc/rpm
+    - /var/lib/yum
+    - /var/cache/yum
 
   pre_tasks:
   - stat:
@@ -121,3 +129,18 @@
       dest: /root/.gce/creds.json
     when: gcp_volume_user_creds is defined
 
+  - name: "Create bind mountpoints for hostpkg checks"
+    file:
+      path: "/var/local/hostpkg{{ item }}"
+      state: directory
+      recurse: yes
+    with_items: "{{hostpkg_bindmnt_dirs}}"
+
+  - name: "Bind mount /host/ dirs to /var/local/hostpkg/ for hostpkg checks"
+    mount:
+      opts: bind
+      fstype: none
+      state: mounted
+      name: "/var/local/hostpkg{{ item }}"
+      src: "/host{{ item }}"
+    with_items: "{{hostpkg_bindmnt_dirs}}"

--- a/docker/oso-host-monitoring/centos7/run.sh
+++ b/docker/oso-host-monitoring/centos7/run.sh
@@ -32,6 +32,16 @@ sudo docker run --rm=true -it --name oso-centos7-host-monitoring \
            -v /var/lib/docker/volumes/shared:/shared:rw     \
            -v /var/run/docker.sock:/var/run/docker.sock     \
            -v /var/lib/rpm:/host/var/lib/rpm:ro             \
+           -v /etc/rhsm/ca:/host/etc/rhsm/ca:ro             \
+           -v /etc/openshift_tools:/host/etc/openshift_tools:ro \
+           -v /etc/pki/entitlement:/host/etc/pki/entitlement:ro \
+           -v /etc/pki/rpm-gpg:/host/etc/pki/rpm-gpg:ro     \
+           -v /etc/rpm:/host/etc/rpm:ro                     \
+           -v /etc/yum:/host/etc/yum:ro                     \
+           -v /etc/yum.conf:/host/etc/yum.conf:ro           \
+           -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro     \
+           -v /var/lib/yum:/host/var/lib/yum:ro             \
+           -v /var/cache/yum:/host/var/cache/yum:rw         \
            -v ${CONFIG_SOURCE}:/container_setup:ro \
            --memory 512m \
            oso-centos7-host-monitoring $@

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -60,6 +60,7 @@ RUN yum clean metadata && \
         python-httplib2 python-oauth2client \
         python-pyasn1 python-pyasn1-modules python-rsa \
         openvswitch \
+        python-configobj \
         python-psutil \
         pylint \
         tito \
@@ -77,6 +78,26 @@ RUN yum clean metadata && \
 
 ADD urllib3-connectionpool-patch /root/
 RUN yum install -y patch && yum clean all && cd /usr/lib/python2.7/site-packages/ && patch -p1 < /root/urllib3-connectionpool-patch
+
+# make mount points for security update count check, and make a circular symlink because yum is dumb about its root
+RUN mkdir -p /host/etc/openshift_tools \
+             /host/etc/rpm \
+             /host/etc/pki/entitlement \
+             /host/etc/pki/rpm-gpg \
+             /host/etc/rhsm/ca \
+             /host/etc/yum \
+             /host/etc/yum.repos.d \
+             /host/var/lib/rpm \
+             /host/var/lib/yum \
+             /host/var/cache/yum \
+             /var/local/hostpkg/etc/rhsm/ca \
+             /var/local/hostpkg/etc/rpm \
+             /var/local/hostpkg/etc/pki/entitlement \
+             /var/local/hostpkg/etc/pki/rpm-gpg \
+             /var/local/hostpkg/var/local \
+             /var/local/hostpkg/var/cache/yum \
+             /var/local/hostpkg/var/lib/yum && \
+    ln -s /var/local/hostpkg /var/local/hostpkg/var/local/hostpkg
 
 # Install python-hawkular-client
 RUN yum install -y python-hawkular-client && yum clean all

--- a/docker/oso-host-monitoring/rhel7/container_setup/monitoring-config.yml
+++ b/docker/oso-host-monitoring/rhel7/container_setup/monitoring-config.yml
@@ -192,3 +192,9 @@ host_monitoring_cron:
 - name: run docker conatiner usage collector
   minute: "*"
   job: ops-runner -f -s 15 -n csdcu.disc.docker.container /usr/bin/cron-send-docker-containers-usage
+
+- name: check for pending security updates once per day
+  minute: "0"
+  hour:   "10"
+  # 43200 is 12 hours. Spread the checks out across a half day
+  job: ops-runner -f -s 43200 -n cssuc.security.updates.count /usr/bin/cron-send-security-updates-count

--- a/docker/oso-host-monitoring/rhel7/root/config.yml
+++ b/docker/oso-host-monitoring/rhel7/root/config.yml
@@ -1,6 +1,14 @@
 ---
 - hosts: localhost
   gather_facts: no
+  vars:
+    hostpkg_bindmnt_dirs:
+    - /etc/rhsm/ca
+    - /etc/pki/entitlement
+    - /etc/pki/rpm-gpg
+    - /etc/rpm
+    - /var/lib/yum
+    - /var/cache/yum
 
   pre_tasks:
   - stat:
@@ -121,3 +129,18 @@
       dest: /root/.gce/creds.json
     when: gcp_volume_user_creds is defined
 
+  - name: "Create bind mountpoints for hostpkg checks"
+    file:
+      path: "/var/local/hostpkg{{ item }}"
+      state: directory
+      recurse: yes
+    with_items: "{{hostpkg_bindmnt_dirs}}"
+
+  - name: "Bind mount /host/ dirs to /var/local/hostpkg/ for hostpkg checks"
+    mount:
+      opts: bind
+      fstype: none
+      state: mounted
+      name: "/var/local/hostpkg{{ item }}"
+      src: "/host{{ item }}"
+    with_items: "{{hostpkg_bindmnt_dirs}}"

--- a/docker/oso-host-monitoring/rhel7/run.sh
+++ b/docker/oso-host-monitoring/rhel7/run.sh
@@ -32,6 +32,16 @@ sudo docker run --rm=true -it --name oso-rhel7-host-monitoring \
            -v /var/lib/docker/volumes/shared:/shared:rw     \
            -v /var/run/docker.sock:/var/run/docker.sock     \
            -v /var/lib/rpm:/host/var/lib/rpm:ro             \
+           -v /etc/rhsm/ca:/host/etc/rhsm/ca:ro             \
+           -v /etc/openshift_tools:/host/etc/openshift_tools:ro \
+           -v /etc/pki/entitlement:/host/etc/pki/entitlement:ro \
+           -v /etc/pki/rpm-gpg:/host/etc/pki/rpm-gpg:ro     \
+           -v /etc/rpm:/host/etc/rpm:ro                     \
+           -v /etc/yum:/host/etc/yum:ro                     \
+           -v /etc/yum.conf:/host/etc/yum.conf:ro           \
+           -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro     \
+           -v /var/lib/yum:/host/var/lib/yum:ro             \
+           -v /var/cache/yum:/host/var/cache/yum:rw         \
            -v ${CONFIG_SOURCE}:/container_setup:ro \
            --memory 512m \
            oso-rhel7-host-monitoring $@

--- a/docker/oso-host-monitoring/src/run.sh.j2
+++ b/docker/oso-host-monitoring/src/run.sh.j2
@@ -32,7 +32,6 @@ sudo docker run --rm=true -it --name oso-{{ base_os }}-host-monitoring \
            -v /etc/yum:/host/etc/yum:ro                     \
            -v /etc/yum.conf:/host/etc/yum.conf:ro           \
            -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro     \
-           -v /var/lib/rpm:/host/var/lib/rpm:ro             \
            -v /var/lib/yum:/host/var/lib/yum:ro             \
            -v /var/cache/yum:/host/var/cache/yum:rw         \
            -v ${CONFIG_SOURCE}:/container_setup:ro \


### PR DESCRIPTION
Also remove double-added /host/var/lib/rpm and generate
rhel7 and centos7 versions of the host monitoring container