### PR TITLE
Revert "Patching comparison operation breaking with iptables lock message is …"

### DIFF
--- a/ansible/roles/lib_ops_utils/library/iptables_chain.py
+++ b/ansible/roles/lib_ops_utils/library/iptables_chain.py
@@ -230,17 +230,12 @@ def main():
     iptchain = IpTablesChain(table, name, ver)
     changed = False
 
-    iptchain_out = iptchain.get()
-
-    if 'Got the lock' in iptchain_out:
-        iptchain_out.remove('Got the lock')
-
     try:
-        if (not iptchain.exists()) or iptchain_out != rules:
+        if (not iptchain.exists()) or iptchain.get() != rules:
             iptchain.set(rules)
             if not iptchain.exists():
                 module.fail_json(msg="Chain create failed")
-            elif iptchain_out == rules:
+            elif iptchain.get() == rules:
                 changed = True
             else:
                 module.fail_json(msg="Chain update failed. Do input rules match 'iptables -S %s' output?" % name)


### PR DESCRIPTION
Reverts openshift/openshift-tools#2563

#2563 breaks the logic by not calling .get() twice. The right place to filter it if we wanted to is in get(), but we don't want to. The correct fix is to uninstall the version of iptables that @eparis installed on our nodes that prints this garbage message into iptables's stdout. If he really needs that message, then he needs to rebuild it to write to stderr instead of stdout.