### PR TITLE
Allow ossh to work for other ec2 identifiers #2652

### DIFF
--- a/scripts/inventory-clients/ossh
+++ b/scripts/inventory-clients/ossh
@@ -118,14 +118,27 @@ class Ossh(object):
         '''select host attempts to match the host specified
            on the command line with a list of hosts.
         '''
-        results = None
+        results = {}
         if self.host_inventory.has_key(self.host):
-            results = (self.host, self.host_inventory[self.host])
+            results[self.host] = self.host_inventory[self.host]
+        # check for an ec2_private_dns_name, like: ip-172-31-49-44.ec2.internal
+        elif self.host.startswith("ip-"):
+            for host, values in self.host_inventory.iteritems():
+                if not values.has_key("ec2_private_dns_name"):
+                    continue
+                if self.host == values["ec2_private_dns_name"]:
+                    results[host] = values
         else:
             print "Could not find specified host: %s." % self.host
 
-        # default - no results found.
-        return results
+        if len(results) > 1:
+            print("Found multiple possible hosts: %s" % ",".join(results))
+            return None
+
+        if len(results) == 0:
+            return None
+
+        return results.items()[0]
 
     def list_hosts(self):
         '''Function to print out the host inventory.

--- a/scripts/inventory-clients/ossh
+++ b/scripts/inventory-clients/ossh
@@ -128,6 +128,13 @@ class Ossh(object):
                     continue
                 if self.host == values["ec2_private_dns_name"]:
                     results[host] = values
+        # check for an aws instance id, like: i-0015104cc95b00f77
+        elif self.host.startswith("i-"):
+            for host, values in self.host_inventory.iteritems():
+                if not values.has_key("ec2_id"):
+                    continue
+                if self.host == values["ec2_id"]:
+                    results[host] = values
         else:
             print "Could not find specified host: %s." % self.host
 


### PR DESCRIPTION
This PR allows commands like:
`ossh ip-172-31-49-31.ec2.internal`
or
`ossh i-0aa23bb16a178517b`
To work.