### PR TITLE
Add early log/drop for udp 80 traffic

### DIFF
--- a/ansible/roles/openshift_udp_limits/tasks/main.yml
+++ b/ansible/roles/openshift_udp_limits/tasks/main.yml
@@ -65,6 +65,8 @@
         {# Note: sdodson says that pod DNS resolution happens via dnsmasq running on the node. That's
                  why we only have DNS traffic to the node whitelisted prior to rate limiting. #}
         -A oo-udp -d {{ oudp_node_ip }}/32 -o eth0 -p udp -m udp --dport 53 -j RETURN
+        -A oo-udp -o eth0 -p udp -m limit --limit 1/min --limit-burst 10 -j LOG --log-prefix "UDP outlog: DROPPED_80:"
+        -A oo-udp -o eth0 -p udp -m udp --dport 80 -j DROP
         -A oo-udp -s {{ node_cidr }} -o eth0 -p udp -j oo-udp-limit
         -A oo-udp -o eth0 -p udp -m udp --dport 53 -j RETURN
         -A oo-udp -o eth0 -p udp -m udp --dport 67 -j RETURN


### PR DESCRIPTION
Adding early log and drop rules within oo-udp to help identify and drop traffic prior to rate limited exceptions for expediency.

