### PR TITLE
adding region support to describe func of gcloud_compute_addresses.py

### DIFF
--- a/ansible/roles/lib_gcloud/library/gcloud_compute_addresses.py
+++ b/ansible/roles/lib_gcloud/library/gcloud_compute_addresses.py
@@ -162,13 +162,13 @@ class GcloudCLI(object):
 
         return self.gcloud_cmd(cmd, output=True, output_type='raw')
 
-    def _list_addresses(self, aname=None):
+    def _list_addresses(self, aname=None, region=None):
         ''' list addresses
             if a name is specified then perform a describe
         '''
         cmd = ['compute', 'addresses']
         if aname:
-            cmd.extend(['describe', aname])
+            cmd.extend(['describe', aname, '--region', region])
         else:
             cmd.append('list')
 
@@ -529,9 +529,9 @@ class GcloudComputeAddresses(GcloudCLI):
         self.address = address
         self.verbose = verbose
 
-    def list_addresses(self, address_name=None):
+    def list_addresses(self, address_name=None, region_name=None):
         '''return a list of addresses'''
-        results = self._list_addresses(address_name)
+        results = self._list_addresses(address_name, region_name)
         if results['returncode'] == 0:
             if not address_name:
                 rval = []

--- a/ansible/roles/lib_gcloud/library/gcloud_compute_addresses.py
+++ b/ansible/roles/lib_gcloud/library/gcloud_compute_addresses.py
@@ -531,7 +531,7 @@ class GcloudComputeAddresses(GcloudCLI):
 
     def list_addresses(self, address_name=None, region_name=None):
         '''return a list of addresses'''
-        results = self._list_addresses(address_name)
+        results = self._list_addresses(address_name, region_name)
         if results['returncode'] == 0:
             if not address_name:
                 rval = []

--- a/ansible/roles/lib_gcloud/library/gcloud_compute_addresses.py
+++ b/ansible/roles/lib_gcloud/library/gcloud_compute_addresses.py
@@ -531,7 +531,7 @@ class GcloudComputeAddresses(GcloudCLI):
 
     def list_addresses(self, address_name=None, region_name=None):
         '''return a list of addresses'''
-        results = self._list_addresses(address_name, region_name)
+        results = self._list_addresses(address_name)
         if results['returncode'] == 0:
             if not address_name:
                 rval = []


### PR DESCRIPTION
old versions of gcloud api didn't need --region=<region> to 'describe' an address, now it does.