### PR TITLE
Mount the entire host FS on the host monitoring container's /host

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
+++ b/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
@@ -53,15 +53,7 @@ ExecStart=/usr/bin/docker run --name {{ osohm_host_monitoring }}                
 {% endif %}
            -v /usr/bin/oc:/usr/bin/oc                                                               \
            -v /usr/bin/oadm:/usr/bin/oadm                                                           \
-           -v /var/lib/rpm:/host/var/lib/rpm:ro                                                     \
-           -v /etc/rhsm/ca:/host/etc/rhsm/ca:ro                                                     \
-           -v /etc/openshift_tools:/host/etc/openshift_tools:ro                                     \
-           -v /etc/pki/entitlement:/host/etc/pki/entitlement:ro                                     \
-           -v /etc/pki/rpm-gpg:/host/etc/pki/rpm-gpg:ro                                             \
-           -v /etc/yum:/host/etc/yum:ro                                                             \
-           -v /etc/yum.conf:/host/etc/yum.conf:ro                                                   \
-           -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro                                             \
-           -v /var/lib/yum:/host/var/lib/yum:ro                                                     \
+           -v /:/host:ro                                                                            \
            -v /var/cache/yum:/host/var/cache/yum:rw                                                 \
            -v /etc/openshift_tools:/container_setup:ro                                              \
            {{ osohm_docker_registry_url }}{{ osohm_host_monitoring }}:{{ osohm_environment }}

--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -82,16 +82,7 @@ RUN yum install -y patch && yum clean all && cd /usr/lib/python2.7/site-packages
 RUN cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/g/Hawkular/python-hawkular-client/repo/epel-7/group_Hawkular-python-hawkular-client-epel-7.repo
 
 # make mount points for security update count check, and make a circular symlink because yum is dumb about its root
-RUN mkdir -p /host/etc/openshift_tools \
-             /host/etc/rpm \
-             /host/etc/pki/entitlement \
-             /host/etc/pki/rpm-gpg \
-             /host/etc/rhsm/ca \
-             /host/etc/yum \
-             /host/etc/yum.repos.d \
-             /host/var/lib/rpm \
-             /host/var/lib/yum \
-             /host/var/cache/yum \
+RUN mkdir -p /host \
              /var/local/hostpkg/etc/rhsm/ca \
              /var/local/hostpkg/etc/rpm \
              /var/local/hostpkg/etc/pki/entitlement \

--- a/docker/oso-host-monitoring/centos7/run.sh
+++ b/docker/oso-host-monitoring/centos7/run.sh
@@ -31,16 +31,7 @@ sudo docker run --rm=true -it --name oso-centos7-host-monitoring \
            -v /var/lib/docker:/var/lib/docker:ro            \
            -v /var/lib/docker/volumes/shared:/shared:rw     \
            -v /var/run/docker.sock:/var/run/docker.sock     \
-           -v /var/lib/rpm:/host/var/lib/rpm:ro             \
-           -v /etc/rhsm/ca:/host/etc/rhsm/ca:ro             \
-           -v /etc/openshift_tools:/host/etc/openshift_tools:ro \
-           -v /etc/pki/entitlement:/host/etc/pki/entitlement:ro \
-           -v /etc/pki/rpm-gpg:/host/etc/pki/rpm-gpg:ro     \
-           -v /etc/rpm:/host/etc/rpm:ro                     \
-           -v /etc/yum:/host/etc/yum:ro                     \
-           -v /etc/yum.conf:/host/etc/yum.conf:ro           \
-           -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro     \
-           -v /var/lib/yum:/host/var/lib/yum:ro             \
+           -v /:/host:ro                                    \
            -v /var/cache/yum:/host/var/cache/yum:rw         \
            -v ${CONFIG_SOURCE}:/container_setup:ro \
            --memory 512m \

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -80,16 +80,7 @@ ADD urllib3-connectionpool-patch /root/
 RUN yum install -y patch && yum clean all && cd /usr/lib/python2.7/site-packages/ && patch -p1 < /root/urllib3-connectionpool-patch
 
 # make mount points for security update count check, and make a circular symlink because yum is dumb about its root
-RUN mkdir -p /host/etc/openshift_tools \
-             /host/etc/rpm \
-             /host/etc/pki/entitlement \
-             /host/etc/pki/rpm-gpg \
-             /host/etc/rhsm/ca \
-             /host/etc/yum \
-             /host/etc/yum.repos.d \
-             /host/var/lib/rpm \
-             /host/var/lib/yum \
-             /host/var/cache/yum \
+RUN mkdir -p /host \
              /var/local/hostpkg/etc/rhsm/ca \
              /var/local/hostpkg/etc/rpm \
              /var/local/hostpkg/etc/pki/entitlement \

--- a/docker/oso-host-monitoring/rhel7/run.sh
+++ b/docker/oso-host-monitoring/rhel7/run.sh
@@ -31,16 +31,7 @@ sudo docker run --rm=true -it --name oso-rhel7-host-monitoring \
            -v /var/lib/docker:/var/lib/docker:ro            \
            -v /var/lib/docker/volumes/shared:/shared:rw     \
            -v /var/run/docker.sock:/var/run/docker.sock     \
-           -v /var/lib/rpm:/host/var/lib/rpm:ro             \
-           -v /etc/rhsm/ca:/host/etc/rhsm/ca:ro             \
-           -v /etc/openshift_tools:/host/etc/openshift_tools:ro \
-           -v /etc/pki/entitlement:/host/etc/pki/entitlement:ro \
-           -v /etc/pki/rpm-gpg:/host/etc/pki/rpm-gpg:ro     \
-           -v /etc/rpm:/host/etc/rpm:ro                     \
-           -v /etc/yum:/host/etc/yum:ro                     \
-           -v /etc/yum.conf:/host/etc/yum.conf:ro           \
-           -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro     \
-           -v /var/lib/yum:/host/var/lib/yum:ro             \
+           -v /:/host:ro                                    \
            -v /var/cache/yum:/host/var/cache/yum:rw         \
            -v ${CONFIG_SOURCE}:/container_setup:ro \
            --memory 512m \

--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -86,16 +86,7 @@ RUN cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/g/Haw
 {% endif %}
 
 # make mount points for security update count check, and make a circular symlink because yum is dumb about its root
-RUN mkdir -p /host/etc/openshift_tools \
-             /host/etc/rpm \
-             /host/etc/pki/entitlement \
-             /host/etc/pki/rpm-gpg \
-             /host/etc/rhsm/ca \
-             /host/etc/yum \
-             /host/etc/yum.repos.d \
-             /host/var/lib/rpm \
-             /host/var/lib/yum \
-             /host/var/cache/yum \
+RUN mkdir -p /host \
              /var/local/hostpkg/etc/rhsm/ca \
              /var/local/hostpkg/etc/rpm \
              /var/local/hostpkg/etc/pki/entitlement \

--- a/docker/oso-host-monitoring/src/run.sh.j2
+++ b/docker/oso-host-monitoring/src/run.sh.j2
@@ -23,16 +23,7 @@ sudo docker run --rm=true -it --name oso-{{ base_os }}-host-monitoring \
            -v /var/lib/docker:/var/lib/docker:ro            \
            -v /var/lib/docker/volumes/shared:/shared:rw     \
            -v /var/run/docker.sock:/var/run/docker.sock     \
-           -v /var/lib/rpm:/host/var/lib/rpm:ro             \
-           -v /etc/rhsm/ca:/host/etc/rhsm/ca:ro             \
-           -v /etc/openshift_tools:/host/etc/openshift_tools:ro \
-           -v /etc/pki/entitlement:/host/etc/pki/entitlement:ro \
-           -v /etc/pki/rpm-gpg:/host/etc/pki/rpm-gpg:ro     \
-           -v /etc/rpm:/host/etc/rpm:ro                     \
-           -v /etc/yum:/host/etc/yum:ro                     \
-           -v /etc/yum.conf:/host/etc/yum.conf:ro           \
-           -v /etc/yum.repos.d:/host/etc/yum.repos.d:ro     \
-           -v /var/lib/yum:/host/var/lib/yum:ro             \
+           -v /:/host:ro                                    \
            -v /var/cache/yum:/host/var/cache/yum:rw         \
            -v ${CONFIG_SOURCE}:/container_setup:ro \
            --memory 512m \


### PR DESCRIPTION
The entirety of the hosts filesystem will now be visible (read-only)
in the host monitoring container so that security scans can be
run on the host from within the container.