### PR TITLE
Remove the reference to k8s flatten hash

### DIFF
--- a/ansible/roles/openshift_logging/templates/logging-fluentd.yaml.j2
+++ b/ansible/roles/openshift_logging/templates/logging-fluentd.yaml.j2
@@ -27,7 +27,6 @@ data:
       @include configs.d/openshift/filter-retag-journal.conf
       @include configs.d/openshift/filter-k8s-meta.conf
       @include configs.d/openshift/filter-kibana-transform.conf
-      @include configs.d/openshift/filter-k8s-flatten-hash.conf
       @include configs.d/openshift/filter-k8s-record-transform.conf
       @include configs.d/openshift/filter-syslog-record-transform.conf
       ##


### PR DESCRIPTION
That configuration can break 3.4+ environments that need the
namespacing.