### PR TITLE
3.5 Upgrade Cherry Picks and Logging fix

### DIFF
--- a/ansible/roles/openshift_dedicated_admin/tasks/main.yml
+++ b/ansible/roles/openshift_dedicated_admin/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install the OpenShift Dedicated Admin scripts
-  yum:
-    name: openshift-scripts-dedicated
-    state: present
-
 - name: Setup the OpenShift Dedicated Admin service config file
   lineinfile:
     dest: /etc/sysconfig/openshift-dedicated-role

--- a/ansible/roles/openshift_dedicated_scripts/README.md
+++ b/ansible/roles/openshift_dedicated_scripts/README.md
@@ -1,0 +1,31 @@
+openshift_dedicated_scripts
+=========
+
+Ansible role for ensuring openshift-dedicated-scripts rpm is installed, and if
+not choosing a correct version for the major version of OpenShift in play.
+
+
+Requirements
+------------
+
+
+Role Variables
+--------------
+
+
+Dependencies
+------------
+
+
+Example Playbook
+----------------
+
+License
+-------
+
+Apache 2.0
+
+Author Information
+------------------
+
+Openshift Operations

--- a/ansible/roles/openshift_dedicated_scripts/meta/main.yml
+++ b/ansible/roles/openshift_dedicated_scripts/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Max Whittingham
-  description: This role deploys the OpenShift Dedicated Admin Role
+  author: Devan Goodwin
+  description: Installs the correct version of openshift-dedicated-scripts for the major OpenShift version.
   company: Red Hat
   license: Apache
   min_ansible_version: 1.9
@@ -12,4 +12,4 @@ galaxy_info:
   categories:
   - cloud
 dependencies:
-- role: tools_roles/openshift_dedicated_scripts
+- role: tools_roles/lib_repoquery

--- a/ansible/roles/openshift_dedicated_scripts/tasks/install.yml
+++ b/ansible/roles/openshift_dedicated_scripts/tasks/install.yml
@@ -1,0 +1,32 @@
+---
+- name: Lookup installed major OpenShift version
+  repoquery:
+    name: atomic-openshift
+    query_type: installed
+  register: openshift_version_out
+  run_once: True
+  ignore_errors: true
+
+- debug: var=openshift_version_out
+
+- set_fact:
+    major_version: "{{ openshift_version_out.results.versions.latest.split('.')[0:2] | join('.') }}"
+
+- name: Lookup correct version of OpenShift Dedicated Admin scripts
+  repoquery:
+    name: openshift-scripts-dedicated
+    show_duplicates: True
+    match_version: "{{ major_version }}"
+  register: scripts_version_out
+  remote_user: root
+
+- debug: var=scripts_version_out
+
+- fail:
+    msg: "Unable to find a {{ major_version }} version of openshift-scripts-dedicated to install"
+  when: not scripts_version_out.results.versions['matched_version_found']
+
+- name: Install the OpenShift Dedicated Admin scripts
+  yum:
+    name: "openshift-scripts-dedicated-{{ scripts_version_out.results.versions.matched_version_latest }}"
+    state: present

--- a/ansible/roles/openshift_dedicated_scripts/tasks/main.yml
+++ b/ansible/roles/openshift_dedicated_scripts/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+# If openshift-scripts-dedicated is already installed, we don't want to
+# waste time doing anything, just leave it alone.
+
+- name: "Check if openshift-scripts-dedicated needs to be installed"
+  repoquery:
+    name: openshift-scripts-dedicated2
+    query_type: installed
+  register: scripts_installed_result
+  ignore_errors: True
+
+- set_fact:
+    scripts_installed: "{{ scripts_installed_result.results.package_found }}"
+
+# Skip everything if scripts is already installed.
+# NOTE: We may need to pass in an upgrade indicator here in future, but for now
+# the implied full master yum update should pick it up.
+- include: install.yml
+  when: not scripts_installed | bool

--- a/ansible/roles/openshift_volume_provisioner/meta/main.yml
+++ b/ansible/roles/openshift_volume_provisioner/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
 dependencies:
 - role: tools_roles/lib_yaml_editor
 - role: tools_roles/lib_openshift_3.2
+- role: tools_roles/openshift_dedicated_scripts

--- a/ansible/roles/openshift_volume_provisioner/tasks/main.yml
+++ b/ansible/roles/openshift_volume_provisioner/tasks/main.yml
@@ -5,11 +5,6 @@
   with_dict: "{{ osvp_provisioner_params }}"
   when: osvp_provisioner_params is undefined
 
-- name: install the openshift-scripts-dedicated
-  yum:
-    name: openshift-scripts-dedicated
-    state: installed
-
 - name: ensure the template file from openshift-scripts-dedicated has metadate.name. This should not be needed in the future
   yedit:
     src: /etc/openshift-dedicated/templates/volume-provisioner.yaml

--- a/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/README.md
+++ b/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/README.md
@@ -63,6 +63,7 @@ When `False` the `openshift_logging` role will uninstall Aggregated logging.
 - `openshift_logging_es_cluster_size`: The number of ES cluster members. Defaults to '1'.
 - `openshift_logging_es_cpu_limit`:  The amount of CPU limit for the ES cluster.  Unused if not set
 - `openshift_logging_es_memory_limit`: The amount of RAM that should be assigned to ES. Defaults to '8Gi'.
+- `openshift_logging_es_log_appenders`: The list of rootLogger appenders for ES logs which can be: 'file', 'console'. Defaults to 'file'.
 - `openshift_logging_es_pv_selector`: A key/value map added to a PVC in order to select specific PVs.  Defaults to 'None'.
 - `openshift_logging_es_pvc_dynamic`: Whether or not to add the dynamic PVC annotation for any generated PVCs. Defaults to 'False'.
 - `openshift_logging_es_pvc_size`: The requested size for the ES PVCs, when not provided the role will not generate any PVCs. Defaults to '""'.

--- a/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/defaults/main.yml
+++ b/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/defaults/main.yml
@@ -80,6 +80,8 @@ openshift_logging_es_client_cert: /etc/fluent/keys/cert
 openshift_logging_es_client_key: /etc/fluent/keys/key
 openshift_logging_es_cluster_size: "{{ openshift_hosted_logging_elasticsearch_cluster_size | default(1) }}"
 openshift_logging_es_cpu_limit: null
+# the logging appenders for the root loggers to write ES logs. Valid values: 'file', 'console'
+openshift_logging_es_log_appenders: ['file']
 openshift_logging_es_memory_limit: "{{ openshift_hosted_logging_elasticsearch_instance_ram | default('8Gi') }}"
 openshift_logging_es_pv_selector: null
 openshift_logging_es_pvc_dynamic: "{{ openshift_hosted_logging_elasticsearch_pvc_dynamic | default(False) }}"

--- a/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/tasks/generate_configmaps.yaml
+++ b/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/tasks/generate_configmaps.yaml
@@ -1,10 +1,20 @@
 ---
 - block:
-    - copy:
-        src: elasticsearch-logging.yml
+    - fail:
+        msg: "The openshift_logging_es_log_appenders '{{openshift_logging_es_log_appenders}}' has an unrecognized option and only supports the following as a list: {{es_log_appenders | join(', ')}}"
+      when:
+        - es_logging_contents is undefined
+        - "{{ openshift_logging_es_log_appenders | list | difference(es_log_appenders) | length != 0 }}"
+      changed_when: no
+
+    - template:
+        src: elasticsearch-logging.yml.j2
         dest: "{{mktemp.stdout}}/elasticsearch-logging.yml"
+      vars:
+        root_logger: "{{openshift_logging_es_log_appenders | join(', ')}}"
       when: es_logging_contents is undefined
       changed_when: no
+      check_mode: no
 
     - template:
         src: elasticsearch.yml.j2

--- a/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -97,7 +97,7 @@
   with_together:
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.keys() }}"
   - "{{ openshift_logging_facts.elasticsearch_ops.deploymentconfigs.values() }}"
-  - "{{ es_ops_indices }}"
+  - "{{ es_ops_indices | default([]) }}"
   loop_control:
     loop_var: deployment
   when:

--- a/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/templates/elasticsearch-logging.yml.j2
+++ b/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/templates/elasticsearch-logging.yml.j2
@@ -1,13 +1,24 @@
 # you can override this using by setting a system property, for example -Des.logger.level=DEBUG
 es.logger.level: INFO
-rootLogger: ${es.logger.level}, console, file
+rootLogger: ${es.logger.level}, {{root_logger}}
 logger:
   # log action execution errors for easier debugging
   action: WARN
+
+  # deprecation logging, turn to DEBUG to see them
+  deprecation: WARN, deprecation_log_file
+
   # reduce the logging for aws, too much is logged under the default INFO
   com.amazonaws: WARN
+
   io.fabric8.elasticsearch: ${PLUGIN_LOGLEVEL}
   io.fabric8.kubernetes: ${PLUGIN_LOGLEVEL}
+
+  # aws will try to do some sketchy JMX stuff, but its not needed.
+  com.amazonaws.jmx.SdkMBeanRegistrySupport: ERROR
+  com.amazonaws.metrics.AwsSdkMetrics: ERROR
+
+  org.apache.http: INFO
 
   # gateway
   #gateway: DEBUG
@@ -28,13 +39,14 @@ logger:
 additivity:
   index.search.slowlog: false
   index.indexing.slowlog: false
+  deprecation: false
 
 appender:
   console:
     type: console
     layout:
       type: consolePattern
-      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %.10000m%n"
 
   file:
     type: dailyRollingFile
@@ -44,16 +56,13 @@ appender:
       type: pattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
-  # Use the following log4j-extras RollingFileAppender to enable gzip compression of log files.
-  # For more information see https://logging.apache.org/log4j/extras/apidocs/org/apache/log4j/rolling/RollingFileAppender.html
-  #file:
-    #type: extrasRollingFile
-    #file: ${path.logs}/${cluster.name}.log
-    #rollingPolicy: timeBased
-    #rollingPolicy.FileNamePattern: ${path.logs}/${cluster.name}.log.%d{yyyy-MM-dd}.gz
-    #layout:
-      #type: pattern
-      #conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+  deprecation_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_deprecation.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
   index_search_slow_log_file:
     type: dailyRollingFile

--- a/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/vars/main.yaml
+++ b/openshift/installer/vendored/openshift-ansible-3.5.62/roles/openshift_logging/vars/main.yaml
@@ -8,3 +8,5 @@ es_recover_expected_nodes: "{{openshift_logging_es_cluster_size|int}}"
 es_ops_node_quorum: "{{openshift_logging_es_ops_cluster_size|int/2 + 1}}"
 es_ops_recover_after_nodes: "{{openshift_logging_es_ops_cluster_size|int - 1}}"
 es_ops_recover_expected_nodes: "{{openshift_logging_es_ops_cluster_size|int}}"
+
+es_log_appenders: ['file', 'console']


### PR DESCRIPTION
Main addition is a fix for the installation of latest openshift-scripts-dedicated every installation. Recently the 3.5 version of this package became incompatible for 3.4. Now we enforce use of an openshift-scripts-dedicated that matches the major OpenShift version. 

WARNING: The repos are not yet ready for this, only one version of the package can exist at any time, so every 3.5 build will break new 3.4 installs, every 3.4 build will break 3.5 installs. Have emailed about this but no one has solutions at this time.

Also included are two commits that are cherry picks from openshift-ansible release-1.5 branch, they will be picked up automatically if 3.5 is vendored again. Both fix issues in logging.