### PR TITLE
add openjdk rpm for systems that we initiate installations from

### DIFF
--- a/ansible/roles/ansible_tower/tasks/main.yaml
+++ b/ansible/roles/ansible_tower/tasks/main.yaml
@@ -12,6 +12,7 @@
   - pylint
   - firewalld
   - python-manageiq-client
+  - java-1.8.0-openjdk-headless
 
 - name: download Tower setup
   get_url: url=http://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-2.1.1.tar.gz dest=/opt/ force=no


### PR DESCRIPTION
required for the metrics installation piece of the openshift installer