### PR TITLE
use centos-release-openshift-origin repo on CentOS

### DIFF
--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -36,13 +36,6 @@ ADD check-pmcd-status.sh /usr/local/bin/check-pmcd-status.sh
 RUN echo -e "\n\nalias oca='KUBECONFIG=/tmp/admin.kubeconfig oc '" >> /root/.bashrc
 RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oadm '" >> /root/.bashrc
 
-# Need to manually install the RPMs, since yum will get confused
-# when resolving dependencies for /usr/bin/oc and /usr/bin/oadm
-# in python-openshift-tools-monitoring-openshift.rpm using the
-# maxamillion/origin-next copr repository below
-RUN cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo
-RUN yum install -y origin origin-clients
-
 RUN yum clean metadata && \
     yum install -y python-pip pcp pcp-conf pcp-testsuite \
         python-requests pyOpenSSL \

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -36,7 +36,6 @@ ADD check-pmcd-status.sh /usr/local/bin/check-pmcd-status.sh
 RUN echo -e "\n\nalias oca='KUBECONFIG=/tmp/admin.kubeconfig oc '" >> /root/.bashrc
 RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oadm '" >> /root/.bashrc
 
-
 RUN yum clean metadata && \
     yum install -y python-pip pcp pcp-conf pcp-testsuite \
         python-requests pyOpenSSL \

--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -32,15 +32,6 @@ ADD check-pmcd-status.sh /usr/local/bin/check-pmcd-status.sh
 RUN echo -e "\n\nalias oca='KUBECONFIG=/tmp/admin.kubeconfig oc '" >> /root/.bashrc
 RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oadm '" >> /root/.bashrc
 
-{% if base_os == "centos7" %}
-# Need to manually install the RPMs, since yum will get confused
-# when resolving dependencies for /usr/bin/oc and /usr/bin/oadm
-# in python-openshift-tools-monitoring-openshift.rpm using the
-# maxamillion/origin-next copr repository below
-RUN cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo
-RUN yum install -y origin origin-clients
-{% endif %}
-
 RUN yum clean metadata && \
     yum install -y python-pip pcp pcp-conf pcp-testsuite \
         python-requests pyOpenSSL \

--- a/docker/oso-ops-base/centos7/Dockerfile
+++ b/docker/oso-ops-base/centos7/Dockerfile
@@ -12,6 +12,8 @@ FROM centos:centos7
 # Pause indefinitely if asked to do so.
 RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
+# centos openshift repo
+RUN yum install -y centos-release-openshift-origin && yum clean all
 
 ADD copr-openshift-tools.repo /etc/yum.repos.d/
 

--- a/docker/oso-ops-base/src/Dockerfile.j2
+++ b/docker/oso-ops-base/src/Dockerfile.j2
@@ -16,6 +16,8 @@ RUN yum repolist --disablerepo=* && \
     yum-config-manager --disable \* > /dev/null && \
     yum-config-manager --enable rhel-7-server-rpms rhel-7-server-extras-rpms
 {% elif base_os == "centos7" %}
+# centos openshift repo
+RUN yum install -y centos-release-openshift-origin && yum clean all
 
 ADD copr-openshift-tools.repo /etc/yum.repos.d/
 {% endif %}


### PR DESCRIPTION
this allows us to use different ansible versions than what is found on EPEL
this allows us to use more up-to-date origin RPMs (for 'oc' and 'oadm' binaries)