### PR TITLE
Fix zabbix config loop problems.

### DIFF
--- a/ansible/roles/os_zabbix/tasks/main.yml
+++ b/ansible/roles/os_zabbix/tasks/main.yml
@@ -261,7 +261,7 @@
     user: "{{ ozb_user }}"
     password: "{{ ozb_password }}"
   tags:
-  - config_loop
+  - zabbix_config
 
 - name: Include Template OpenShift Metrics
   include: ../../lib_zabbix/tasks/create_template.yml

--- a/ansible/roles/os_zabbix/vars/template_docker.yml
+++ b/ansible/roles/os_zabbix/vars/template_docker.yml
@@ -114,17 +114,17 @@ g_template_docker:
     url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_docker_storage.asciidoc"
     priority: high
 
-
-  - name: "Critically High Memory usage of  docker  on {HOST.NAME}"
-    expression: "{Template Docker:docker.memoryusage.rss.last()}>6442450944"
-    url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_docker_memoryusage.asciidoc"
-    priority: average
-
-
   - name: "Critically High Memory usage of  docker  on {HOST.NAME}"
     expression: "{Template Docker:docker.memoryusage.rss.last()}>10737418240"
     url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_docker_memoryusage.asciidoc"
     priority: high
+
+  - name: "High Memory usage of  docker  on {HOST.NAME}"
+    expression: "{Template Docker:docker.memoryusage.rss.last()}>6442450944"
+    url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/check_docker_memoryusage.asciidoc"
+    dependencies:
+    - "Critically High Memory usage of  docker  on {HOST.NAME}"
+    priority: average
 
   - name: "Critically low docker storage metadata space on {HOST.NAME}"
     expression: "{Template Docker:docker.storage.metadata.space.percent_available.max(#2)}<5 or {Template Docker:docker.storage.metadata.space.available.max(#2)}<0.005" # < 5% or < 5MB


### PR DESCRIPTION
Fix zabbix config loop problems:
* zabbix_config wasn't actually configuring the zabbix_config template.
* two triggers for docker memory usage were named the same thing, causing one to overwrite the other. Depending on timeing, this was also causing zabbix-web to return a 504 on either the first or second attempt to define this trigger. This was meant to be 2 different triggers and as such needs to have 2 different names. Since these are related, there also needed to be a dependency setup. This PR adds those things.