### PR TITLE
stg: Add adhoc playbook docker_storage_to_overlay2.yml

### DIFF
--- a/ansible/playbooks/adhoc/docker_storage_to_overlay2/docker_storage_to_overlay2.yml
+++ b/ansible/playbooks/adhoc/docker_storage_to_overlay2/docker_storage_to_overlay2.yml
@@ -1,0 +1,125 @@
+# This playbook wraps the similarly named role in openshift-ansible.
+#
+# It's idempotent and safe to run repeatedly.  If the node's storage driver
+# is already overlay2, the ephemeral storage is left untouched.
+#
+# The role itself wipes all ephemeral storage with "atomic storage reset", so
+# this playbook drains nodes before invoking the role.
+#
+# Usage example:
+#
+#  ansible-playbook docker_storage_to_overlay2.yml -e cli_clusterid=testcluster
+#
+
+- hosts: localhost
+  gather_facts: no
+  become: no
+  user: root
+
+  tasks:
+
+  - name: Check for required variables
+    fail:
+      msg: "Please define {{ item }}"
+    when: "{{ item }} is undefined"
+    with_items:
+    - cli_clusterid
+    run_once: True
+
+##############################################
+# Master upgrade
+##############################################
+
+- hosts: "oo_clusterid_{{ cli_clusterid }}:&oo_hosttype_master"
+  gather_facts: yes  # docker_storage_to_overlay2 needs ansible_distribution
+  become: no
+  user: root
+  serial: 1
+
+  roles:
+  - role: ../../../../openshift/installer/atomic-openshift-3.7/roles/docker_storage_driver
+
+  - role: ../../../roles/openshift_aws_elb_instance_manager
+    osaeim_elb_name: "{{ cli_clusterid }}-master"
+    osaeim_state: absent
+    osaeim_instance_ids: "{{ ec2_id }}"
+    osaeim_region: "{{ oo_sublocation }}"
+    osaeim_aws_access_key: "{{ lookup('env', 'ACCESS_KEY_ID') }}"
+    osaeim_aws_secret_key: "{{ lookup('env', 'SECRET_ACCESS_KEY') }}"
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../../openshift/installer/atomic-openshift-3.7/roles/docker_storage_to_overlay2
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../roles/os_reboot_server
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../roles/openshift_aws_elb_instance_manager
+    osaeim_elb_name: "{{ cli_clusterid }}-master"
+    osaeim_state: present
+    osaeim_instance_ids: "{{ ec2_id }}"
+    osaeim_region: "{{ oo_sublocation }}"
+    osaeim_aws_access_key: "{{ lookup('env', 'ACCESS_KEY_ID') }}"
+    osaeim_aws_secret_key: "{{ lookup('env', 'SECRET_ACCESS_KEY') }}"
+    when: docker_storage_driver != "overlay2"
+    run_once: True
+
+##############################################
+# Infra upgrade
+##############################################
+
+- hosts: "oo_clusterid_{{ cli_clusterid }}:&oo_subhosttype_infra"
+  gather_facts: yes  # docker_storage_to_overlay2 needs ansible_distribution
+  become: no
+  user: root
+  serial: 1
+
+  roles:
+  - role: ../../../../openshift/installer/atomic-openshift-3.7/roles/docker_storage_driver
+
+  - role: ../../../roles/openshift_node_schedulable
+    osns_is_schedulable: False
+    osns_drain: True
+    osns_cluster_master: "{{ groups['oo_hosttype_master'] | intersect(groups['oo_clusterid_' ~ oo_clusterid]) | first }}"
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../../openshift/installer/atomic-openshift-3.7/roles/docker_storage_to_overlay2
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../roles/os_reboot_server
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../roles/openshift_node_schedulable
+    osns_is_schedulable: True
+    osns_cluster_master: "{{ groups['oo_hosttype_master'] | intersect(groups['oo_clusterid_' ~ oo_clusterid]) | first }}"
+    when: docker_storage_driver != "overlay2"
+
+##############################################
+# Compute upgrade
+##############################################
+
+- hosts: "oo_clusterid_{{ cli_clusterid }}:&oo_subhosttype_compute"
+  gather_facts: yes  # docker_storage_to_overlay2 needs ansible_distribution
+  become: no
+  user: root
+  serial: 10%
+
+  roles:
+  - role: ../../../../openshift/installer/atomic-openshift-3.7/roles/docker_storage_driver
+
+  - role: ../../../roles/openshift_node_schedulable
+    osns_is_schedulable: False
+    osns_drain: True
+    osns_cluster_master: "{{ groups['oo_hosttype_master'] | intersect(groups['oo_clusterid_' ~ oo_clusterid]) | first }}"
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../../openshift/installer/atomic-openshift-3.7/roles/docker_storage_to_overlay2
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../roles/os_reboot_server
+    when: docker_storage_driver != "overlay2"
+
+  - role: ../../../roles/openshift_node_schedulable
+    osns_is_schedulable: True
+    osns_cluster_master: "{{ groups['oo_hosttype_master'] | intersect(groups['oo_clusterid_' ~ oo_clusterid]) | first }}"
+    when: docker_storage_driver != "overlay2"


### PR DESCRIPTION
Wraps the similarly named role in `openshift-ansible`.

See https://github.com/openshift/openshift-tools/pull/2957 for `prod`.