### PR TITLE
lower severity of EBS volumes stuck in attaching to average for the weekend

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_aws.yml
+++ b/ansible/roles/os_zabbix/vars/template_aws.yml
@@ -98,4 +98,4 @@ g_template_aws:
   - name: "{% raw %}EBS Attach State[{{ '{#' }}OSO_EBS_VOLUME_URI}]: EBS volume stuck attaching or detaching{% endraw %}"
     expression: "{% raw %}{Template AWS:disc.aws.ebs.attach_state[{{ '{#' }}OSO_EBS_VOLUME_URI}].last()}>0{% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_ebs_stuck_attaching_detaching.asciidoc"
-    priority: high
+    priority: average


### PR DESCRIPTION
This lowers the severity of the stuck EBS volume alert to average for the long weekend. I am on-call this weekend and will still regularly check and fix stuck volumes. 