### PR TITLE
stop storage alert flapping

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_os_linux.yml
+++ b/ansible/roles/os_zabbix/vars/template_os_linux.yml
@@ -290,7 +290,7 @@ g_template_os_linux:
 
   # This has a dependency on the previous trigger
   - name: "{% raw %}[Heal] Filesystem: {{ '{#' }}OSO_FILESYS} has less than 10% free disk space on {HOST.NAME}{% endraw %}"
-    expression: "{% raw %}{Template OS Linux:disc.filesys.full[{{ '{#' }}OSO_FILESYS}].last()}>90{% endraw %}"
+    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OS Linux:disc.filesys.full[{{ '{#' }}OSO_FILESYS}].last()}>90) or ({TRIGGER.VALUE}=1 and {Template OS Linux:disc.filesys.full[{{ '{#' }}OSO_FILESYS}].last()}>80){% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_filesys_full.asciidoc"
     priority: high
 


### PR DESCRIPTION
we have some storage volumes that can hover around 90% storage utilization by design (their high watermark). this means the 90% storage alert can trigger multiple times from 91->89->91 type transitions.

add some hysteresis so that we only clear the storage alert after storage utilization has dropped below 80%