### PR TITLE
don't apply PROXY env var changes to 3.3 clusters

### DIFF
--- a/ansible/roles/openshift_secure_router/README.md
+++ b/ansible/roles/openshift_secure_router/README.md
@@ -14,8 +14,11 @@ Ansible Modules:
 Role Variables
 --------------
 
-ossr_default_router_cert: path to the default router cert
-ossr_default_router_key: path to the default router key
+ossr_default_router_certs: list of paths to the router cert files
+ossr_default_router_keys: corresponding list of paths to the router key files (in same order as ossr_default_router_certs)
+ossr_default_router_cacert: path to chain certificate file for the certs/keys above
+ossr_routers: list of router objects with router configuration details per router
+ossr_cloud: one of aws or gcp that the OpenShift router is being configured for (will pull in cloud-specific router settings)
 
 Dependencies
 ------------

--- a/ansible/roles/openshift_secure_router/tasks/main.yml
+++ b/ansible/roles/openshift_secure_router/tasks/main.yml
@@ -8,12 +8,24 @@
   - "{{ ossr_default_router_keys }}"
   - "{{ ossr_default_router_cacert }}"
 
+- name: get OpenShift version
+  oc_version:
+  register: oc_version
+
 - name: Include cloud-specific router edits
   include_vars: "{{ ossr_cloud }}.yml"
 
+# pre-3.4 clusters should ignore PROXY env var settings from vars/aws.yml
+- name: Set router edit(s) list
+  set_fact:
+    ossr_router_edits: "{{ ossr_default_router_edits }}"
+  when: oc_version['result']['openshift_short'] | version_compare('3.4', '<')
+
+# anything beyond a 3.3 cluster should set the router up for PROXY protocol (from vars/aws.yml)
 - name: Merge default and cloud-specific router edits
   set_fact:
     ossr_router_edits: "{{ ossr_default_router_edits | union(ossr_cloud_router_edits) }}"
+  when: oc_version['result']['openshift_short'] | version_compare('3.4', '>=')
 
 - name: create routers
   oadm_router:


### PR DESCRIPTION
moving to PROXY-by-default is for 3.4, so don't add this setting for pre-3.4 clusters

also update README to more accurately reflect variables to be passed into the role