### PR TITLE
metrics every 30m, 2 fails in a row to trigger

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_metrics.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_metrics.yml
@@ -10,7 +10,7 @@ g_template_metrics:
 
   ztriggers:
   - name: "OpenShift Metrics failed on {HOST.NAME}"
-    expression: "{Template OpenShift Metrics:openshift.metrics.nodes_reporting.last()}<1"
+    expression: "{Template OpenShift Metrics:openshift.metrics.nodes_reporting.sum(#2)}=0"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_metrics.asciidoc"
     priority: high
 
@@ -19,7 +19,7 @@ g_template_metrics:
     key: openshift.metrics.hawkular
     lifetime: 7
     description: "Hawkular metrics"
- 
+
   zitemprototypes:
   - discoveryrule_key: openshift.metrics.hawkular
     name: "{% raw %}openshift.metrics.hawkular.status.{{ '{#' }}OSO_METRICS}{% endraw %}"
@@ -28,7 +28,7 @@ g_template_metrics:
     description: "hawkular metrics status"
     applications:
     - Hawkular Cassandra
- 
+
   - discoveryrule_key: openshift.metrics.hawkular
     name: "{% raw %}openshift.metrics.hawkular.starttime.{{ '{#' }}OSO_METRICS}{% endraw %}"
     key: "{% raw %}openshift.metrics.hawkular.starttime[{{ '{#' }}OSO_METRICS}]{% endraw %}"
@@ -36,7 +36,7 @@ g_template_metrics:
     description: "hawkular metrics start time"
     applications:
     - Hawkular Cassandra
- 
+
   - discoveryrule_key: openshift.metrics.hawkular
     name: "{% raw %}openshift.metrics.hawkular.restarts.{{ '{#' }}OSO_METRICS}{% endraw %}"
     key: "{% raw %}openshift.metrics.hawkular.restarts[{{ '{#' }}OSO_METRICS}]{% endraw %}"
@@ -45,4 +45,4 @@ g_template_metrics:
     applications:
     - Hawkular Cassandra
 
- 
+

--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -397,7 +397,7 @@ host_monitoring_cron:
 
 - name: "Report metrics health"
   hour: "*"
-  minute: "30"
+  minute: "*/30"
   job: "ops-runner -f -s 30 -n cosp.openshift.metrics.check cron-send-metrics-checks"
 
 - name: "Report logging health"


### PR DESCRIPTION
+1 from @BlueShells on https://github.com/openshift/openshift-tools/pull/2613

=====

Change to have 2x failed checks in a row, but check twice as fast.
I assume the original intention was to run every 30m, not once per 60m
(on :30).