### PR TITLE
new MetricSender/ZaggSender uses metric_sender.yaml for config info

### DIFF
--- a/ansible/roles/oso_monitoring_tools/tasks/main.yml
+++ b/ansible/roles/oso_monitoring_tools/tasks/main.yml
@@ -9,10 +9,12 @@
     - python-openshift-tools-monitoring-zagg
     - python-openshift-tools-monitoring-zabbix
 
-- debug: var=g_zagg_client_config
 
-- name: Generate the /etc/openshift_tools/zagg_client.yaml config file
+- name: Read in monitoring-config.yaml
+  include_vars: "/etc/openshift_tools/monitoring-config.yml"
+
+- name: Generate metric_sender.yaml config file
   copy:
-    content: "{{ osomt_zagg_client_config | to_nice_yaml }}"
-    dest: /etc/openshift_tools/zagg_client.yaml
+    content: "{{ metric_sender_config | to_nice_yaml }}"
+    dest: /etc/openshift_tools/metric_sender.yaml
     mode: "644"

--- a/ansible/roles/oso_monitoring_tools/vars/main.yml
+++ b/ansible/roles/oso_monitoring_tools/vars/main.yml
@@ -1,12 +1,2 @@
 ---
 # vars file for oso_monitoring_tools
-osomt_zagg_client_config:
-  host:
-    name: "{{ osomt_host_name }}"
-  zagg:
-    url: "{{ osomt_zagg_url }}"
-    user: "{{ osomt_zagg_user }}"
-    pass: "{{ osomt_zagg_password }}"
-    ssl_verify: "{{ osomt_zagg_ssl_verify }}"
-    verbose: "{{ osomt_zagg_verbose }}"
-    debug: "{{ osomt_zagg_debug }}"


### PR DESCRIPTION
generate that file from the intalled /etc/openshift_tools/monitoring-config.yml