### PR TITLE
Revert "Lower the critical memory alert to avg"

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_os_linux.yml
+++ b/ansible/roles/os_zabbix/vars/template_os_linux.yml
@@ -308,7 +308,7 @@ g_template_os_linux:
   - name: "Critical lack of available memory on {HOST.NAME}"
     expression: "{Template OS Linux:mem.util.available.last()}<314572800"
     url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_memory.asciidoc"
-    priority: avg
+    priority: high
 
   - name: "Lack of available memory on {HOST.NAME}"
     expression: "{Template OS Linux:mem.util.available.last()}<524288000"


### PR DESCRIPTION
This reverts commit f736700ae4f40609ee59a0b88f3607887f66ab8a.

#2223 to prod