### PR TITLE
 /usr/bin/oadm does not exist in OCP 3.8

### DIFF
--- a/ansible/roles/lib_openshift_3.2/build/lib/base.py
+++ b/ansible/roles/lib_openshift_3.2/build/lib/base.py
@@ -215,7 +215,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/build/lib/base.py
+++ b/ansible/roles/lib_openshift_3.2/build/lib/base.py
@@ -215,7 +215,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_ca.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_ca.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_ca.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_ca.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_manage_node.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_manage_node.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_manage_node.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_manage_node.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_policy_user.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_policy_user.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_policy_user.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_policy_user.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_project.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_project.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_project.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_project.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_registry.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_registry.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_registry.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_registry.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_router.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_router.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oadm_router.py
+++ b/ansible/roles/lib_openshift_3.2/library/oadm_router.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_edit.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_edit.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_edit.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_edit.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_env.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_env.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_env.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_env.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_group.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_group.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_group.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_group.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_image.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_image.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_image.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_image.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_label.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_label.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_label.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_label.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_obj.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_obj.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_obj.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_obj.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_process.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_process.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_process.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_process.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_pvc.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_pvc.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_pvc.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_pvc.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_route.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_route.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_route.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_route.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_scale.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_scale.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_scale.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_scale.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_secret.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_secret.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_secret.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_secret.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_secret_add.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_secret_add.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_secret_add.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_secret_add.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_service.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_service.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_service.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_service.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_serviceaccount.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_serviceaccount.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_serviceaccount.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_serviceaccount.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_user.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_user.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_user.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_user.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_version.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_version.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_version.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_version.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_volume.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_volume.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oc adm']
+            cmds = ['/usr/bin/oc', 'adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/lib_openshift_3.2/library/oc_volume.py
+++ b/ansible/roles/lib_openshift_3.2/library/oc_volume.py
@@ -222,7 +222,7 @@ class OpenShiftCLI(object):
         '''Base command for oc '''
         cmds = []
         if oadm:
-            cmds = ['/usr/bin/oadm']
+            cmds = ['/usr/bin/oc adm']
         else:
             cmds = ['/usr/bin/oc']
 

--- a/ansible/roles/openshift_node_schedulable/tasks/main.yml
+++ b/ansible/roles/openshift_node_schedulable/tasks/main.yml
@@ -15,7 +15,7 @@
 
 # Attempt to drain nodes for 2 hours before giving up. Continue with upgrade if drain fails after that long
 - name: Drain Node (when specified)
-  command: /usr/bin/oadm drain "{{ node_dns_name }}"  --force --delete-local-data --ignore-daemonsets
+  command: /usr/bin/oc adm drain "{{ node_dns_name }}"  --force --delete-local-data --ignore-daemonsets
   delegate_to: "{{ osns_cluster_master }}"
   register: result_drain
   when: osns_drain is defined

--- a/ansible/roles/openshift_reconcile_cluster_roles/tasks/main.yml
+++ b/ansible/roles/openshift_reconcile_cluster_roles/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Reconcile cluster roles
-  command: /usr/bin/oadm --config=/etc/origin/master/admin.kubeconfig policy reconcile-cluster-roles --additive-only=true --confirm
+  command: /usr/bin/oc adm --config=/etc/origin/master/admin.kubeconfig policy reconcile-cluster-roles --additive-only=true --confirm
 
 - name: Reconcile cluster role bindings
-  command: /usr/bin/oadm --config=/etc/origin/master/admin.kubeconfig policy reconcile-cluster-role-bindings --exclude-groups=system:authenticated --exclude-groups=system:authenticated:oauth --exclude-users=system:anonymous --additive-only=true --confirm
+  command: /usr/bin/oc adm --config=/etc/origin/master/admin.kubeconfig policy reconcile-cluster-role-bindings --exclude-groups=system:authenticated --exclude-groups=system:authenticated:oauth --exclude-users=system:anonymous --additive-only=true --confirm
 
 - name: Reconcile Security Context Constraints
-  command: /usr/bin/oadm policy reconcile-sccs --confirm --additive-only=true
+  command: /usr/bin/oc adm policy reconcile-sccs --confirm --additive-only=true

--- a/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
+++ b/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
@@ -51,7 +51,6 @@ ExecStart=/usr/bin/docker run --name {{ osohm_host_monitoring }}                
            -v /etc/origin/node:/etc/origin/node                                                     \
 {% endif %}
            -v /usr/bin/oc:/usr/bin/oc                                                               \
-           -v /usr/bin/oadm:/usr/bin/oadm                                                           \
            -v /:/host:ro,rslave                                                                     \
            -v /var/cache/yum:/host/var/cache/yum:rw                                                 \
            -v /etc/openshift_tools:/container_setup:ro                                              \

--- a/openshift_tools/python-openshift-tools.spec
+++ b/openshift_tools/python-openshift-tools.spec
@@ -176,9 +176,8 @@ GCP Python libraries developed for monitoring OpenShift.
 # ----------------------------------------------------------------------------------
 %package monitoring-openshift
 Summary:       OpenShift Tools Openshift Python Libraries Package
-# Requiring on /usr/bin/oadm (atomic-openshift or upstream origin
 # and /usr/bin/oc (atomic-openshift-clients or upstream origin-clients)
-Requires:      python2,python-openshift-tools,/usr/bin/oadm,/usr/bin/oc
+Requires:      python2,python-openshift-tools,/usr/bin/oc
 BuildArch:     noarch
 
 %description monitoring-openshift


### PR DESCRIPTION
Tested in Starter, Pro, Dedicated. Approved in PR #3238 