### PR TITLE
fix mis-spell in logging check script and add trigger for the logging

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
@@ -47,30 +47,36 @@ g_template_logging:
     priority: high
 
   zdiscoveryrules:
-  - name: openshift.logging.elasticsarch.pods
-    key: openshift.logging.elasticsarch.pods
+  - name: openshift.logging.elasticsearch.pods
+    key: openshift.logging.elasticsearch.pods
     lifetime: 7
     description: "Elasticsearch pods"
  
   zitemprototypes:
-  - discoveryrule_key: openshift.logging.elasticsarch.pods
-    name: "{% raw %}openshift.logging.elasticsarch.pod_health.{{ '{#' }}OSO_METRICS}{% endraw %}"
-    key: "{% raw %}openshift.logging.elasticsarch.pod_health[{{ '{#' }}OSO_METRICS}]{% endraw %}"
+  - discoveryrule_key: openshift.logging.elasticsearch.pods
+    name: "{% raw %}openshift.logging.elasticsearch.pod_health.{{ '{#' }}OSO_METRICS}{% endraw %}"
+    key: "{% raw %}openshift.logging.elasticsearch.pod_health[{{ '{#' }}OSO_METRICS}]{% endraw %}"
     value_type: int
     description: "elasticsearch pod health status"
     applications:
     - EFK
-  - discoveryrule_key: openshift.logging.elasticsarch.pods
-    name: "{% raw %}openshift.logging.elasticsarch.disk_used.{{ '{#' }}OSO_METRICS}{% endraw %}"
-    key: "{% raw %}openshift.logging.elasticsarch.disk_used[{{ '{#' }}OSO_METRICS}]{% endraw %}"
+  - discoveryrule_key: openshift.logging.elasticsearch.pods
+    name: "{% raw %}openshift.logging.elasticsearch.disk_used.{{ '{#' }}OSO_METRICS}{% endraw %}"
+    key: "{% raw %}openshift.logging.elasticsearch.disk_used[{{ '{#' }}OSO_METRICS}]{% endraw %}"
     value_type: int
     description: "elasticsearch pv disk usage"
     applications:
     - EFK
-  - discoveryrule_key: openshift.logging.elasticsarch.pods
-    name: "{% raw %}openshift.logging.elasticsarch.disk_free.{{ '{#' }}OSO_METRICS}{% endraw %}"
-    key: "{% raw %}openshift.logging.elasticsarch.disk_free[{{ '{#' }}OSO_METRICS}]{% endraw %}"
+  - discoveryrule_key: openshift.logging.elasticsearch.pods
+    name: "{% raw %}openshift.logging.elasticsearch.disk_free.{{ '{#' }}OSO_METRICS}{% endraw %}"
+    key: "{% raw %}openshift.logging.elasticsearch.disk_free[{{ '{#' }}OSO_METRICS}]{% endraw %}"
     value_type: int
     description: "elasticsearch pv free space"
     applications:
     - EFK
+
+  ztriggerprototypes:
+  - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster is not green on {HOST.NAME}{% endraw %}"
+    expression: "{% raw %}{Template OpenShift Logging:openshift.logging.elasticsearch.pod_health[{{ '{#' }}OSO_METRICS}].last()}<2{% endraw %}"
+    url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_logging.asciidoc"
+    priority: high

--- a/scripts/monitoring/cron-send-logging-checks.py
+++ b/scripts/monitoring/cron-send-logging-checks.py
@@ -245,8 +245,8 @@ class OpenshiftLoggingStatus(object):
 
     def report_to_zabbix(self, logging_status):
         ''' Report all of our findings to zabbix '''
-        self.metric_sender.add_dynamic_metric('openshift.logging.elasticsarch.pods',
-                                              '#OSO_ELASTIC',
+        self.metric_sender.add_dynamic_metric('openshift.logging.elasticsearch.pods',
+                                              '#OSO_METRICS',
                                               logging_status['elasticsearch']['pods'].keys())
         for item, data in logging_status.iteritems():
             if item == "fluentd":
@@ -265,9 +265,9 @@ class OpenshiftLoggingStatus(object):
                 })
                 for pod, value in data['pods'].iteritems():
                     self.metric_sender.add_metric({
-                        "openshift.logging.elasticsarch.pod_health[%s]" %(pod): value['elasticsearch_health'],
-                        "openshift.logging.elasticsarch.disk_used[%s]" %(pod): value['disk']['used'],
-                        "openshift.logging.elasticsarch.disk_free[%s]" %(pod): value['disk']['free']
+                        "openshift.logging.elasticsearch.pod_health[%s]" %(pod): value['elasticsearch_health'],
+                        "openshift.logging.elasticsearch.disk_used[%s]" %(pod): value['disk']['used'],
+                        "openshift.logging.elasticsearch.disk_free[%s]" %(pod): value['disk']['free']
                     })
         self.metric_sender.send_metrics()
 


### PR DESCRIPTION
fix mis-spell in logging check script and add trigger for the logging es cluster when the status of es cluster is not green 

@drewandersonnz  +1 on #3203 