### PR TITLE
Add container-build-env-fingerprint generation

### DIFF
--- a/docker/roles/generate_containers/tasks/main.yml
+++ b/docker/roles/generate_containers/tasks/main.yml
@@ -57,6 +57,15 @@
     state: absent
   with_items: "{{ template_list.results }}"
 
+- name: Check if container-build-env-fingerprint.sh exists
+  stat:
+    path: "./{{ base_os }}/container-build-env-fingerprint.sh"
+  register: container_build_env_fingerprint
+
+- name: Create the container-build-env-fingerprint
+  shell: "./{{ base_os }}/container-build-env-fingerprint.sh > ./{{ base_os }}/container-build-env-fingerprint"
+  when: container_build_env_fingerprint.stat.exists == True
+
 - name: Insert auto-generated readme
   copy:
     content: |


### PR DESCRIPTION
I'm not sure how well this would be received, but I would like to open discussion for keeping the container-build-env-fingerprint as an autogenerated file.

If using the OpenShift build or DockerHub build facilities to generate the image, the build will fail because of the missing file.