### PR TITLE
use 'oc adm' instead of deprecated 'oadm'

### DIFF
--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -34,7 +34,7 @@ ADD check-pmcd-status.sh /usr/local/bin/check-pmcd-status.sh
 
 
 RUN echo -e "\n\nalias oca='KUBECONFIG=/tmp/admin.kubeconfig oc '" >> /root/.bashrc
-RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oadm '" >> /root/.bashrc
+RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oc adm '" >> /root/.bashrc
 
 {% if base_os == "rhel7" %}
 # /usr/bin/oc workaround

--- a/openshift_tools/monitoring/oadmutil.py
+++ b/openshift_tools/monitoring/oadmutil.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # vim: expandtab:tabstop=4:shiftwidth=4
 '''
-  Interface to OpenShift oadm command
+  Interface to OpenShift 'oc adm' command
 '''
 #
 #   Copyright 2015 Red Hat Inc.
@@ -39,11 +39,11 @@ def cleanup_file(inc_file):
         pass
 
 class OadmUtil(object):
-    ''' Wrapper for interfacing with OpenShift 'oadm' utility '''
+    ''' Wrapper for interfacing with OpenShift 'oc adm' utility '''
 
     def __init__(self, namespace='default', config_file='/tmp/admin.kubeconfig', verbose=False):
         '''
-        Take initial values for running 'oadm'
+        Take initial values for running 'oc adm'
         Ensure to set non-default namespace if that is what is desired
         '''
         self.namespace = namespace
@@ -80,7 +80,7 @@ class OadmUtil(object):
     def get_version(self):
         ''' Get version of openshift/kubernetes '''
 
-        version_cmd = "oadm version "
+        version_cmd = "oc version "
         version_output = self._run_cmd(version_cmd)
 
         return version_output

--- a/scripts/monitoring/cron-openshift-pruner.py
+++ b/scripts/monitoring/cron-openshift-pruner.py
@@ -112,7 +112,7 @@ class OpenShiftPrune(object):
             if self.args.debug:
                 print "Granding image pruning perms"
 
-            cmd = ['oadm', 'policy', 'add-cluster-role-to-user',
+            cmd = ['oc', 'adm', 'policy', 'add-cluster-role-to-user',
                    'system:image-pruner', username,
                    '--config', self.args.kube_config]
             try:
@@ -150,11 +150,11 @@ class OpenShiftPrune(object):
         return token
 
     def prune_images(self):
-        ''' call oadm to prune images '''
+        ''' call oc adm to prune images '''
 
         token = self.get_autopruner_token()
 
-        cmd = ['oadm', 'prune', 'images',
+        cmd = ['oc, 'adm', 'prune', 'images',
                '--keep-younger-than', self.args.image_keep_younger_than,
                '--keep-tag-revisions', self.args.image_keep_tag_revisions,
                '--config', self.args.kube_config,
@@ -168,9 +168,9 @@ class OpenShiftPrune(object):
             print "Prune images output:\n" + output
 
     def prune_builds(self):
-        ''' call oadm to prune builds '''
+        ''' call oc adm to prune builds '''
 
-        cmd = ['oadm', 'prune', 'builds',
+        cmd = ['oc', 'adm', 'prune', 'builds',
                '--keep-complete', self.args.build_keep_complete,
                '--keep-younger-than', self.args.build_keep_younger_than,
                '--keep-failed', self.args.build_keep_failed,
@@ -184,9 +184,9 @@ class OpenShiftPrune(object):
             print "Prune build output:\n" + output
 
     def prune_deployments(self):
-        ''' call oadm to prune deployments '''
+        ''' call oc adm to prune deployments '''
 
-        cmd = ['oadm', 'prune', 'deployments',
+        cmd = ['oc', 'adm', 'prune', 'deployments',
                '--keep-complete', self.args.deploy_keep_complete,
                '--keep-younger-than', self.args.deploy_keep_younger_than,
                '--keep-failed', self.args.deploy_keep_failed,

--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -169,7 +169,7 @@ def setup(config):
 
     if not project:
         try:
-            runOCcmd("new-project {}".format(config.namespace), base_cmd='oadm')
+            runOCcmd("new-project {}".format(config.namespace), base_cmd='oc adm')
             time.sleep(commandDelay)
         except Exception:
             logger.exception('error creating new project')

--- a/scripts/monitoring/cron-send-project-operation.py
+++ b/scripts/monitoring/cron-send-project-operation.py
@@ -80,7 +80,7 @@ def check_project(config):
 def create_project(config):
     " create the project "
     try:
-        runOCcmd("new-project {}".format(config.namespace), base_cmd='oadm')
+        runOCcmd("new-project {}".format(config.namespace), base_cmd='oc adm')
         time.sleep(commandDelay)
     except Exception:
         logger.exception('error creating new project')


### PR DESCRIPTION
Approved in PR #3243 . Jenkins failures aren't related to this change.