### PR TITLE
allow dig ansible lookups

### DIFF
--- a/ansible/roles/ansible_tower/tasks/main.yaml
+++ b/ansible/roles/ansible_tower/tasks/main.yaml
@@ -13,6 +13,7 @@
   - firewalld
   - python-manageiq-client
   - java-1.8.0-openjdk-headless
+  - python-dns
 
 - name: download Tower setup
   get_url: url=http://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-2.1.1.tar.gz dest=/opt/ force=no


### PR DESCRIPTION
trying an ansible filter of lookup('dig'...) fails without python-dns RPM