### PR TITLE
send only internal or external expirations

### DIFF
--- a/scripts/monitoring/cron-certificate-expirations.py
+++ b/scripts/monitoring/cron-certificate-expirations.py
@@ -11,6 +11,7 @@ from dateutil import parser
 import OpenSSL.crypto
 import os
 from stat import S_ISDIR, S_ISREG
+import re
 
 # Reason: disable pylint import-error because our libs aren't loaded on jenkins.
 # Status: temporary until we start testing in a container where our stuff is ins talled.
@@ -32,6 +33,8 @@ class CertificateReporting(object):
         self.current_date = datetime.datetime.today()
         self.parse_args()
         self.msend = MetricSender(debug=self.args.debug)
+        self.days_left_internal = None
+        self.days_left_external = None
 
     def dprint(self, msg):
         ''' debug printer '''
@@ -62,6 +65,18 @@ class CertificateReporting(object):
         delta = expiration_date - self.current_date
         return delta.days
 
+    def set_days_left(self, cert_file, days_left):
+        ''' set days left per cert type to closest to now '''
+
+        if self.openshift_cert_issuer(cert_file):
+            if (self.days_left_internal > days_left) or (self.days_left_internal == None):
+                self.days_left_internal = days_left
+            #self.dprint("{} days left on internal certs".format(self.days_left_internal))
+        else:
+            if (self.days_left_external > days_left) or (self.days_left_external == None):
+                self.days_left_external = days_left
+            #self.dprint("{} days left on external certs".format(self.days_left_external))
+
     def process_certificates(self):
         ''' check through list of certificates/directories '''
 
@@ -75,19 +90,27 @@ class CertificateReporting(object):
                 self.all_certs_in_dir(cert)
             elif S_ISREG(mode):
                 days = self.days_to_expiration(cert)
+                self.set_days_left(cert, days)
                 self.dprint("{} in {} days".format(cert, days))
-                self.add_metrics(cert, days)
             else:
                 self.dprint("not a file. not a directory. skipping.")
 
-        # now push out all queued up item(s) to metric servers
-        self.msend.send_metrics()
+        self.dprint("{} days left on internal certs".format(self.days_left_internal))
+        if self.days_left_internal != None:
+            self.add_metrics("internal", self.days_left_internal)
 
-    def add_metrics(self, certificate, days_to_expiration):
+        self.dprint("{} days left on external certs".format(self.days_left_external))
+        if self.days_left_external != None:
+            self.add_metrics("external", self.days_left_external)
+
+        # now push out all queued up item(s) to metric servers
+        #self.msend.send_metrics()
+
+    def add_metrics(self, certtype, days_to_expiration):
         ''' queue up item for submission to zabbix '''
 
-        self.msend.add_dynamic_metric(CERT_DISC_KEY, CERT_DISC_MACRO, [certificate])
-        zbx_key = "{}[{}]".format(CERT_DISC_KEY, certificate)
+        self.msend.add_dynamic_metric(CERT_DISC_KEY, CERT_DISC_MACRO, [certtype])
+        zbx_key = "{}[{}]".format(CERT_DISC_KEY, certtype)
         self.msend.add_metric({zbx_key: days_to_expiration})
 
     def all_certs_in_dir(self, directory):
@@ -98,8 +121,29 @@ class CertificateReporting(object):
                 if filename.endswith('.crt'):
                     full_path = os.path.join(root, filename)
                     days = self.days_to_expiration(full_path)
+                    self.set_days_left(full_path, days)
                     self.dprint("{} in {} days".format(full_path, days))
-                    self.add_metrics(full_path, days)
+
+    def openshift_cert_issuer(self, cert_file):
+        ''' return internal if certificate is issued by an openshift signer otherwise external '''
+
+        crypto = OpenSSL.crypto
+
+        ## openshift CA matches e.g. etcd-issuer@12345678 or openshift-issuer@12345678
+        openshift_issuer_match = re.compile('.*-signer@[0-9]{10}$')
+
+        cert = open(cert_file).read()
+        certificate = crypto.load_certificate(crypto.FILETYPE_PEM, cert)
+        issuer = certificate.get_issuer().CN
+
+        match = openshift_issuer_match.match(issuer)
+
+        if match:
+            self.dprint("{} type internal".format(cert_file))
+            return True
+        else:
+            self.dprint("{} type external".format(cert_file))
+            return False
 
 if __name__ == '__main__':
     CertificateReporting().process_certificates()

--- a/scripts/monitoring/cron-certificate-expirations.py
+++ b/scripts/monitoring/cron-certificate-expirations.py
@@ -5,13 +5,13 @@
 # Reason: disable invalid-name because pylint does not like our naming convention
 # pylint: disable=invalid-name
 
+import os
+import re
 import argparse
 import datetime
+from stat import S_ISDIR, S_ISREG
 from dateutil import parser
 import OpenSSL.crypto
-import os
-from stat import S_ISDIR, S_ISREG
-import re
 
 # Reason: disable pylint import-error because our libs aren't loaded on jenkins.
 # Status: temporary until we start testing in a container where our stuff is ins talled.
@@ -69,11 +69,11 @@ class CertificateReporting(object):
         ''' set days left per cert type to closest to now '''
 
         if self.openshift_cert_issuer(cert_file):
-            if (self.days_left_internal > days_left) or (self.days_left_internal == None):
+            if (self.days_left_internal > days_left) or (self.days_left_internal is None):
                 self.days_left_internal = days_left
             #self.dprint("{} days left on internal certs".format(self.days_left_internal))
         else:
-            if (self.days_left_external > days_left) or (self.days_left_external == None):
+            if (self.days_left_external > days_left) or (self.days_left_external is None):
                 self.days_left_external = days_left
             #self.dprint("{} days left on external certs".format(self.days_left_external))
 


### PR DESCRIPTION
We're working on https://trello.com/c/RJAPd2Nv/ and as part of that, we're going to create SNow tickets out of upcoming SSL expiration events. I don't want a ticket for every cert, just internal or external. I've refactored some of the check to do that. I'm thinking about ditching the discovery part, since internal or external would be static, any other thoughts? 