### PR TITLE
zabbix server object cache increase

### DIFF
--- a/docker/oso-zabbix-server/centos7/zabbix/conf/zabbix_server.conf
+++ b/docker/oso-zabbix-server/centos7/zabbix/conf/zabbix_server.conf
@@ -317,7 +317,7 @@ SNMPTrapperFile=/var/log/snmptt/snmptt.log
 # Range: 128K-8G
 # Default:
 # CacheSize=8M
-CacheSize=256M
+CacheSize=512M
 
 ### Option: CacheUpdateFrequency
 #	How often Zabbix will perform update of configuration cache, in seconds.

--- a/docker/oso-zabbix-server/rhel7/zabbix/conf/zabbix_server.conf
+++ b/docker/oso-zabbix-server/rhel7/zabbix/conf/zabbix_server.conf
@@ -317,7 +317,7 @@ SNMPTrapperFile=/var/log/snmptt/snmptt.log
 # Range: 128K-8G
 # Default:
 # CacheSize=8M
-CacheSize=256M
+CacheSize=512M
 
 ### Option: CacheUpdateFrequency
 #	How often Zabbix will perform update of configuration cache, in seconds.

--- a/docker/oso-zabbix-server/src/zabbix/conf/zabbix_server.conf
+++ b/docker/oso-zabbix-server/src/zabbix/conf/zabbix_server.conf
@@ -317,7 +317,7 @@ SNMPTrapperFile=/var/log/snmptt/snmptt.log
 # Range: 128K-8G
 # Default:
 # CacheSize=8M
-CacheSize=256M
+CacheSize=512M
 
 ### Option: CacheUpdateFrequency
 #	How often Zabbix will perform update of configuration cache, in seconds.


### PR DESCRIPTION
+1 from @robotmaxtron on https://github.com/openshift/openshift-tools/pull/2894

======

298:20170918:191704.727 __mem_malloc: skipped 0 asked 24 skip_min
4294967295 skip_max 0
   298:20170918:191704.727 [file:dbconfig.c,line:545] zbx_mem_realloc():
out of memory (requested 24 bytes)
   298:20170918:191704.727 [file:dbconfig.c,line:545] zbx_mem_realloc():
please increase CacheSize configuration parameter