### PR TITLE
Package docker-python is obsoleted by python-docker

### DIFF
--- a/scripts/monitoring/cron-send-docker-containers-usage.py
+++ b/scripts/monitoring/cron-send-docker-containers-usage.py
@@ -12,7 +12,7 @@
 # pylint: disable=import-error
 
 
-from docker import AutoVersionClient
+from docker import APIClient as DockerClient
 from openshift_tools.monitoring.metric_sender import MetricSender
 from openshift_tools.monitoring.dockerutil import DockerUtil
 import os
@@ -50,7 +50,7 @@ class DockerContainerUsageCli(object):
 
         self.parse_config()
 
-        self.cli = AutoVersionClient(base_url='unix://var/run/docker.sock', timeout=120)
+        self.cli = DockerClient(version='auto', base_url='unix://var/run/docker.sock', timeout=120)
         self.docker_util = DockerUtil(self.cli)
         self.metric_sender = MetricSender(verbose=True)
 

--- a/scripts/monitoring/cron-send-docker-dns-resolution.py
+++ b/scripts/monitoring/cron-send-docker-dns-resolution.py
@@ -12,7 +12,7 @@
 
 import time
 import os
-from docker import AutoVersionClient
+from docker import APIClient as DockerClient
 from docker.errors import APIError
 # Jenkins doesn't have our tools which results in import errors
 # pylint: disable=import-error
@@ -21,7 +21,7 @@ from openshift_tools.monitoring.metric_sender import MetricSender
 ZBX_KEY = "docker.container.dns.resolution"
 
 if __name__ == "__main__":
-    cli = AutoVersionClient(base_url='unix://var/run/docker.sock')
+    cli = DockerClient(version='auto', base_url='unix://var/run/docker.sock', timeout=120)
 
     container_id = os.environ['container_uuid']
 

--- a/scripts/monitoring/cron-send-docker-existing-dns-resolution.py
+++ b/scripts/monitoring/cron-send-docker-existing-dns-resolution.py
@@ -12,7 +12,7 @@
 # pylint: disable=import-error
 
 
-from docker import AutoVersionClient
+from docker import APIClient as DockerClient
 from docker.errors import APIError
 from openshift_tools.monitoring.metric_sender import MetricSender
 
@@ -20,7 +20,7 @@ ZBX_KEY = "docker.container.existing.dns.resolution.failed"
 CMD_NOT_FOUND = -1
 
 if __name__ == "__main__":
-    cli = AutoVersionClient(base_url='unix://var/run/docker.sock', timeout=120)
+    cli = DockerClient(version='auto', base_url='unix://var/run/docker.sock', timeout=120)
     bad_dns_count = 0
 
     for ctr in cli.containers():

--- a/scripts/monitoring/cron-send-docker-metrics.py
+++ b/scripts/monitoring/cron-send-docker-metrics.py
@@ -12,7 +12,7 @@
 
 import json
 import psutil
-from docker import AutoVersionClient
+from docker import APIClient as DockerClient
 from docker.errors import DockerException
 from openshift_tools.monitoring.metric_sender import MetricSender
 from openshift_tools.timeout import TimeoutException
@@ -41,7 +41,8 @@ if __name__ == "__main__":
     ms = MetricSender()
 
     try:
-        cli = AutoVersionClient(base_url='unix://var/run/docker.sock')
+        cli = DockerClient(version='auto', base_url='unix://var/run/docker.sock', timeout=120)
+
         du = DockerUtil(cli)
         du_dds = du.get_disk_usage()
         docker_memoryusages = getRssVmsofDocker()

--- a/scripts/monitoring/cron-send-docker-timer.py
+++ b/scripts/monitoring/cron-send-docker-timer.py
@@ -10,7 +10,7 @@
 # pylint: disable=invalid-name,import-error
 
 
-from docker import AutoVersionClient
+from docker import APIClient as DockerClient
 from docker.errors import DockerException
 from openshift_tools.monitoring.metric_sender import MetricSender
 from openshift_tools.timeout import TimeoutException
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     keys = None
     mts = MetricSender()
     try:
-        cli = AutoVersionClient(base_url='unix://var/run/docker.sock')
+        cli = DockerClient(version='auto', base_url='unix://var/run/docker.sock', timeout=120)
         du = DockerUtil(cli, max_wait=360)
 
         # Wait up to 6 minutes


### PR DESCRIPTION
+1 from @zhiwliu in https://github.com/openshift/openshift-tools/pull/3308

=====

`Package docker-python is obsoleted by python-docker, trying to install python-docker-2.4.2-1.3.el7.noarch instead`

This caused problems in relation to this commit from Oct 2016 which removes AutoVersionClient from the docker python library.
https://github.com/docker/docker-py/commit/c7903f084eb3a7525e21974390b48e2a0dc03732