### PR TITLE
add cgroup memory usage metrics

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_os_linux.yml
+++ b/ansible/roles/os_zabbix/vars/template_os_linux.yml
@@ -188,6 +188,34 @@ g_template_os_linux:
     multiplier: 1024
     units: B
 
+  - key: mem.system.slice.max
+    applications:
+    - Memory
+    value_type: int
+    description: "Max memory usage reading from system.slice cgroup"
+    units: B
+
+  - key: mem.system.slice.current
+    applications:
+    - Memory
+    value_type: int
+    description: "Current memory usage reading from system.slice cgroup"
+    units: B
+
+  - key: mem.kubepod.slice.max
+    applications:
+    - Memory
+    value_type: int
+    description: "Max memory usage reading from kubepod.slice cgroup"
+    units: B
+
+  - key: mem.kubepod.slice.current
+    applications:
+    - Memory
+    value_type: int
+    description: "Current memory usage reading from kubepod.slice cgroup"
+    units: B
+
   # security items
   - key: yum.security.updates
     applications:

--- a/scripts/monitoring/cron-send-cgroup-slice-metrics.sh
+++ b/scripts/monitoring/cron-send-cgroup-slice-metrics.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+SYSTEM_MAX_MEM=$(cat /sys/fs/cgroup/memory/system.slice/memory.max_usage_in_bytes)
+SYSTEM_CURR_MEM=$(cat /sys/fs/cgroup/memory/system.slice/memory.usage_in_bytes)
+
+KUBEPOD_MAX_MEM=$(cat /sys/fs/cgroup/memory/kubepods.slice/memory.max_usage_in_bytes)
+KUBEPOD_CURR_MEM=$(cat /sys/fs/cgroup/memory/kubepods.slice/memory.usage_in_bytes)
+
+echo "system.slice current: $SYSTEM_CURR_MEM"
+echo "system.slice max:     $SYSTEM_MAX_MEM"
+
+echo "kubepod.slice current: $KUBEPOD_CURR_MEM"
+echo "kubepod.slice max:     $KUBEPOD_MAX_MEM"
+
+ops-metric-client -k "mem.system.slice.current" -o "$SYSTEM_CURR_MEM"
+ops-metric-client -k "mem.system.slice.max" -o "$SYSTEM_MAX_MEM"
+
+ops-metric-client -k "mem.kubepod.slice.current" -o "$KUBEPOD_CURR_MEM"
+ops-metric-client -k "mem.kubepod.slice.max" -o "$KUBEPOD_MAX_MEM"

--- a/scripts/openshift-tools-scripts.spec
+++ b/scripts/openshift-tools-scripts.spec
@@ -94,6 +94,7 @@ cp -p devaccess/devaccess_wrap.py %{buildroot}/usr/bin/devaccess_wrap
 cp -p monitoring/cron-send-service-web-check.py %{buildroot}/usr/bin/cron-send-service-web-check
 cp -p monitoring/cron-send-rkhunter-checks.py %{buildroot}/usr/bin/cron-send-rkhunter-checks
 cp -p scan/scanpod-inmem.py %{buildroot}/usr/bin/scanpod-inmem
+cp -p monitoring/cron-send-cgroup-slice-metrics.sh %{buildroot}/usr/bin/cron-send-cgroup-slice-metrics
 
 mkdir -p %{buildroot}/etc/openshift_tools
 cp -p monitoring/metric_sender.yaml.example %{buildroot}/etc/openshift_tools/metric_sender.yaml
@@ -390,6 +391,7 @@ OpenShift Tools Openshift Product Scripts
 /usr/bin/cron-send-service-web-check
 /usr/bin/cron-send-rkhunter-checks
 /usr/bin/cron-send-router-reload-time
+/usr/bin/cron-send-cgroup-slice-metrics
 
 # ----------------------------------------------------------------------------------
 # openshift-tools-scripts-monitoring-zabbix-heal subpackage


### PR DESCRIPTION
cron-send-cgroup-slice-metrics will send the max memory usage and current memory usage for the system.slice and kubepods.slice cgroup
    
gathering this data over time will allow setting the non-OpenShift and OpenShift memory allocation for the rest of the system
