### PR TITLE
Change memory level and change the metrics trigger on last 2 value

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_metrics.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_metrics.yml
@@ -9,8 +9,8 @@ g_template_metrics:
     value_type: int
 
   ztriggers:
-  - name: "OpenShift Metrics failed on {HOST.NAME}"
-    expression: "{Template OpenShift Metrics:openshift.metrics.nodes_reporting.last()}<1"
+  - name: "OpenShift Metrics failed 2 times on {HOST.NAME}"
+    expression: "{Template OpenShift Metrics:openshift.metrics.nodes_reporting.sum(#2)}<1"
     url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_metrics.asciidoc"
     priority: high
 

--- a/ansible/roles/os_zabbix/vars/template_os_linux.yml
+++ b/ansible/roles/os_zabbix/vars/template_os_linux.yml
@@ -308,7 +308,7 @@ g_template_os_linux:
   - name: "Critical lack of available memory on {HOST.NAME}"
     expression: "{Template OS Linux:mem.util.available.last()}<314572800"
     url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_memory.asciidoc"
-    priority: high
+    priority: average
 
   - name: "Lack of available memory on {HOST.NAME}"
     expression: "{Template OS Linux:mem.util.available.last()}<524288000"


### PR DESCRIPTION
since we have bug for the "Critical lack of available Memory", so temp change the trigger level from high to average to reduce some noisy 

metrics changed to check on the last 2 value of the key , if both failed , alert