### PR TITLE
Filter out JenkinsPipelines from stuck builds check, lower severity

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_master.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_master.yml
@@ -859,12 +859,12 @@ g_template_openshift_master:
   - name: "Too many new builds {HOST.NAME}"
     expression: "{Template Openshift Master:openshift.build_state.new.avg(#3)}>10"
     url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/build_count_alerts.asciidoc"
-    priority: high
+    priority: info
 
   - name: "Builds stuck in New state for longer than 3 minutes on {HOST.NAME}"
     expression: "{Template Openshift Master:openshift.stuck_builds.new.last()}>0"
     url: "https://github.com/openshift/ops-sop/blob/master/V3/Alerts/stuck_build_alerts.asciidoc"
-    priority: high
+    priority: info
 
   # Put triggers that depend on other triggers here (deps must be created first)
   - name: "Application creation has failed on {HOST.NAME}"

--- a/scripts/monitoring/cron-send-stuck-builds.py
+++ b/scripts/monitoring/cron-send-stuck-builds.py
@@ -69,8 +69,11 @@ def get_stuck_build_count(age, build_state):
     #get_builds="get builds -o=custom-columns=Phase:.status.phase,TS:.status.startTimestamp --all-namespaces"
 
     # go template method - shiny!
+    # template returns creationTimestamp for non-JenkinsPipeline builds in build_state
     get_new_build_timestamps = ("get builds --all-namespaces -o go-template='{{range .items}}"
-                                "{{if eq .status.phase \"%s\"}}{{.metadata.creationTimestamp}}"
+                                "{{if and (eq .status.phase \"%s\")"
+                                " (not (eq .spec.strategy.type \"JenkinsPipeline\"))}}"
+                                "{{.metadata.creationTimestamp}}"
                                 "{{print \"\\n\"}}{{end}}{{end}}'")
 
     all_ts = runOCcmd(get_new_build_timestamps % build_state).split()


### PR DESCRIPTION
This updated the stuck builds check to ignore JenkinsPipeline builds. It also lowers the severity of the "Builds stuck" and "Too many new builds" checks to Informational.