### PR TITLE
add checks for docker usage of rss and vms

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_docker.yml
+++ b/ansible/roles/os_zabbix/vars/template_docker.yml
@@ -17,6 +17,18 @@ g_template_docker:
     - Docker Daemon
     value_type: int
 
+  - key: docker.memoryusage.rss
+    applications:
+    - Docker Daemon
+    value_type: int
+    units: B
+
+  - key: docker.memoryusage.vms
+    applications:
+    - Docker Daemon
+    value_type: int
+    units: B
+
   - key: docker.container.dns.resolution
     applications:
     - Docker Container

--- a/scripts/monitoring/cron-send-docker-metrics.py
+++ b/scripts/monitoring/cron-send-docker-metrics.py
@@ -16,15 +16,35 @@ from openshift_tools.monitoring.metric_sender import MetricSender
 from openshift_tools.timeout import TimeoutException
 from openshift_tools.monitoring.dockerutil import DockerUtil
 import json
+import psutil
+
+def getRssVmsofDocker():
+    """get rss and vms for docker"""
+    docker_memoryusage = {}
+    for proc in psutil.process_iter():
+        try:
+            pinfo = proc.as_dict(attrs=['pid', 'name'])
+            if pinfo['name'] == 'dockerd-current':
+                #print pinfo
+                docker_p = psutil.Process(pinfo['pid'])
+                #print docker_p.memory_info().rss
+                #print docker_p.memory_info().vms
+                docker_memoryusage['rss'] = docker_p.memory_info().rss
+                docker_memoryusage['vms'] = docker_p.memory_info().vms
+        except psutil.NoSuchProcess:
+            print 'error'
+
+    return docker_memoryusage
 
 if __name__ == "__main__":
     keys = None
     ms = MetricSender()
+
     try:
         cli = AutoVersionClient(base_url='unix://var/run/docker.sock')
         du = DockerUtil(cli)
         du_dds = du.get_disk_usage()
-
+        docker_memoryusages = getRssVmsofDocker()
         keys = {
             'docker.storage.data.space.used': du_dds.data_space_used,
             'docker.storage.data.space.available': du_dds.data_space_available,
@@ -39,6 +59,13 @@ if __name__ == "__main__":
             'docker.storage.is_loopback': int(du_dds.is_loopback),
             'docker.ping': 1, # Docker is up
         }
+        if docker_memoryusages.has_key('rss'):
+            keys['docker.memoryusage.rss'] = int(docker_memoryusages['rss'])
+            keys['docker.memoryusage.vms'] = int(docker_memoryusages['vms'])
+        else:
+            # this means this is a master , there is not dockerd
+            pass
+
     except (DockerException, TimeoutException) as ex:
         print "\nERROR talking to docker: %s\n" % ex.message
         keys = {


### PR DESCRIPTION
add checks for docker usage of rss and vms(https://trello.com/c/c5feqM7T/15-2-v3-monitoring-add-items-to-track-how-much-rss-and-vsz-memory-docker-is-taking)

@drewandersonnz  has +1 
https://github.com/openshift/openshift-tools/pull/2279
