### PR TITLE
rkhunter is stopping our monitoring from starting

### DIFF
--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -38,7 +38,7 @@ ADD check-pmcd-status.sh /usr/local/bin/check-pmcd-status.sh
 
 
 RUN echo -e "\n\nalias oca='KUBECONFIG=/tmp/admin.kubeconfig oc '" >> /root/.bashrc
-RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oadm '" >> /root/.bashrc
+RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oc adm '" >> /root/.bashrc
 
 
 

--- a/docker/oso-host-monitoring/centos7/root/config.yml
+++ b/docker/oso-host-monitoring/centos7/root/config.yml
@@ -18,16 +18,7 @@
     - /var/lib/yum
     - /var/cache/yum
 
-    rkhunter_cron:
-    - name: check_rkhunter
-      minute: "30"
-      hour: 21
-      job: "/usr/bin/cron-send-rkhunter-checks"
 
-    - name: rkhunter_scan
-      minute: "0"
-      hour: "21"
-      job: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter >/dev/null 2>&1"
 
   pre_tasks:
   - stat:
@@ -118,7 +109,6 @@
       weekday: "{{ item.weekday | default('*', True) }}"
     with_items:
     - "{{ host_monitoring_cron }}"
-    - "{{ rkhunter_cron }}"
 
   - name: stat the kubeconfig
     stat:
@@ -190,68 +180,3 @@
       src: "/host{{ item }}"
     with_items: "{{hostpkg_bindmnt_dirs}}"
 
-  - name: "Create bind mountpoints for rkhunter scans"
-    file:
-      path: "{{ item }}"
-      state: directory
-      recurse: yes
-    with_items:
-    - /var/local/rkhunter_chroot
-    - /var/local/rkhunter_tmp
-    - /var/local/rkhunter_tmp/rkhunter
-    - /var/local/rkhunter_tmp/rkhunter/bin
-    - /var/local/rkhunter_tmp/rkhunter/db
-    - /var/local/rkhunter_tmp/rkhunter/etc
-    - /var/local/rkhunter_tmp/rkhunter/scripts
-
-  - name: "Bind rkhunter scan directories"
-    mount:
-      opts: "{{ item.mnt_opts }}"
-      fstype: auto
-      state: mounted
-      name: "{{ item.mnt_name }}"
-      src: "{{ item.mnt_src }}"
-    with_items:
-    - mnt_src: "/usr/bin"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/bin"
-      mnt_opts: "bind,ro"
-    - mnt_src:  "/var/lib/rkhunter/db"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/db"
-      mnt_opts: "bind"
-    - mnt_src: "/usr/share/rkhunter/scripts/"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/scripts/"
-      mnt_opts: "bind,ro"
-
-  # Running as commands because mount module doesn't seem to recognize rbind
-  - name: "Bind more rkhunter scan directories"
-    command: "{{ item }}"
-    with_items:
-    - "mount --rbind -o ro /host /var/local/rkhunter_chroot"
-    - "mount --rbind /var/local/rkhunter_tmp /var/local/rkhunter_chroot/tmp"
-
-  - name: "Set initial values for rkhunter to use"
-    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --propupd --pkgmgr RPM --nomow -q"
-
-  - name: "Run a no-log scan to get copies of passwd and group"
-    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter -q --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --nolog"
-    ignore_errors: yes
-
-  - name: "create rkhunter variables file"
-    copy:
-      dest: "/etc/openshift_tools/rkhunter_config.yaml"
-      content: |-
-        ---
-        logfile: /var/local/rkhunter_tmp/rkhunter/rkhunter.log
-
-  - name: "Set additional rkhunter ignore rules"
-    blockinfile:
-      dest: "/var/local/rkhunter_tmp/rkhunter/etc/rkhunter.conf"
-      insertafter: "ALLOWHIDDENDIR"
-      marker: "# {mark} Ansible-managed rkhunter ignore rules"
-      block: |-
-        ALLOWHIDDENDIR=/dev/shm/.ansible
-        ALLOWDEVDIR=/dev/shm/.ansible/*
-        ALLOWDEVDIR=/dev/shm/.ansible/tmp/*
-        ALLOWDEVDIR=/dev/shm/.ansible/tmp/account/*
-        ALLOWDEVFILE=/dev/shm/.ansible/tmp/*
-        ALLOWDEVFILE=/dev/shm/.ansible/tmp/account/*

--- a/docker/oso-host-monitoring/centos7/root/rkhunter.yml
+++ b/docker/oso-host-monitoring/centos7/root/rkhunter.yml
@@ -1,0 +1,104 @@
+#     ___ ___ _  _ ___ ___    _ _____ ___ ___         
+#    / __| __| \| | __| _ \  /_\_   _| __|   \        
+#   | (_ | _|| .` | _||   / / _ \| | | _|| |) |       
+#    \___|___|_|\_|___|_|_\/_/_\_\_|_|___|___/_ _____ 
+#   |   \ / _ \  | \| |/ _ \_   _| | __|   \_ _|_   _|
+#   | |) | (_) | | .` | (_) || |   | _|| |) | |  | |  
+#   |___/ \___/  |_|\_|\___/ |_|   |___|___/___| |_|  
+# 
+
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+
+    rkhunter_cron:
+    - name: check_rkhunter
+      minute: "30"
+      hour: 21
+      job: "/usr/bin/cron-send-rkhunter-checks"
+
+    - name: rkhunter_scan
+      minute: "0"
+      hour: "21"
+      job: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter >/dev/null 2>&1"
+
+  pre_tasks:
+
+  - name: Setup Cron
+    cron:
+      name: "{{ item.name }}"
+      job: "{{ item.job }}"
+      minute: "{{ item.minute | default('*', True) }}"
+      hour: "{{ item.hour | default('*', True) }}"
+      day: "{{ item.day | default('*', True) }}"
+      month: "{{ item.month | default('*', True) }}"
+      weekday: "{{ item.weekday | default('*', True) }}"
+    with_items:
+    - "{{ rkhunter_cron }}"
+
+  - name: "Create bind mountpoints for rkhunter scans"
+    file:
+      path: "{{ item }}"
+      state: directory
+      recurse: yes
+    with_items:
+    - /var/local/rkhunter_chroot
+    - /var/local/rkhunter_tmp
+    - /var/local/rkhunter_tmp/rkhunter
+    - /var/local/rkhunter_tmp/rkhunter/bin
+    - /var/local/rkhunter_tmp/rkhunter/db
+    - /var/local/rkhunter_tmp/rkhunter/etc
+    - /var/local/rkhunter_tmp/rkhunter/scripts
+
+  - name: "Bind rkhunter scan directories"
+    mount:
+      opts: "{{ item.mnt_opts }}"
+      fstype: auto
+      state: mounted
+      name: "{{ item.mnt_name }}"
+      src: "{{ item.mnt_src }}"
+    with_items:
+    - mnt_src: "/usr/bin"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/bin"
+      mnt_opts: "bind,ro"
+    - mnt_src:  "/var/lib/rkhunter/db"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/db"
+      mnt_opts: "bind"
+    - mnt_src: "/usr/share/rkhunter/scripts/"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/scripts/"
+      mnt_opts: "bind,ro"
+
+  # Running as commands because mount module doesn't seem to recognize rbind
+  - name: "Bind more rkhunter scan directories"
+    command: "{{ item }}"
+    with_items:
+    - "mount --rbind -o ro /host /var/local/rkhunter_chroot"
+    - "mount --rbind /var/local/rkhunter_tmp /var/local/rkhunter_chroot/tmp"
+
+  - name: "Set initial values for rkhunter to use"
+    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --propupd --pkgmgr RPM --nomow -q"
+
+  - name: "Run a no-log scan to get copies of passwd and group"
+    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter -q --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --nolog"
+    ignore_errors: yes
+
+  - name: "create rkhunter variables file"
+    copy:
+      dest: "/etc/openshift_tools/rkhunter_config.yaml"
+      content: |-
+        ---
+        logfile: /var/local/rkhunter_tmp/rkhunter/rkhunter.log
+
+  - name: "Set additional rkhunter ignore rules"
+    blockinfile:
+      dest: "/var/local/rkhunter_tmp/rkhunter/etc/rkhunter.conf"
+      insertafter: "ALLOWHIDDENDIR"
+      marker: "# {mark} Ansible-managed rkhunter ignore rules"
+      block: |-
+        ALLOWHIDDENDIR=/dev/shm/.ansible
+        ALLOWDEVDIR=/dev/shm/.ansible/*
+        ALLOWDEVDIR=/dev/shm/.ansible/tmp/*
+        ALLOWDEVDIR=/dev/shm/.ansible/tmp/account/*
+        ALLOWDEVFILE=/dev/shm/.ansible/tmp/*
+        ALLOWDEVFILE=/dev/shm/.ansible/tmp/account/*

--- a/docker/oso-host-monitoring/centos7/start.sh
+++ b/docker/oso-host-monitoring/centos7/start.sh
@@ -18,8 +18,8 @@ source /root/.bashrc
 time ansible-playbook /root/config.yml
 
 # Configure rkhunter
-echo '/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
-/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
+echo '/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
+/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
 
 # Send a heartbeat when the container starts up
 /usr/bin/ops-metric-client --send-heartbeat

--- a/docker/oso-host-monitoring/centos7/start.sh
+++ b/docker/oso-host-monitoring/centos7/start.sh
@@ -17,6 +17,10 @@ source /root/.bashrc
 # Configure the container
 time ansible-playbook /root/config.yml
 
+# Configure rkhunter
+echo '/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
+/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
+
 # Send a heartbeat when the container starts up
 /usr/bin/ops-metric-client --send-heartbeat
 

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -38,7 +38,7 @@ ADD check-pmcd-status.sh /usr/local/bin/check-pmcd-status.sh
 
 
 RUN echo -e "\n\nalias oca='KUBECONFIG=/tmp/admin.kubeconfig oc '" >> /root/.bashrc
-RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oadm '" >> /root/.bashrc
+RUN echo "alias oadma='KUBECONFIG=/tmp/admin.kubeconfig oc adm '" >> /root/.bashrc
 
 # /usr/bin/oc workaround
 # python-openshift-tools-monitoring-openshift depends on /usr/bin/oc

--- a/docker/oso-host-monitoring/rhel7/root/config.yml
+++ b/docker/oso-host-monitoring/rhel7/root/config.yml
@@ -20,16 +20,7 @@
     - /var/lib/yum
     - /var/cache/yum
 
-    rkhunter_cron:
-    - name: check_rkhunter
-      minute: "30"
-      hour: 21
-      job: "/usr/bin/cron-send-rkhunter-checks"
 
-    - name: rkhunter_scan
-      minute: "0"
-      hour: "21"
-      job: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter >/dev/null 2>&1"
 
   pre_tasks:
   - stat:
@@ -120,7 +111,6 @@
       weekday: "{{ item.weekday | default('*', True) }}"
     with_items:
     - "{{ host_monitoring_cron }}"
-    - "{{ rkhunter_cron }}"
 
   - name: stat the kubeconfig
     stat:
@@ -192,68 +182,3 @@
       src: "/host{{ item }}"
     with_items: "{{hostpkg_bindmnt_dirs}}"
 
-  - name: "Create bind mountpoints for rkhunter scans"
-    file:
-      path: "{{ item }}"
-      state: directory
-      recurse: yes
-    with_items:
-    - /var/local/rkhunter_chroot
-    - /var/local/rkhunter_tmp
-    - /var/local/rkhunter_tmp/rkhunter
-    - /var/local/rkhunter_tmp/rkhunter/bin
-    - /var/local/rkhunter_tmp/rkhunter/db
-    - /var/local/rkhunter_tmp/rkhunter/etc
-    - /var/local/rkhunter_tmp/rkhunter/scripts
-
-  - name: "Bind rkhunter scan directories"
-    mount:
-      opts: "{{ item.mnt_opts }}"
-      fstype: auto
-      state: mounted
-      name: "{{ item.mnt_name }}"
-      src: "{{ item.mnt_src }}"
-    with_items:
-    - mnt_src: "/usr/bin"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/bin"
-      mnt_opts: "bind,ro"
-    - mnt_src:  "/var/lib/rkhunter/db"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/db"
-      mnt_opts: "bind"
-    - mnt_src: "/usr/share/rkhunter/scripts/"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/scripts/"
-      mnt_opts: "bind,ro"
-
-  # Running as commands because mount module doesn't seem to recognize rbind
-  - name: "Bind more rkhunter scan directories"
-    command: "{{ item }}"
-    with_items:
-    - "mount --rbind -o ro /host /var/local/rkhunter_chroot"
-    - "mount --rbind /var/local/rkhunter_tmp /var/local/rkhunter_chroot/tmp"
-
-  - name: "Set initial values for rkhunter to use"
-    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --propupd --pkgmgr RPM --nomow -q"
-
-  - name: "Run a no-log scan to get copies of passwd and group"
-    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter -q --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --nolog"
-    ignore_errors: yes
-
-  - name: "create rkhunter variables file"
-    copy:
-      dest: "/etc/openshift_tools/rkhunter_config.yaml"
-      content: |-
-        ---
-        logfile: /var/local/rkhunter_tmp/rkhunter/rkhunter.log
-
-  - name: "Set additional rkhunter ignore rules"
-    blockinfile:
-      dest: "/var/local/rkhunter_tmp/rkhunter/etc/rkhunter.conf"
-      insertafter: "ALLOWHIDDENDIR"
-      marker: "# {mark} Ansible-managed rkhunter ignore rules"
-      block: |-
-        ALLOWHIDDENDIR=/dev/shm/.ansible
-        ALLOWDEVDIR=/dev/shm/.ansible/*
-        ALLOWDEVDIR=/dev/shm/.ansible/tmp/*
-        ALLOWDEVDIR=/dev/shm/.ansible/tmp/account/*
-        ALLOWDEVFILE=/dev/shm/.ansible/tmp/*
-        ALLOWDEVFILE=/dev/shm/.ansible/tmp/account/*

--- a/docker/oso-host-monitoring/rhel7/root/rkhunter.yml
+++ b/docker/oso-host-monitoring/rhel7/root/rkhunter.yml
@@ -1,0 +1,104 @@
+#     ___ ___ _  _ ___ ___    _ _____ ___ ___         
+#    / __| __| \| | __| _ \  /_\_   _| __|   \        
+#   | (_ | _|| .` | _||   / / _ \| | | _|| |) |       
+#    \___|___|_|\_|___|_|_\/_/_\_\_|_|___|___/_ _____ 
+#   |   \ / _ \  | \| |/ _ \_   _| | __|   \_ _|_   _|
+#   | |) | (_) | | .` | (_) || |   | _|| |) | |  | |  
+#   |___/ \___/  |_|\_|\___/ |_|   |___|___/___| |_|  
+# 
+
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+
+    rkhunter_cron:
+    - name: check_rkhunter
+      minute: "30"
+      hour: 21
+      job: "/usr/bin/cron-send-rkhunter-checks"
+
+    - name: rkhunter_scan
+      minute: "0"
+      hour: "21"
+      job: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter >/dev/null 2>&1"
+
+  pre_tasks:
+
+  - name: Setup Cron
+    cron:
+      name: "{{ item.name }}"
+      job: "{{ item.job }}"
+      minute: "{{ item.minute | default('*', True) }}"
+      hour: "{{ item.hour | default('*', True) }}"
+      day: "{{ item.day | default('*', True) }}"
+      month: "{{ item.month | default('*', True) }}"
+      weekday: "{{ item.weekday | default('*', True) }}"
+    with_items:
+    - "{{ rkhunter_cron }}"
+
+  - name: "Create bind mountpoints for rkhunter scans"
+    file:
+      path: "{{ item }}"
+      state: directory
+      recurse: yes
+    with_items:
+    - /var/local/rkhunter_chroot
+    - /var/local/rkhunter_tmp
+    - /var/local/rkhunter_tmp/rkhunter
+    - /var/local/rkhunter_tmp/rkhunter/bin
+    - /var/local/rkhunter_tmp/rkhunter/db
+    - /var/local/rkhunter_tmp/rkhunter/etc
+    - /var/local/rkhunter_tmp/rkhunter/scripts
+
+  - name: "Bind rkhunter scan directories"
+    mount:
+      opts: "{{ item.mnt_opts }}"
+      fstype: auto
+      state: mounted
+      name: "{{ item.mnt_name }}"
+      src: "{{ item.mnt_src }}"
+    with_items:
+    - mnt_src: "/usr/bin"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/bin"
+      mnt_opts: "bind,ro"
+    - mnt_src:  "/var/lib/rkhunter/db"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/db"
+      mnt_opts: "bind"
+    - mnt_src: "/usr/share/rkhunter/scripts/"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/scripts/"
+      mnt_opts: "bind,ro"
+
+  # Running as commands because mount module doesn't seem to recognize rbind
+  - name: "Bind more rkhunter scan directories"
+    command: "{{ item }}"
+    with_items:
+    - "mount --rbind -o ro /host /var/local/rkhunter_chroot"
+    - "mount --rbind /var/local/rkhunter_tmp /var/local/rkhunter_chroot/tmp"
+
+  - name: "Set initial values for rkhunter to use"
+    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --propupd --pkgmgr RPM --nomow -q"
+
+  - name: "Run a no-log scan to get copies of passwd and group"
+    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter -q --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --nolog"
+    ignore_errors: yes
+
+  - name: "create rkhunter variables file"
+    copy:
+      dest: "/etc/openshift_tools/rkhunter_config.yaml"
+      content: |-
+        ---
+        logfile: /var/local/rkhunter_tmp/rkhunter/rkhunter.log
+
+  - name: "Set additional rkhunter ignore rules"
+    blockinfile:
+      dest: "/var/local/rkhunter_tmp/rkhunter/etc/rkhunter.conf"
+      insertafter: "ALLOWHIDDENDIR"
+      marker: "# {mark} Ansible-managed rkhunter ignore rules"
+      block: |-
+        ALLOWHIDDENDIR=/dev/shm/.ansible
+        ALLOWDEVDIR=/dev/shm/.ansible/*
+        ALLOWDEVDIR=/dev/shm/.ansible/tmp/*
+        ALLOWDEVDIR=/dev/shm/.ansible/tmp/account/*
+        ALLOWDEVFILE=/dev/shm/.ansible/tmp/*
+        ALLOWDEVFILE=/dev/shm/.ansible/tmp/account/*

--- a/docker/oso-host-monitoring/rhel7/start.sh
+++ b/docker/oso-host-monitoring/rhel7/start.sh
@@ -18,8 +18,8 @@ source /root/.bashrc
 time ansible-playbook /root/config.yml
 
 # Configure rkhunter
-echo '/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
-/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
+echo '/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
+/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
 
 # Send a heartbeat when the container starts up
 /usr/bin/ops-metric-client --send-heartbeat

--- a/docker/oso-host-monitoring/rhel7/start.sh
+++ b/docker/oso-host-monitoring/rhel7/start.sh
@@ -17,6 +17,10 @@ source /root/.bashrc
 # Configure the container
 time ansible-playbook /root/config.yml
 
+# Configure rkhunter
+echo '/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
+/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
+
 # Send a heartbeat when the container starts up
 /usr/bin/ops-metric-client --send-heartbeat
 

--- a/docker/oso-host-monitoring/src/root/config.yml.j2
+++ b/docker/oso-host-monitoring/src/root/config.yml.j2
@@ -13,17 +13,8 @@
     - /var/lib/rpm
     - /var/lib/yum
     - /var/cache/yum
-{% raw %}
-    rkhunter_cron:
-    - name: check_rkhunter
-      minute: "30"
-      hour: 21
-      job: "/usr/bin/cron-send-rkhunter-checks"
 
-    - name: rkhunter_scan
-      minute: "0"
-      hour: "21"
-      job: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter >/dev/null 2>&1"
+{% raw %}
 
   pre_tasks:
   - stat:
@@ -115,7 +106,6 @@
       weekday: "{{ item.weekday | default('*', True) }}"
     with_items:
     - "{{ host_monitoring_cron }}"
-    - "{{ rkhunter_cron }}"
 
   - name: stat the kubeconfig
     stat:
@@ -187,69 +177,4 @@
       src: "/host{{ item }}"
     with_items: "{{hostpkg_bindmnt_dirs}}"
 
-  - name: "Create bind mountpoints for rkhunter scans"
-    file:
-      path: "{{ item }}"
-      state: directory
-      recurse: yes
-    with_items:
-    - /var/local/rkhunter_chroot
-    - /var/local/rkhunter_tmp
-    - /var/local/rkhunter_tmp/rkhunter
-    - /var/local/rkhunter_tmp/rkhunter/bin
-    - /var/local/rkhunter_tmp/rkhunter/db
-    - /var/local/rkhunter_tmp/rkhunter/etc
-    - /var/local/rkhunter_tmp/rkhunter/scripts
-
-  - name: "Bind rkhunter scan directories"
-    mount:
-      opts: "{{ item.mnt_opts }}"
-      fstype: auto
-      state: mounted
-      name: "{{ item.mnt_name }}"
-      src: "{{ item.mnt_src }}"
-    with_items:
-    - mnt_src: "/usr/bin"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/bin"
-      mnt_opts: "bind,ro"
-    - mnt_src:  "/var/lib/rkhunter/db"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/db"
-      mnt_opts: "bind"
-    - mnt_src: "/usr/share/rkhunter/scripts/"
-      mnt_name: "/var/local/rkhunter_tmp/rkhunter/scripts/"
-      mnt_opts: "bind,ro"
-
-  # Running as commands because mount module doesn't seem to recognize rbind
-  - name: "Bind more rkhunter scan directories"
-    command: "{{ item }}"
-    with_items:
-    - "mount --rbind -o ro /host /var/local/rkhunter_chroot"
-    - "mount --rbind /var/local/rkhunter_tmp /var/local/rkhunter_chroot/tmp"
-
-  - name: "Set initial values for rkhunter to use"
-    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --propupd --pkgmgr RPM --nomow -q"
-
-  - name: "Run a no-log scan to get copies of passwd and group"
-    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter -q --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --nolog"
-    ignore_errors: yes
-
-  - name: "create rkhunter variables file"
-    copy:
-      dest: "/etc/openshift_tools/rkhunter_config.yaml"
-      content: |-
-        ---
-        logfile: /var/local/rkhunter_tmp/rkhunter/rkhunter.log
-
-  - name: "Set additional rkhunter ignore rules"
-    blockinfile:
-      dest: "/var/local/rkhunter_tmp/rkhunter/etc/rkhunter.conf"
-      insertafter: "ALLOWHIDDENDIR"
-      marker: "# {mark} Ansible-managed rkhunter ignore rules"
-      block: |-
-        ALLOWHIDDENDIR=/dev/shm/.ansible
-        ALLOWDEVDIR=/dev/shm/.ansible/*
-        ALLOWDEVDIR=/dev/shm/.ansible/tmp/*
-        ALLOWDEVDIR=/dev/shm/.ansible/tmp/account/*
-        ALLOWDEVFILE=/dev/shm/.ansible/tmp/*
-        ALLOWDEVFILE=/dev/shm/.ansible/tmp/account/*
 {% endraw %}

--- a/docker/oso-host-monitoring/src/root/rkhunter.yml.j2
+++ b/docker/oso-host-monitoring/src/root/rkhunter.yml.j2
@@ -1,0 +1,97 @@
+{{ generated_header }}
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+{% raw %}
+    rkhunter_cron:
+    - name: check_rkhunter
+      minute: "30"
+      hour: 21
+      job: "/usr/bin/cron-send-rkhunter-checks"
+
+    - name: rkhunter_scan
+      minute: "0"
+      hour: "21"
+      job: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter >/dev/null 2>&1"
+
+  pre_tasks:
+
+  - name: Setup Cron
+    cron:
+      name: "{{ item.name }}"
+      job: "{{ item.job }}"
+      minute: "{{ item.minute | default('*', True) }}"
+      hour: "{{ item.hour | default('*', True) }}"
+      day: "{{ item.day | default('*', True) }}"
+      month: "{{ item.month | default('*', True) }}"
+      weekday: "{{ item.weekday | default('*', True) }}"
+    with_items:
+    - "{{ rkhunter_cron }}"
+
+  - name: "Create bind mountpoints for rkhunter scans"
+    file:
+      path: "{{ item }}"
+      state: directory
+      recurse: yes
+    with_items:
+    - /var/local/rkhunter_chroot
+    - /var/local/rkhunter_tmp
+    - /var/local/rkhunter_tmp/rkhunter
+    - /var/local/rkhunter_tmp/rkhunter/bin
+    - /var/local/rkhunter_tmp/rkhunter/db
+    - /var/local/rkhunter_tmp/rkhunter/etc
+    - /var/local/rkhunter_tmp/rkhunter/scripts
+
+  - name: "Bind rkhunter scan directories"
+    mount:
+      opts: "{{ item.mnt_opts }}"
+      fstype: auto
+      state: mounted
+      name: "{{ item.mnt_name }}"
+      src: "{{ item.mnt_src }}"
+    with_items:
+    - mnt_src: "/usr/bin"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/bin"
+      mnt_opts: "bind,ro"
+    - mnt_src:  "/var/lib/rkhunter/db"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/db"
+      mnt_opts: "bind"
+    - mnt_src: "/usr/share/rkhunter/scripts/"
+      mnt_name: "/var/local/rkhunter_tmp/rkhunter/scripts/"
+      mnt_opts: "bind,ro"
+
+  # Running as commands because mount module doesn't seem to recognize rbind
+  - name: "Bind more rkhunter scan directories"
+    command: "{{ item }}"
+    with_items:
+    - "mount --rbind -o ro /host /var/local/rkhunter_chroot"
+    - "mount --rbind /var/local/rkhunter_tmp /var/local/rkhunter_chroot/tmp"
+
+  - name: "Set initial values for rkhunter to use"
+    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --propupd --pkgmgr RPM --nomow -q"
+
+  - name: "Run a no-log scan to get copies of passwd and group"
+    command: "chroot /var/local/rkhunter_chroot /tmp/rkhunter/bin/rkhunter -q --sk --check --configfile /tmp/rkhunter/etc/rkhunter.conf --dbdir /tmp/rkhunter/db --tmpdir /tmp/rkhunter --nolog"
+    ignore_errors: yes
+
+  - name: "create rkhunter variables file"
+    copy:
+      dest: "/etc/openshift_tools/rkhunter_config.yaml"
+      content: |-
+        ---
+        logfile: /var/local/rkhunter_tmp/rkhunter/rkhunter.log
+
+  - name: "Set additional rkhunter ignore rules"
+    blockinfile:
+      dest: "/var/local/rkhunter_tmp/rkhunter/etc/rkhunter.conf"
+      insertafter: "ALLOWHIDDENDIR"
+      marker: "# {mark} Ansible-managed rkhunter ignore rules"
+      block: |-
+        ALLOWHIDDENDIR=/dev/shm/.ansible
+        ALLOWDEVDIR=/dev/shm/.ansible/*
+        ALLOWDEVDIR=/dev/shm/.ansible/tmp/*
+        ALLOWDEVDIR=/dev/shm/.ansible/tmp/account/*
+        ALLOWDEVFILE=/dev/shm/.ansible/tmp/*
+        ALLOWDEVFILE=/dev/shm/.ansible/tmp/account/*
+{% endraw %}

--- a/docker/oso-host-monitoring/src/start.sh
+++ b/docker/oso-host-monitoring/src/start.sh
@@ -18,8 +18,8 @@ source /root/.bashrc
 time ansible-playbook /root/config.yml
 
 # Configure rkhunter
-echo '/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
-/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
+echo '/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
+/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
 
 # Send a heartbeat when the container starts up
 /usr/bin/ops-metric-client --send-heartbeat

--- a/docker/oso-host-monitoring/src/start.sh
+++ b/docker/oso-host-monitoring/src/start.sh
@@ -17,6 +17,10 @@ source /root/.bashrc
 # Configure the container
 time ansible-playbook /root/config.yml
 
+# Configure rkhunter
+echo '/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &'
+/usr/bin/ops-runner -f -t 60 -n monitoring.root.rkhunter.yml ansible-playbook /root/rkhunter.yml >> /var/log/rkhunter.yml.log &
+
 # Send a heartbeat when the container starts up
 /usr/bin/ops-metric-client --send-heartbeat
 


### PR DESCRIPTION
* separate rkhunter to rkhunter.yml
* execute by ops-runner to track result in zabbix
* add timeout to ops-runner to ensure script doesn't take too long
* execute configuration in background, allowing container to start crond

Note:  `oc adm` snuck into this due to someone not running `generate-containers.yml`, but I'm ok with the change.