### PR TITLE
Add starter-us-west-1 to allowed clusters for log gathering

### DIFF
--- a/scripts/cicd/verify-gather-logs-operations.py
+++ b/scripts/cicd/verify-gather-logs-operations.py
@@ -35,8 +35,10 @@ import logging.handlers
 VALID_CLUSTER_NAMES = [
     'free-int',
     'free-stg',
+    'starter-ca-central-1',
     'starter-us-east-1',
     'starter-us-east-2',
+    'starter-us-west-1',
     'starter-us-west-2'
 ]
 


### PR DESCRIPTION
@dbaker-rh as per your suggestion in openshift/aos-cd-jobs#555 this is to add starter-us-west-1 to the list of valid clusters to gather logs from.