### PR TITLE
start docker on boot

### DIFF
--- a/ansible/roles/docker_storage_setup/tasks/main.yml
+++ b/ansible/roles/docker_storage_setup/tasks/main.yml
@@ -18,6 +18,11 @@
     name: docker
     state: started
 
+- name: Ensure docker is enabled to start on boot
+  service:
+    name: docker
+    state: enabled
+
 - name: docker info
   command: docker info
   register: dockerinfo


### PR DESCRIPTION
This is needed so we can set up docker authentication during openshift cluster builds. 