### PR TITLE
Touch SSO container's reconfig touchfile via ansible

### DIFF
--- a/ansible/roles/openshift_sso_app/files/openshift_sso_app.yml
+++ b/ansible/roles/openshift_sso_app/files/openshift_sso_app.yml
@@ -331,8 +331,8 @@ objects:
               - --insecure
               - https://127.0.0.1:8443/status.php
             failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
+            initialDelaySeconds: 120
+            periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 2
           name: oso-saml-sso
@@ -346,8 +346,8 @@ objects:
               - -sf
               - --insecure
               - https://127.0.0.1:8443/status.php
-            failureThreshold: 3
-            initialDelaySeconds: 2
+            failureThreshold: 12
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2

--- a/docker/oso-saml-sso/centos7/root/config.yml
+++ b/docker/oso-saml-sso/centos7/root/config.yml
@@ -105,3 +105,11 @@
         content: "{{ saml2_sso_configdata.saml2_idp_cert_data.cert }}"
       - name: "{{ saml2_sso_configdata.saml_privatekey_file }}"
         content: "{{ saml2_sso_configdata.saml2_idp_cert_data.key }}"
+
+  # NOTE: this must be the final task because it indicates to
+  #       the start-up script that this playbook successfully
+  #       ran to completion.
+  - name: touch file to indicate that the reconfigure was successful
+    copy:
+      content: ""
+      dest: "{{ config_success_touchfile }}"

--- a/docker/oso-saml-sso/centos7/root/default_vars.yml
+++ b/docker/oso-saml-sso/centos7/root/default_vars.yml
@@ -1,1 +1,2 @@
 ---
+config_success_touchfile: /configdata/reconfigure_successful

--- a/docker/oso-saml-sso/centos7/start.sh
+++ b/docker/oso-saml-sso/centos7/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+mypid=$$
+
+if [ $mypid -eq 1 ]; then
+  # allow somebody to "kill" us even though we're running as pid 1 in a Docker container
+  trap "echo 'PID 1 received SIGTERM (from liveness or readiness probe?), exiting!'; exit 1" SIGTERM
+  trap "echo 'PID 1 received SIGINT (failed reconfigure?), exiting!'; exit 1" SIGINT
+fi
+
 # This is useful so we can debug containers running inside of OpenShift that are
 # failing to start properly.
 if [ "$OO_PAUSE_ON_START" = "true" ] ; then
@@ -13,6 +21,7 @@ fi
 
 echo user:x:$(id -u):0:USER:/root:/bin/bash >> /etc/passwd
 echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
+reconf_touchfile="/configdata/reconfigure_successful"
 
 # This backgrounded block will run in a loop forever.
 # Its job is to monitor for secrets changes and
@@ -23,18 +32,27 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
     config_version_dir=$(readlink -f /secrets/..data)
     echo "Running config playbook"
     for attempt_number in {1..3}; do
-      if ansible-playbook /root/config.yml; then
-        break
-      else
-        echo "Pod configuration attempt #$attempt_number failed"
-        if [ "$attempt_number" -eq 3 ]; then
-          echo "Giving up, killing pod"
-          kill -9 1
-          exit
+      rm -f "$reconf_touchfile"
+      if ansible-playbook /root/config.yml -e config_success_touchfile="$reconf_touchfile"; then
+        # if the playbook is successful, it will touch $reconf_touchfile as its final task
+        if [ -f "$reconf_touchfile" ]; then
+          break
         else
-          echo "Sleeping for $((10**attempt_number)) seconds before retry"
-          sleep $((10**attempt_number))
+          failmsg="ansible-playbook /root/config.yml apparent failure. Final task to touch $reconf_touchfile was not run"
         fi
+      else
+        failmsg="ansible-playbook /root/config.yml failed with exit status $?"
+      fi
+      echo "Pod configuration attempt #$attempt_number failed: $failmsg"
+      if [ "$attempt_number" -eq 3 ]; then
+        echo "Giving up, killing pod"
+        kill -INT $mypid
+        sleep 1
+        kill -KILL $mypid
+        exit
+      else
+        echo "Sleeping for $((10**attempt_number)) seconds before retry"
+        sleep $((10**attempt_number))
       fi
     done
     if [ -f /var/run/sshd.pid ]; then
@@ -45,7 +63,6 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
       echo "Reloading httpd config"
       pkill --signal USR1 --pidfile /var/run/httpd/httpd.pid httpd
     fi
-    touch /configdata/initial_config
     # wait until the secrets change
     inotifywait -e DELETE_SELF "$config_version_dir"
     sleep 5
@@ -54,7 +71,7 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
 
 
 echo "Waiting for initial configuration to finish"
-while ! [ -f /configdata/initial_config ]; do
+while ! [ -f "$reconf_touchfile" ]; do
   sleep 1
 done
 

--- a/docker/oso-saml-sso/rhel7/root/config.yml
+++ b/docker/oso-saml-sso/rhel7/root/config.yml
@@ -105,3 +105,11 @@
         content: "{{ saml2_sso_configdata.saml2_idp_cert_data.cert }}"
       - name: "{{ saml2_sso_configdata.saml_privatekey_file }}"
         content: "{{ saml2_sso_configdata.saml2_idp_cert_data.key }}"
+
+  # NOTE: this must be the final task because it indicates to
+  #       the start-up script that this playbook successfully
+  #       ran to completion.
+  - name: touch file to indicate that the reconfigure was successful
+    copy:
+      content: ""
+      dest: "{{ config_success_touchfile }}"

--- a/docker/oso-saml-sso/rhel7/root/default_vars.yml
+++ b/docker/oso-saml-sso/rhel7/root/default_vars.yml
@@ -1,1 +1,2 @@
 ---
+config_success_touchfile: /configdata/reconfigure_successful

--- a/docker/oso-saml-sso/rhel7/start.sh
+++ b/docker/oso-saml-sso/rhel7/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+mypid=$$
+
+if [ $mypid -eq 1 ]; then
+  # allow somebody to "kill" us even though we're running as pid 1 in a Docker container
+  trap "echo 'PID 1 received SIGTERM (from liveness or readiness probe?), exiting!'; exit 1" SIGTERM
+  trap "echo 'PID 1 received SIGINT (failed reconfigure?), exiting!'; exit 1" SIGINT
+fi
+
 # This is useful so we can debug containers running inside of OpenShift that are
 # failing to start properly.
 if [ "$OO_PAUSE_ON_START" = "true" ] ; then
@@ -13,6 +21,7 @@ fi
 
 echo user:x:$(id -u):0:USER:/root:/bin/bash >> /etc/passwd
 echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
+reconf_touchfile="/configdata/reconfigure_successful"
 
 # This backgrounded block will run in a loop forever.
 # Its job is to monitor for secrets changes and
@@ -23,18 +32,27 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
     config_version_dir=$(readlink -f /secrets/..data)
     echo "Running config playbook"
     for attempt_number in {1..3}; do
-      if ansible-playbook /root/config.yml; then
-        break
-      else
-        echo "Pod configuration attempt #$attempt_number failed"
-        if [ "$attempt_number" -eq 3 ]; then
-          echo "Giving up, killing pod"
-          kill -9 1
-          exit
+      rm -f "$reconf_touchfile"
+      if ansible-playbook /root/config.yml -e config_success_touchfile="$reconf_touchfile"; then
+        # if the playbook is successful, it will touch $reconf_touchfile as its final task
+        if [ -f "$reconf_touchfile" ]; then
+          break
         else
-          echo "Sleeping for $((10**attempt_number)) seconds before retry"
-          sleep $((10**attempt_number))
+          failmsg="ansible-playbook /root/config.yml apparent failure. Final task to touch $reconf_touchfile was not run"
         fi
+      else
+        failmsg="ansible-playbook /root/config.yml failed with exit status $?"
+      fi
+      echo "Pod configuration attempt #$attempt_number failed: $failmsg"
+      if [ "$attempt_number" -eq 3 ]; then
+        echo "Giving up, killing pod"
+        kill -INT $mypid
+        sleep 1
+        kill -KILL $mypid
+        exit
+      else
+        echo "Sleeping for $((10**attempt_number)) seconds before retry"
+        sleep $((10**attempt_number))
       fi
     done
     if [ -f /var/run/sshd.pid ]; then
@@ -45,7 +63,6 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
       echo "Reloading httpd config"
       pkill --signal USR1 --pidfile /var/run/httpd/httpd.pid httpd
     fi
-    touch /configdata/initial_config
     # wait until the secrets change
     inotifywait -e DELETE_SELF "$config_version_dir"
     sleep 5
@@ -54,7 +71,7 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
 
 
 echo "Waiting for initial configuration to finish"
-while ! [ -f /configdata/initial_config ]; do
+while ! [ -f "$reconf_touchfile" ]; do
   sleep 1
 done
 

--- a/docker/oso-saml-sso/src/root/config.yml
+++ b/docker/oso-saml-sso/src/root/config.yml
@@ -105,3 +105,11 @@
         content: "{{ saml2_sso_configdata.saml2_idp_cert_data.cert }}"
       - name: "{{ saml2_sso_configdata.saml_privatekey_file }}"
         content: "{{ saml2_sso_configdata.saml2_idp_cert_data.key }}"
+
+  # NOTE: this must be the final task because it indicates to
+  #       the start-up script that this playbook successfully
+  #       ran to completion.
+  - name: touch file to indicate that the reconfigure was successful
+    copy:
+      content: ""
+      dest: "{{ config_success_touchfile }}"

--- a/docker/oso-saml-sso/src/root/default_vars.yml
+++ b/docker/oso-saml-sso/src/root/default_vars.yml
@@ -1,1 +1,2 @@
 ---
+config_success_touchfile: /configdata/reconfigure_successful

--- a/docker/oso-saml-sso/src/start.sh
+++ b/docker/oso-saml-sso/src/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+mypid=$$
+
+if [ $mypid -eq 1 ]; then
+  # allow somebody to "kill" us even though we're running as pid 1 in a Docker container
+  trap "echo 'PID 1 received SIGTERM (from liveness or readiness probe?), exiting!'; exit 1" SIGTERM
+  trap "echo 'PID 1 received SIGINT (failed reconfigure?), exiting!'; exit 1" SIGINT
+fi
+
 # This is useful so we can debug containers running inside of OpenShift that are
 # failing to start properly.
 if [ "$OO_PAUSE_ON_START" = "true" ] ; then
@@ -13,6 +21,7 @@ fi
 
 echo user:x:$(id -u):0:USER:/root:/bin/bash >> /etc/passwd
 echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
+reconf_touchfile="/configdata/reconfigure_successful"
 
 # This backgrounded block will run in a loop forever.
 # Its job is to monitor for secrets changes and
@@ -23,18 +32,27 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
     config_version_dir=$(readlink -f /secrets/..data)
     echo "Running config playbook"
     for attempt_number in {1..3}; do
-      if ansible-playbook /root/config.yml; then
-        break
-      else
-        echo "Pod configuration attempt #$attempt_number failed"
-        if [ "$attempt_number" -eq 3 ]; then
-          echo "Giving up, killing pod"
-          kill -9 1
-          exit
+      rm -f "$reconf_touchfile"
+      if ansible-playbook /root/config.yml -e config_success_touchfile="$reconf_touchfile"; then
+        # if the playbook is successful, it will touch $reconf_touchfile as its final task
+        if [ -f "$reconf_touchfile" ]; then
+          break
         else
-          echo "Sleeping for $((10**attempt_number)) seconds before retry"
-          sleep $((10**attempt_number))
+          failmsg="ansible-playbook /root/config.yml apparent failure. Final task to touch $reconf_touchfile was not run"
         fi
+      else
+        failmsg="ansible-playbook /root/config.yml failed with exit status $?"
+      fi
+      echo "Pod configuration attempt #$attempt_number failed: $failmsg"
+      if [ "$attempt_number" -eq 3 ]; then
+        echo "Giving up, killing pod"
+        kill -INT $mypid
+        sleep 1
+        kill -KILL $mypid
+        exit
+      else
+        echo "Sleeping for $((10**attempt_number)) seconds before retry"
+        sleep $((10**attempt_number))
       fi
     done
     if [ -f /var/run/sshd.pid ]; then
@@ -45,7 +63,6 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
       echo "Reloading httpd config"
       pkill --signal USR1 --pidfile /var/run/httpd/httpd.pid httpd
     fi
-    touch /configdata/initial_config
     # wait until the secrets change
     inotifywait -e DELETE_SELF "$config_version_dir"
     sleep 5
@@ -54,7 +71,7 @@ echo group:x:$(id -G | awk '{print $2}'):user >> /etc/group
 
 
 echo "Waiting for initial configuration to finish"
-while ! [ -f /configdata/initial_config ]; do
+while ! [ -f "$reconf_touchfile" ]; do
   sleep 1
 done
 


### PR DESCRIPTION
Under high load situations, "ansible-playbook" was exiting with a 0 return
status (true) despite its never having run any of the tasks in the
playbook. By moving the
"I'm done!" touchfile to the Ansible playbook, we can make sure that the
playbook ran to completion.

Also, add a signal handler for SIGTERM and SIGINT since it seems that our
error path didn't work well. It appears that the SIGKILL was not delivered
to PID 1 when there were reconfigure errors. (Dockerism?)