### PR TITLE
Updating to 3.6 lib_openshift

### DIFF
--- a/ansible/roles/lib_openshift
+++ b/ansible/roles/lib_openshift
@@ -1,1 +1,1 @@
-../../openshift/installer/atomic-openshift-3.5/roles/lib_openshift/
+../../openshift/installer/atomic-openshift-3.6/roles/lib_openshift


### PR DESCRIPTION
The 3.5 version does not have oc_pvc, oc_image, or oc_volumes.