### PR TITLE
put more detailed check for whether zabbix is ready to be configured

### DIFF
--- a/docker/local_development/start-local-dev-env.sh
+++ b/docker/local_development/start-local-dev-env.sh
@@ -111,15 +111,15 @@ if [ "${GREP_RESULT}" == "" ]; then
 	sudo bash -c "echo '127.0.0.1  oso-cent7-zabbix-web' >> /etc/hosts"
 fi
 
-while [ "$(curl -k -s -o /dev/null -w %{http_code} https://oso-cent7-zabbix-web/zabbix/)" != "200" ]; do
-	echo "Waiting for zabbix to be ready"
-	sleep 5
+GREP_RESULT=""
+echo -n "Waiting for zabbix to be ready"
+while [ "$GREP_RESULT" == "" ]; do
+	sleep 1
+	echo -n "."
+	GREP_RESULT=$(curl -k https://oso-cent7-zabbix-web/zabbix/ 2>/dev/null | grep 'sign in as guest' || :)
 done
 
-
-echo "Sleeping for 300 seconds to wait for zabbix-web to really come up..."
-sleep 300
-
+echo " Done"
 echo "Config zabbix"
 PYTHONPATH=${OPENSHIFT_TOOLS_REPO}:${PYTHONPATH} ansible-playbook ../../ansible/playbooks/adhoc/zabbix_setup/oo-clean-zaio.yml -e g_server="https://oso-cent7-zabbix-web/zabbix/api_jsonrpc.php"
 PYTHONPATH=${OPENSHIFT_TOOLS_REPO}:${PYTHONPATH} ansible-playbook ../../ansible/playbooks/adhoc/zabbix_setup/oo-config-zaio.yml -e g_server="https://oso-cent7-zabbix-web/zabbix/api_jsonrpc.php"


### PR DESCRIPTION
attempt to access the web UI results in HTTP response '200' even when mysql isn't yet configured.

keep accessing the web UI until the HTML output includes the text 'sign in as guest' (which is some of the text you would find when the web UI was able to successfully talk to the mysql backend