### PR TITLE
Restart Apache httpd if secrets change

### DIFF
--- a/ansible/roles/openshift_sso_app/tasks/main.yml
+++ b/ansible/roles/openshift_sso_app/tasks/main.yml
@@ -88,9 +88,9 @@
     service_name: sso
     host: "{{ osso_app_domain }}"
 
-- name: "Redeploy SSO app in {{ osso_namespace }} when secrets change or not running"
+- name: "Redeploy SSO app in {{ osso_namespace }} when not running"
   command: "oc deploy --latest -n {{ osso_namespace }} oso-saml-sso"
-  # if we just created the project, we should not try a re-deploy. Otherwise, we'll try if the pods don't seem to be running or if secrets change
+  # if we just created the project, we should not try a re-deploy. Otherwise, we'll try if the pods don't seem to be running
   when: "{{ not createout.changed and (osso_pods_running | select('match', '^oso-saml-sso$') | list | length < 3) }}"
 
 - name: "Redeploy memcache pod 1 in {{ osso_namespace }} when not running"

--- a/docker/oso-saml-sso/centos7/start.sh
+++ b/docker/oso-saml-sso/centos7/start.sh
@@ -41,6 +41,10 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
       echo "Reloading sshd config"
       pkill --signal HUP --pidfile /var/run/sshd.pid sshd
     fi
+    if [ -f /var/run/httpd/httpd.pid ]; then
+      echo "Reloading httpd config"
+      pkill --signal USR1 --pidfile /var/run/httpd/httpd.pid httpd
+    fi
     touch /configdata/initial_config
     # wait until the secrets change
     inotifywait -e DELETE_SELF "$config_version_dir"

--- a/docker/oso-saml-sso/rhel7/start.sh
+++ b/docker/oso-saml-sso/rhel7/start.sh
@@ -41,6 +41,10 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
       echo "Reloading sshd config"
       pkill --signal HUP --pidfile /var/run/sshd.pid sshd
     fi
+    if [ -f /var/run/httpd/httpd.pid ]; then
+      echo "Reloading httpd config"
+      pkill --signal USR1 --pidfile /var/run/httpd/httpd.pid httpd
+    fi
     touch /configdata/initial_config
     # wait until the secrets change
     inotifywait -e DELETE_SELF "$config_version_dir"

--- a/docker/oso-saml-sso/src/start.sh
+++ b/docker/oso-saml-sso/src/start.sh
@@ -41,6 +41,10 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
       echo "Reloading sshd config"
       pkill --signal HUP --pidfile /var/run/sshd.pid sshd
     fi
+    if [ -f /var/run/httpd/httpd.pid ]; then
+      echo "Reloading httpd config"
+      pkill --signal USR1 --pidfile /var/run/httpd/httpd.pid httpd
+    fi
     touch /configdata/initial_config
     # wait until the secrets change
     inotifywait -e DELETE_SELF "$config_version_dir"


### PR DESCRIPTION
Necessary when the cert/key pair that comes as a secret are changed

Also fix outdated comments w.r.t. pod restarts on secrets changes