### PR TITLE
Metrics check changes: update API endpoint and bucket size

### DIFF
--- a/scripts/monitoring/cron-send-metrics-checks.py
+++ b/scripts/monitoring/cron-send-metrics-checks.py
@@ -181,8 +181,8 @@ class OpenshiftMetricsStatus(object):
                    "Hawkular-tenant": "_system"}
 
         # Build url
-        hawkular_url_start = "https://{}/hawkular/metrics/gauges/data?tags=nodename:".format(route)
-        hawkular_url_end = ",type:node,group_id:/memory/usage&buckets=1&start=-2mn&end=-1mn"
+        hawkular_url_start = "https://{}/hawkular/metrics/gauges/rate/stats?tags=nodename:".format(route)
+        hawkular_url_end = ",type:node,group_id:/memory/usage&buckets=1&start=-5mn&end=-1mn"
 
         # Loop through nodes
         for item in nodes['items']:


### PR DESCRIPTION
This changes the endpoint used by the metrics check to check node health. The former endpoint was deprecated; the data returned by the new one is still the same format. 

This also changes the size of the bucket from 1 min to 4. This is to account for the fact that, on larger clusters, heapster can sometimes be slow to feed metrics into hawkular and will sometimes find nodes that haven't yet gotten a new metric within that one minute window. By expanding the window a bit, the metric just needs to have 1 data point within that 4 minute window. This should help to minimize false positives from the metrics check.

We'll still get log spam in the hawkular-metrics pod due to our check, but this appears to be an issue with the product API and now how we are calling it: https://issues.jboss.org/browse/HWKMETRICS-580s