### PR TITLE
tag centos images so fedora know to push them out to docker hub

### DIFF
--- a/docker/oso-host-monitoring/centos7/build.sh
+++ b/docker/oso-host-monitoring/centos7/build.sh
@@ -42,4 +42,4 @@ container_fingerprint='./container-build-env-fingerprint.output'
 echo
 echo "Building oso-centos7-host-monitoring..."
 sudo time docker build $@ -t oso-centos7-host-monitoring .
-sudo docker tag oso-centos7-host-monitoring openshifttools/oso-centos7-host-monitoring:latest
+sudo docker tag oso-centos7-host-monitoring docker.io/openshifttools/oso-centos7-host-monitoring:latest

--- a/docker/oso-host-monitoring/centos7/push.sh
+++ b/docker/oso-host-monitoring/centos7/push.sh
@@ -17,5 +17,5 @@ if ../../oso-ops-base/centos7/push.sh ; then
   echo
   echo "Pushing oso-centos7-host-monitoring..."
   echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-  sudo docker push openshifttools/oso-centos7-host-monitoring
+  sudo docker push docker.io/openshifttools/oso-centos7-host-monitoring
 fi

--- a/docker/oso-host-monitoring/src/build.sh.j2
+++ b/docker/oso-host-monitoring/src/build.sh.j2
@@ -37,5 +37,5 @@ echo "Building oso-{{ base_os }}-host-monitoring..."
 sudo time docker build $@ -t oso-rhel7-host-monitoring .
 {% elif base_os == "centos7" %}
 sudo time docker build $@ -t oso-centos7-host-monitoring .
-sudo docker tag oso-centos7-host-monitoring openshifttools/oso-centos7-host-monitoring:latest
+sudo docker tag oso-centos7-host-monitoring docker.io/openshifttools/oso-centos7-host-monitoring:latest
 {% endif %}

--- a/docker/oso-host-monitoring/src/push.sh.j2
+++ b/docker/oso-host-monitoring/src/push.sh.j2
@@ -18,6 +18,6 @@ if ../../oso-ops-base/{{ base_os }}/push.sh ; then
   echo "No push for rhel7, use the automation on tower"
 {% elif base_os == "centos7" %}
   echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-  sudo docker push openshifttools/oso-centos7-host-monitoring
+  sudo docker push docker.io/openshifttools/oso-centos7-host-monitoring
 {% endif %}
 fi

--- a/docker/oso-ops-base/centos7/Dockerfile
+++ b/docker/oso-ops-base/centos7/Dockerfile
@@ -60,3 +60,4 @@ RUN echo -e '[local]\nlocalhost       ansible_connection=local\n' > /etc/ansible
 # BE CAREFUL!!! If you change these, you may bloat the image! Use 'docker history' to see the size!
 RUN chmod -R g+rwX /root/
 
+

--- a/docker/oso-ops-base/centos7/build.sh
+++ b/docker/oso-ops-base/centos7/build.sh
@@ -32,5 +32,5 @@ cd $(dirname $0)
 echo
 echo "Building oso-centos7-ops-base..."
 sudo time docker build $@ -t oso-centos7-ops-base .
-sudo docker tag oso-centos7-ops-base openshifttools/oso-centos7-ops-base:latest
+sudo docker tag oso-centos7-ops-base docker.io/openshifttools/oso-centos7-ops-base:latest
 

--- a/docker/oso-ops-base/centos7/push.sh
+++ b/docker/oso-ops-base/centos7/push.sh
@@ -13,4 +13,4 @@
 echo
 echo "Pushing oso-centos7-ops-base..."
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-ops-base
+sudo docker push docker.io/openshifttools/oso-centos7-ops-base

--- a/docker/oso-ops-base/rhel7/Dockerfile
+++ b/docker/oso-ops-base/rhel7/Dockerfile
@@ -61,4 +61,10 @@ RUN echo -e '[local]\nlocalhost       ansible_connection=local\n' > /etc/ansible
 # BE CAREFUL!!! If you change these, you may bloat the image! Use 'docker history' to see the size!
 RUN chmod -R g+rwX /root/
 
+
+# This is a temporary fix, until we find something that works better, PRs are welcome
+# The reason for this change is that some repos get disabled, especially with the latest rhel74 image
+# so this was added so other containers can start with their repos properly enabled
+# this change might have been that there was a bug in yum-config-manager previously, that didn't
+# actually disable every repo and now it does, or maybe something else, further research is required
 RUN yum-config-manager --enable rhel-7-server-rpms rhel-7-server-extras-rpms epel

--- a/docker/oso-ops-base/src/Dockerfile.j2
+++ b/docker/oso-ops-base/src/Dockerfile.j2
@@ -65,11 +65,11 @@ RUN echo -e '[local]\nlocalhost       ansible_connection=local\n' > /etc/ansible
 RUN chmod -R g+rwX /root/
 
 
+{% if base_os == "rhel7" %}
 # This is a temporary fix, until we find something that works better, PRs are welcome
 # The reason for this change is that some repos get disabled, especially with the latest rhel74 image
 # so this was added so other containers can start with their repos properly enabled
 # this change might have been that there was a bug in yum-config-manager previously, that didn't
 # actually disable every repo and now it does, or maybe something else, further research is required
-{% if base_os == "rhel7" %}
 RUN yum-config-manager --enable rhel-7-server-rpms rhel-7-server-extras-rpms epel
 {% endif %}

--- a/docker/oso-ops-base/src/build.sh.j2
+++ b/docker/oso-ops-base/src/build.sh.j2
@@ -52,7 +52,7 @@ sudo time docker build $@ -t oso-rhel7-ops-base .
 sudo docker tag oso-rhel7-ops-base docker-registry.ops.rhcloud.com/ops/oso-rhel7-ops-base
 {% elif base_os == "centos7" %}
 sudo time docker build $@ -t oso-centos7-ops-base .
-sudo docker tag oso-centos7-ops-base openshifttools/oso-centos7-ops-base:latest
+sudo docker tag oso-centos7-ops-base docker.io/openshifttools/oso-centos7-ops-base:latest
 {% endif %}
 
 {% if base_os == "rhel7" %}

--- a/docker/oso-ops-base/src/push.sh.j2
+++ b/docker/oso-ops-base/src/push.sh.j2
@@ -14,5 +14,5 @@ echo "Pushing oso-{{ base_os }}-ops-base..."
 sudo docker push docker-registry.ops.rhcloud.com/ops/oso-{{ base_os }}-ops-base
 {% elif base_os == "centos7" %}
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-ops-base
+sudo docker push docker.io/openshifttools/oso-centos7-ops-base
 {% endif %}

--- a/docker/oso-zabbix-server/centos7/build.sh
+++ b/docker/oso-zabbix-server/centos7/build.sh
@@ -26,4 +26,4 @@ sudo echo -e "\nTesting sudo works...\n"
 
 cd $(dirname $0)
 sudo time docker build -t oso-centos7-zabbix-server .
-sudo docker tag oso-centos7-zabbix-server openshifttools/oso-centos7-zabbix-server:latest
+sudo docker tag oso-centos7-zabbix-server docker.io/openshifttools/oso-centos7-zabbix-server:latest

--- a/docker/oso-zabbix-server/centos7/push.sh
+++ b/docker/oso-zabbix-server/centos7/push.sh
@@ -13,4 +13,4 @@
 echo
 echo "Pushing oso-centos7-zabbix-server..."
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-zabbix-server
+sudo docker push docker.io/openshifttools/oso-centos7-zabbix-server

--- a/docker/oso-zabbix-server/src/build.sh.j2
+++ b/docker/oso-zabbix-server/src/build.sh.j2
@@ -21,5 +21,5 @@ cd $(dirname $0)
 sudo time docker build -t oso-rhel7-zabbix-server .
 {% elif base_os == "centos7" %}
 sudo time docker build -t oso-centos7-zabbix-server .
-sudo docker tag oso-centos7-zabbix-server openshifttools/oso-centos7-zabbix-server:latest
+sudo docker tag oso-centos7-zabbix-server docker.io/openshifttools/oso-centos7-zabbix-server:latest
 {% endif %}

--- a/docker/oso-zabbix-server/src/push.sh.j2
+++ b/docker/oso-zabbix-server/src/push.sh.j2
@@ -14,5 +14,5 @@ echo "Pushing oso-{{ base_os }}-zabbix-server..."
 echo "oso-rhel7-zabbix-server isn't pushed to any Docker repository"
 {% elif base_os == "centos7" %}
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-zabbix-server
+sudo docker push docker.io/openshifttools/oso-centos7-zabbix-server
 {% endif %}

--- a/docker/oso-zabbix-web/centos7/build.sh
+++ b/docker/oso-zabbix-web/centos7/build.sh
@@ -26,4 +26,4 @@ sudo echo -e "\nTesting sudo works...\n"
 
 cd $(dirname $0)
 sudo time docker build -t oso-centos7-zabbix-web .
-sudo docker tag oso-centos7-zabbix-web openshifttools/oso-centos7-zabbix-web:latest
+sudo docker tag oso-centos7-zabbix-web docker.io/openshifttools/oso-centos7-zabbix-web:latest

--- a/docker/oso-zabbix-web/centos7/push.sh
+++ b/docker/oso-zabbix-web/centos7/push.sh
@@ -13,4 +13,4 @@
 echo
 echo "Pushing oso-centos7-ops-base..."
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-zabbix-web
+sudo docker push docker.io/openshifttools/oso-centos7-zabbix-web

--- a/docker/oso-zabbix-web/src/build.sh.j2
+++ b/docker/oso-zabbix-web/src/build.sh.j2
@@ -21,5 +21,5 @@ cd $(dirname $0)
 sudo time docker build -t oso-rhel7-zabbix-web .
 {% elif base_os == "centos7" %}
 sudo time docker build -t oso-centos7-zabbix-web .
-sudo docker tag oso-centos7-zabbix-web openshifttools/oso-centos7-zabbix-web:latest
+sudo docker tag oso-centos7-zabbix-web docker.io/openshifttools/oso-centos7-zabbix-web:latest
 {% endif %}

--- a/docker/oso-zabbix-web/src/push.sh.j2
+++ b/docker/oso-zabbix-web/src/push.sh.j2
@@ -14,5 +14,5 @@ echo "Pushing oso-{{ base_os }}-ops-base..."
 echo "oso-rhel7-zabbix-web isn't pushed to any Docker repository"
 {% elif base_os == "centos7" %}
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-zabbix-web
+sudo docker push docker.io/openshifttools/oso-centos7-zabbix-web
 {% endif %}

--- a/docker/oso-zagg-web/centos7/build.sh
+++ b/docker/oso-zagg-web/centos7/build.sh
@@ -26,4 +26,4 @@ sudo echo -e "\nTesting sudo works...\n"
 
 cd $(dirname $0)
 sudo time docker build $@ -t oso-centos7-zagg-web .
-sudo docker tag oso-centos7-zagg-web openshifttools/oso-centos7-zagg-web:latest
+sudo docker tag oso-centos7-zagg-web docker.io/openshifttools/oso-centos7-zagg-web:latest

--- a/docker/oso-zagg-web/centos7/push.sh
+++ b/docker/oso-zagg-web/centos7/push.sh
@@ -13,4 +13,4 @@
 echo
 echo "Pushing oso-centos7-ops-base..."
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-zagg-web
+sudo docker push docker.io/openshifttools/oso-centos7-zagg-web

--- a/docker/oso-zagg-web/src/build.sh.j2
+++ b/docker/oso-zagg-web/src/build.sh.j2
@@ -21,5 +21,5 @@ cd $(dirname $0)
 sudo time docker build $@ -t oso-rhel7-zagg-web .
 {% elif base_os == "centos7" %}
 sudo time docker build $@ -t oso-centos7-zagg-web .
-sudo docker tag oso-centos7-zagg-web openshifttools/oso-centos7-zagg-web:latest
+sudo docker tag oso-centos7-zagg-web docker.io/openshifttools/oso-centos7-zagg-web:latest
 {% endif %}

--- a/docker/oso-zagg-web/src/push.sh.j2
+++ b/docker/oso-zagg-web/src/push.sh.j2
@@ -14,5 +14,5 @@ echo "oso-rhel7-zagg-web isn't pushed to any Docker repository"
 {% elif base_os == "centos7" %}
 echo "Pushing oso-centos7-ops-base..."
 echo "Ensure you have successfully authenticated against docker with a 'docker login'"
-sudo docker push openshifttools/oso-centos7-zagg-web
+sudo docker push docker.io/openshifttools/oso-centos7-zagg-web
 {% endif %}


### PR DESCRIPTION
newer fedora releases don't assume docker hub as the default repo. tag images to make things more explicit.