### PR TITLE
Resolve issues with redeployment of jenkins CI

### DIFF
--- a/jenkins/openshift-tools-pr-automation-template.json
+++ b/jenkins/openshift-tools-pr-automation-template.json
@@ -73,7 +73,7 @@
             "noCache": true,
             "env": [
                 {
-                  "name": "GITHUB_WEBHOOK_PAYLOAD",
+                  "name": "PULL_REQUEST",
                   "value": "{}"
                 },
                 {


### PR DESCRIPTION
The environment variable name for the pull request json data was
incorrect in the template for the buildConfig.

Additionally, some configuration steps were not specific enough or were
missing necessary actions.