### PR TITLE
Disable restricted name check for 3.5

### DIFF
--- a/openshift/installer/vendored/openshift-ansible-3.5.52/roles/lib_openshift/library/oc_objectvalidator.py
+++ b/openshift/installer/vendored/openshift-ansible-3.5.52/roles/lib_openshift/library/oc_objectvalidator.py
@@ -1340,18 +1340,10 @@ class OCObjectValidator(OpenShiftCLI):
         failed = False
 
         def _is_invalid_namespace(namespace):
-            # check if it uses a reserved name
-            name = namespace['metadata']['name']
-            if not any((name == 'kube',
-                        name == 'openshift',
-                        name.startswith('kube-'),
-                        name.startswith('openshift-'),)):
-                return False
-
-            # determine if the namespace was created by a user
-            if 'annotations' not in namespace['metadata']:
-                return False
-            return 'openshift.io/requester' in namespace['metadata']['annotations']
+            # Justin Pierce: patching to avoid this check. dev-preview-prod contains newly "invalid" namespaces created
+            # by users. Since dev-preview-prod is going to be decommissioned soon and there is no harm in leaving
+            # these around until that decommission.
+            return False
 
         checks = (
             (

--- a/openshift/installer/vendored/openshift-ansible-3.5.52/roles/lib_openshift/src/class/oc_objectvalidator.py
+++ b/openshift/installer/vendored/openshift-ansible-3.5.52/roles/lib_openshift/src/class/oc_objectvalidator.py
@@ -32,18 +32,10 @@ class OCObjectValidator(OpenShiftCLI):
         failed = False
 
         def _is_invalid_namespace(namespace):
-            # check if it uses a reserved name
-            name = namespace['metadata']['name']
-            if not any((name == 'kube',
-                        name == 'openshift',
-                        name.startswith('kube-'),
-                        name.startswith('openshift-'),)):
-                return False
-
-            # determine if the namespace was created by a user
-            if 'annotations' not in namespace['metadata']:
-                return False
-            return 'openshift.io/requester' in namespace['metadata']['annotations']
+            # Justin Pierce: patching to avoid this check. dev-preview-prod contains newly "invalid" namespaces created
+            # by users. Since dev-preview-prod is going to be decommissioned soon and there is no harm in leaving
+            # these around until that decommission.
+            return False
 
         checks = (
             (


### PR DESCRIPTION
Until https://github.com/openshift/origin/pull/13673/files is merged and installed, nothing prevents users from creating these restricted namespaces after the upgrade. A pointless check that would otherwise cause use to need to delete user data in dev-preview-prod was deemed removable by the technical team.