### PR TITLE
catch and ignore epipe errors

### DIFF
--- a/scripts/inventory-clients/ossh
+++ b/scripts/inventory-clients/ossh
@@ -3,6 +3,7 @@
 ''' ssh wrapper with multi-inventory capabilities '''
 
 import argparse
+import errno
 import traceback
 import sys
 import os
@@ -48,7 +49,16 @@ class Ossh(object):
 
         # perform the SSH
         if self.args.list:
-            self.list_hosts()
+            try:
+                self.list_hosts()
+            # You can get IOErrors when piping output to another tool
+            # (ie 'head') b/c the pipe being written to is closed by
+            # the reader. This is okay. Catch and ignore EPIPE errors.
+            except IOError as e:
+                if e.errno == errno.EPIPE:
+                    pass
+                else:
+                    raise e
         else:
             self.ssh()
 


### PR DESCRIPTION
when doing something like:
  ossh --list | head

'head' will close the pipe and python will raise an IOError. It is okay for the program receiving the output of ossh to close the pipe once it is complete before processing all of the output.

Catch and ignore these EPIPE errors so that we can build things like:
  ossh --list | grep --max-count=1 clustername | awk '{ print $3 }'

...to get the environment for a particular cluster.