### PR TITLE
Add centos-release-openshift-origin for ansible 2.2

### DIFF
--- a/docker/oso-ops-base/centos7/Dockerfile
+++ b/docker/oso-ops-base/centos7/Dockerfile
@@ -12,7 +12,8 @@ FROM centos:centos7
 # Pause indefinitely if asked to do so.
 RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
-
+# Temporary fix while ansible-2.2.0.0 isn't available in EPEL
+RUN yum -y install centos-release-openshift-origin && yum clean all
 ADD copr-openshift-tools.repo /etc/yum.repos.d/
 
 # creature comforts (make it feel like a normal linux environment)

--- a/docker/oso-ops-base/src/Dockerfile.j2
+++ b/docker/oso-ops-base/src/Dockerfile.j2
@@ -16,7 +16,8 @@ RUN yum repolist --disablerepo=* && \
     yum-config-manager --disable \* > /dev/null && \
     yum-config-manager --enable rhel-7-server-rpms rhel-7-server-extras-rpms
 {% elif base_os == "centos7" %}
-
+# Temporary fix while ansible-2.2.0.0 isn't available in EPEL
+RUN yum -y install centos-release-openshift-origin && yum clean all
 ADD copr-openshift-tools.repo /etc/yum.repos.d/
 {% endif %}
 


### PR DESCRIPTION
Ansible 2.2.0.0 isn't yet available in epel