### PR TITLE
 Use oc_volume to add the router configmap volume. 

### DIFF
--- a/ansible/roles/openshift_online_ha_proxy/tasks/main.yml
+++ b/ansible/roles/openshift_online_ha_proxy/tasks/main.yml
@@ -31,10 +31,15 @@
     oc create configmap customrouter -n default --from-file=/etc/openshift-online/templates/haproxy-config.template
   run_once: true
 
-# The oc_volume command does not currently support a configmap source. Falling back to command module.
 - name: Add a volume to the router
-  command: >
-    oc set volume dc/router --add --overwrite --name=config-volume --mount-path=/var/lib/haproxy/conf/custom --configmap-name=customrouter
+  oc_volume:
+    namespace: default
+    kind: dc
+    name: router
+    vol_name: config-volume
+    mount_type: configmap
+    mount_path: /var/lib/haproxy/conf/custom
+    configmap_name: customrouter
   run_once: true
 
 - name: Add our env vars to new customrouter


### PR DESCRIPTION
@jupierce, @themurph: PTAL.  The command works on a local `oc cluster up`.

Is there documentation on how the `meta/main.yml` dependencies are supposed to
work?  For my tests I hard-coded the paths to the modules, I'd like to be sure
they work with this change.