### PR TITLE
Package docker-python is obsoleted by python-docker

### DIFF
--- a/docker/oso-host-monitoring/centos7/Dockerfile
+++ b/docker/oso-host-monitoring/centos7/Dockerfile
@@ -88,7 +88,7 @@ RUN yum clean metadata && \
         python2-boto3 \
         python-lxml \
         rkhunter \
-        docker-python && \
+        python-docker && \
     yum clean all
 
 ADD urllib3-connectionpool-patch /root/

--- a/docker/oso-host-monitoring/rhel7/Dockerfile
+++ b/docker/oso-host-monitoring/rhel7/Dockerfile
@@ -97,7 +97,7 @@ RUN yum clean metadata && \
         python2-boto3 \
         python-lxml \
         rkhunter \
-        docker-python && \
+        python-docker && \
     yum-install-check.sh -y google-cloud-sdk python2-uritemplate python2-google-api-client python2-oauth2client --disablerepo="rhel-server-releases-optional" --enablerepo="google-cloud-sdk" && \
     yum clean all
 

--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -95,7 +95,7 @@ RUN yum clean metadata && \
         python2-boto3 \
         python-lxml \
         rkhunter \
-        docker-python && \
+        python-docker && \
 {# This is installed for gsutil and calculating the size of the gcs #}
 {# centos users should install this from https://cloud.google.com/sdk/downloads and follow the instructions #}
 {# disabling releases-optional repo as the filelist_db metadata file is over 1GB #}


### PR DESCRIPTION
+1 from @BlueShells in https://github.com/openshift/openshift-tools/pull/3306