### PR TITLE
allow world read for the multi_inventory.cache file

### DIFF
--- a/ansible/roles/ansible_inventory/tasks/main.yml
+++ b/ansible/roles/ansible_inventory/tasks/main.yml
@@ -69,5 +69,5 @@
     owner: root
     group: libra_ops
     recurse: yes
-    mode: '2770'
+    mode: '2775'
   when: oo_inventory_cache_location is defined


### PR DESCRIPTION
after review, it has been determined there's no sensitive data in there