### PR TITLE
Allow optional nodes for gather logs script

### DIFF
--- a/scripts/cicd/verify-gather-logs-operations.py
+++ b/scripts/cicd/verify-gather-logs-operations.py
@@ -40,10 +40,20 @@ VALID_CLUSTER_NAMES = [
     'starter-us-west-2'
 ]
 
-# This regex matches a valid hostname: an optional set of DNS labels each
-# ending with dot, followed by a final DNS label. Each DNS label is 1 to
-# 63 digits, letters or '-', but must start with a letter. This is used
-# to match each of the provided node names
+# This regex is used to check that the provided node names look like a valid
+# node name (i.e. from "oc get node") or an inventory host name.
+#
+# In order to keep the check simple this doesn't aim at RFC 1123 compliance,
+# only that the provided node name is "similar enough" to a valid hostname
+# and that it matches what our cluster's node names/inventory names look like
+#
+# Here labels must start with a letter. This prevents using IPs to identify
+# nodes (the log gathering script should be modified to allow IPs).
+#
+# NOTE: this is only an input sanity check, not a full verification that the
+# provided node names actually exist. The full/final hostname validation
+# happens in the log gathering script itself by accessing the cluster's
+# ansible inventory
 HOSTNAME_RE = re.compile(
     r'([a-z][a-z\d-]{0,62}\.)*'
     r'([a-z][a-z\d-]{0,62})$',

--- a/scripts/cicd/verify-gather-logs-operations.py
+++ b/scripts/cicd/verify-gather-logs-operations.py
@@ -87,7 +87,7 @@ def gather_logs(command):
     This function never returns (it can raise exceptions though)
     '''
 
-    usage = "ssh -i gather_logs_key %(prog)s -- -u USER -c CLUSTER [-n node1 node2...]"
+    usage = "ssh -i gather_logs_key %(prog)s -- -u USER -c CLUSTER [-n node1 node2...] > logs.tar.gz"
     parser = argparse.ArgumentParser(prog=INVOCATION, usage=usage)
     parser.add_argument('-u', dest='user', help="Your kerberos ID",
                         required=True, type=valid_krbid)


### PR DESCRIPTION
The cluster log gathering script is being expanded to allow an optional list of nodes to get logs from, see openshift/aos-cd-jobs#461

This modifies the entry point script to add a parameter for that list of nodes. With this, you can get master logs as before with:

    ssh -i logs_access_key tower -- -u username -c clusterID

or add a list of nodes to get these extra logs:

    ssh -i logs_access_key tower -- -u username -c clusterID -n node1 node2 node3

@dbaker-rh would you have a few mins to review? Feel free to schedule a chat if needed, thanks!
