### PR TITLE
upgrade cron-send-internal-pods-check

### DIFF
--- a/scripts/monitoring/cron-send-internal-pods-check.py
+++ b/scripts/monitoring/cron-send-internal-pods-check.py
@@ -1,26 +1,36 @@
 #!/usr/bin/env python
+''' Send Cluster Infra node's pod status to Zagg '''
 
-'''
-  Send Cluster Infra node's pod status to Zagg
-'''
+# TODO: change to use arguments for podname, and run once per podname
+
 #pylint: disable=import-error
 #pylint: disable=invalid-name
+#pylint: disable=broad-except
+
+import argparse
+import logging
 
 from openshift_tools.monitoring.ocutil import OCUtil
 from openshift_tools.monitoring.metric_sender import MetricSender
+
+logging.basicConfig(
+    format='%(asctime)s - %(relativeCreated)6d - %(levelname)-8s - %(message)s',
+)
+logging.getLogger().setLevel(logging.WARN)
 
 class InfraNodePodStatus(object):
     '''
       This is a check for making sure the internal pods like
       router and registry running and located on different infra nodes
     '''
-    def __init__(self):
+    def __init__(self, args=None, ):
         '''initial for the InfraNodePodStatus'''
+        self.args = args
         self.kubeconfig = '/tmp/admin.kubeconfig'
-        self.oc = OCUtil(namespace='default', config_file=self.kubeconfig)
-        self.pod_report = self.check_pods()
+        self.oc = OCUtil(namespace=self.args.namespace, config_file=self.kubeconfig)
+        self.all_pods = self.get_all_pods()
 
-    def check_pods(self):
+    def get_all_pods(self):
         ''' get all the pod information '''
         pods = self.oc.get_pods()
         pod_report = {}
@@ -36,46 +46,83 @@ class InfraNodePodStatus(object):
         defined_replicas = self.oc.get_dc(deploymentconfig)['spec']['replicas']
         return defined_replicas
 
-    def compare_ip(self, keyword):
+    def get_pods_by_name(self, podname):
+        """get_pods_by_name"""
+        return [self.all_pods[i] for i in self.all_pods.keys() if i.startswith(podname + '-')]
+
+    def check_pods(self, podname, keybase="", pod_optional=False, ):
         ''' to compare the pod host ip and check the pod status '''
-        pod_hostip_status = [self.pod_report[i] for i in self.pod_report.keys() if keyword in i]
+        logging.getLogger().info("Finding pods for: %s", podname)
 
-        pod_run_num = 0
-        for i in pod_hostip_status:
-            if i['status'] == "Running":
-                pod_run_num += 1
-        if len(pod_hostip_status) == self.get_expected_replicas(keyword):
-            # get IP of nodes the pods are running on
-            # so we can see if each pod is on a different node
-            hostip_set = set([x['hostIP'] for x in pod_hostip_status])
-            if len(hostip_set) == len(pod_hostip_status):
-                # print "ok, you do not need do anything for {} pod".format(keyword)
-                result_code = 1
-            else:
-                # print "there are something wrong, please check the pod"
-                result_code = 0
-        else:
-            print "please check the pod"
+        result_code = 1
+
+        pods = self.get_pods_by_name(podname)
+        logging.getLogger().info("Pods Found: %s", len(pods))
+
+        expected_replicas = 0
+        try:
+            expected_replicas = self.get_expected_replicas(podname)
+        except Exception:
+            logging.getLogger().warn("dc not found for pod %s", podname)
+            if pod_optional:
+                logging.getLogger().warn(
+                    "Some clusters don't have pod %s, please confirm before trying to fix this",
+                    podname)
+            return # nothing we should do, so quit early, don't do more checks
+
+        logging.getLogger().info("Expected Replicas: %s", expected_replicas)
+        if len(pods) != expected_replicas:
             result_code = 0
-        # result_code 1 means the two pods are on different nodes
-        # pod_run_num means the running pod number
-        return result_code, pod_run_num
+            logging.getLogger().critical("Count Pods and Replicas don't match")
 
-    def run(self):
-        ''' run the command and send the code to zabbix '''
-        ms = MetricSender()
+        count_pods_running = len([i for i in pods if i['status'] == "Running"])
+        logging.getLogger().info("Pods Running: %s", count_pods_running)
+        if len(pods) != count_pods_running:
+            result_code = 0
+            logging.getLogger().critical("Some pods are not in running state")
 
-        # the check_value is the value to send to zabbix
-        router_check_value = self.compare_ip('router')
-        registry_check_value = self.compare_ip('docker-registry')
-        print router_check_value, registry_check_value
+        host_ips = set([x['hostIP'] for x in pods])
+        logging.getLogger().info("Hosts found: %d", len(host_ips))
+        if len(host_ips) != len(pods):
+            result_code = 0
+            logging.getLogger().critical(
+                "%s has %d pods on %d hosts, not evenly distributed",
+                podname, len(pods), len(host_ips))
 
-        ms.add_metric({'openshift.router.pod.location': router_check_value[0]})
-        ms.add_metric({'openshift.router.pod.status': router_check_value[1]})
-        ms.add_metric({'openshift.registry.pod.location': registry_check_value[0]})
-        ms.add_metric({'openshift.registry.pod.status': registry_check_value[1]})
+        if result_code == 0:
+            logging.getLogger().critical("Please check pods are in running "
+                                         "state, and on unique hosts")
+            logging.getLogger().critical("oc get pods -n %s -o wide", self.args.namespace)
+
+        # result_code 1 means the pods are on different nodes
+        # count_pods_running means the running pod number
+        self.send_metrics(keybase=keybase, location=result_code, status=count_pods_running)
+
+    def send_metrics(self, keybase="", location="", status=""):
+        """send_metrics"""
+        ms = MetricSender(verbose=self.args.verbose)
+        ms.add_metric({keybase + '.location': location})
+        ms.add_metric({keybase + '.status': status})
         ms.send_metrics()
 
+def parse_args():
+    """ parse the args from the cli """
+    logging.getLogger().debug("parse_args()")
+
+    parser = argparse.ArgumentParser(description='AWS instance health')
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='verbosity level, specify multiple')
+    parser.add_argument('--namespace', default="default",
+                        help='Project namespace')
+    args = parser.parse_args()
+
+    if args.verbose > 0:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    return args
+
 if __name__ == '__main__':
-    INPS = InfraNodePodStatus()
-    INPS.run()
+    INPS = InfraNodePodStatus(args=parse_args(), )
+    INPS.check_pods('router', keybase="openshift.router.pod", )
+    INPS.check_pods('docker-registry', keybase="openshift.registry.pod", )
+    INPS.check_pods('router2', keybase="openshift.router2.pod", pod_optional=True, )


### PR DESCRIPTION
+1 from @zhiwliu on https://github.com/openshift/openshift-tools/pull/2599

=====

* import logging
* import argparse
* verbosity
* logging
* reusable code (check_pods)
* safe to use with router2, even though some clusters don't have router2
* checks running state
* checks anti-affinity (pods distributed across hosts)
* warning when pod is optional