### PR TITLE
add docker and atomic-openshift-node memory reporting

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_os_linux.yml
+++ b/ansible/roles/os_zabbix/vars/template_os_linux.yml
@@ -188,32 +188,32 @@ g_template_os_linux:
     multiplier: 1024
     units: B
 
-  - key: mem.system.slice.max
-    applications:
-    - Memory
-    value_type: int
-    description: "Max memory usage reading from system.slice cgroup"
-    units: B
-
   - key: mem.system.slice.current
     applications:
     - Memory
     value_type: int
-    description: "Current memory usage reading from system.slice cgroup"
-    units: B
-
-  - key: mem.kubepod.slice.max
-    applications:
-    - Memory
-    value_type: int
-    description: "Max memory usage reading from kubepod.slice cgroup"
+    description: "Current RSS memory usage reading from system.slice cgroup"
     units: B
 
   - key: mem.kubepod.slice.current
     applications:
     - Memory
     value_type: int
-    description: "Current memory usage reading from kubepod.slice cgroup"
+    description: "Current RSS memory usage reading from kubepod.slice cgroup"
+    units: B
+
+  - key: mem.docker.service.current
+    applications:
+    - Memory
+    value_type: int
+    description: "Current RSS memory usage reading from system/docker.service cgroup"
+    units: B
+
+  - key: mem.aos-node.service.current
+    applications:
+    - Memory
+    value_type: int
+    description: "Current RSS memory usage reading from system/atomic-openshift-node.service cgroup"
     units: B
 
   # security items

--- a/scripts/monitoring/cron-send-cgroup-slice-metrics.sh
+++ b/scripts/monitoring/cron-send-cgroup-slice-metrics.sh
@@ -1,19 +1,25 @@
 #!/bin/bash -e
 
-SYSTEM_MAX_MEM=$(cat /sys/fs/cgroup/memory/system.slice/memory.max_usage_in_bytes)
-SYSTEM_CURR_MEM=$(cat /sys/fs/cgroup/memory/system.slice/memory.usage_in_bytes)
+SYSTEM_CURR_MEM=$(cat /sys/fs/cgroup/memory/system.slice/memory.stat | awk '/^total_rss / { print $2 }')
 
-KUBEPOD_MAX_MEM=$(cat /sys/fs/cgroup/memory/kubepods.slice/memory.max_usage_in_bytes)
-KUBEPOD_CURR_MEM=$(cat /sys/fs/cgroup/memory/kubepods.slice/memory.usage_in_bytes)
+KUBEPOD_CURR_MEM=$(cat /sys/fs/cgroup/memory/kubepods.slice/memory.stat | awk '/^total_rss / { print $2 }')
+
+DOCKER_CURR_MEM=$(cat /sys/fs/cgroup/memory/system.slice/docker.service/memory.stat | awk '/^total_rss / { print $2 }')
+
+ATOMIC_OPENSHIFT_NODE_CURR_MEM=$(cat /sys/fs/cgroup/memory/system.slice/atomic-openshift-node.service/memory.stat | awk '/^total_rss / { print $2 }')
 
 echo "system.slice current: $SYSTEM_CURR_MEM"
-echo "system.slice max:     $SYSTEM_MAX_MEM"
 
 echo "kubepod.slice current: $KUBEPOD_CURR_MEM"
-echo "kubepod.slice max:     $KUBEPOD_MAX_MEM"
+
+echo "docker.service current: $DOCKER_CURR_MEM"
+
+echo "aos-node current: $ATOMIC_OPENSHIFT_NODE_CURR_MEM"
 
 ops-metric-client -k "mem.system.slice.current" -o "$SYSTEM_CURR_MEM"
-ops-metric-client -k "mem.system.slice.max" -o "$SYSTEM_MAX_MEM"
 
 ops-metric-client -k "mem.kubepod.slice.current" -o "$KUBEPOD_CURR_MEM"
-ops-metric-client -k "mem.kubepod.slice.max" -o "$KUBEPOD_MAX_MEM"
+
+ops-metric-client -k "mem.docker.service.current" -o "$DOCKER_CURR_MEM"
+
+ops-metric-client -k "mem.aos-node.service.current" -o "$ATOMIC_OPENSHIFT_NODE_CURR_MEM"


### PR DESCRIPTION
change system and kubepods slice reporting to read RSS (to avoid counting page cache)
    
remove max reporting (we can just view the graph over time)