### PR TITLE
start pmcd in container without checking for other running instances

### DIFF
--- a/docker/oso-host-monitoring/centos7/root/start-pmcd.bash
+++ b/docker/oso-host-monitoring/centos7/root/start-pmcd.bash
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+# original source: https://github.com/redhat-developer/osd-monitor-poc/blob/master/pcp-node-collector/run-pmcd.sh
+
+: "${PCP_HOSTNAME:=`hostname`}"
+
+# Adjust to OSD/OSO? AWS conventions: ip-172-31-51-101.ec2.internal => NODE-ip-172-31-51-101
+PCP_NODE_HOSTNAME=NODE-`echo $PCP_HOSTNAME | cut -f1 -d.`
+
+# Setup pmcd to run in unprivileged mode of operation
+. /etc/pcp.conf
+
+# allow unauthenticated access to proc.* metrics (default is false)
+export PROC_ACCESS=1
+export PMCD_ROOT_AGENT=0
+
+
+# NB: we can't use the rc.pmcd script.  It assumes that it's run as root.
+cd $PCP_VAR_DIR/pmns
+./Rebuild
+
+cd $PCP_LOG_DIR
+exec /usr/libexec/pcp/bin/pmcd -A -f -l /dev/no-such-file -H $PCP_NODE_HOSTNAME

--- a/docker/oso-host-monitoring/centos7/start.sh
+++ b/docker/oso-host-monitoring/centos7/start.sh
@@ -27,7 +27,8 @@ echo '/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-play
 # fire off the check pmcd status script
 check-pmcd-status.sh &
 # fire off the pmcd script
-/usr/share/pcp/lib/pmcd start &
+#/usr/share/pcp/lib/pmcd start &
+/root/start-pmcd.bash > /var/log/pmcd.log &
 
 # Run the main service of this container
 echo

--- a/docker/oso-host-monitoring/rhel7/root/start-pmcd.bash
+++ b/docker/oso-host-monitoring/rhel7/root/start-pmcd.bash
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+# original source: https://github.com/redhat-developer/osd-monitor-poc/blob/master/pcp-node-collector/run-pmcd.sh
+
+: "${PCP_HOSTNAME:=`hostname`}"
+
+# Adjust to OSD/OSO? AWS conventions: ip-172-31-51-101.ec2.internal => NODE-ip-172-31-51-101
+PCP_NODE_HOSTNAME=NODE-`echo $PCP_HOSTNAME | cut -f1 -d.`
+
+# Setup pmcd to run in unprivileged mode of operation
+. /etc/pcp.conf
+
+# allow unauthenticated access to proc.* metrics (default is false)
+export PROC_ACCESS=1
+export PMCD_ROOT_AGENT=0
+
+
+# NB: we can't use the rc.pmcd script.  It assumes that it's run as root.
+cd $PCP_VAR_DIR/pmns
+./Rebuild
+
+cd $PCP_LOG_DIR
+exec /usr/libexec/pcp/bin/pmcd -A -f -l /dev/no-such-file -H $PCP_NODE_HOSTNAME

--- a/docker/oso-host-monitoring/rhel7/start.sh
+++ b/docker/oso-host-monitoring/rhel7/start.sh
@@ -27,7 +27,8 @@ echo '/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-play
 # fire off the check pmcd status script
 check-pmcd-status.sh &
 # fire off the pmcd script
-/usr/share/pcp/lib/pmcd start &
+#/usr/share/pcp/lib/pmcd start &
+/root/start-pmcd.bash > /var/log/pmcd.log &
 
 # Run the main service of this container
 echo

--- a/docker/oso-host-monitoring/src/root/start-pmcd.bash
+++ b/docker/oso-host-monitoring/src/root/start-pmcd.bash
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+# original source: https://github.com/redhat-developer/osd-monitor-poc/blob/master/pcp-node-collector/run-pmcd.sh
+
+: "${PCP_HOSTNAME:=`hostname`}"
+
+# Adjust to OSD/OSO? AWS conventions: ip-172-31-51-101.ec2.internal => NODE-ip-172-31-51-101
+PCP_NODE_HOSTNAME=NODE-`echo $PCP_HOSTNAME | cut -f1 -d.`
+
+# Setup pmcd to run in unprivileged mode of operation
+. /etc/pcp.conf
+
+# allow unauthenticated access to proc.* metrics (default is false)
+export PROC_ACCESS=1
+export PMCD_ROOT_AGENT=0
+
+
+# NB: we can't use the rc.pmcd script.  It assumes that it's run as root.
+cd $PCP_VAR_DIR/pmns
+./Rebuild
+
+cd $PCP_LOG_DIR
+exec /usr/libexec/pcp/bin/pmcd -A -f -l /dev/no-such-file -H $PCP_NODE_HOSTNAME

--- a/docker/oso-host-monitoring/src/start.sh
+++ b/docker/oso-host-monitoring/src/start.sh
@@ -27,7 +27,8 @@ echo '/usr/bin/ops-runner -f -t 600 -n monitoring.root.rkhunter.yml ansible-play
 # fire off the check pmcd status script
 check-pmcd-status.sh &
 # fire off the pmcd script
-/usr/share/pcp/lib/pmcd start &
+#/usr/share/pcp/lib/pmcd start &
+/root/start-pmcd.bash > /var/log/pmcd.log &
 
 # Run the main service of this container
 echo


### PR DESCRIPTION
original script source
https://github.com/redhat-developer/osd-monitor-poc/blob/master/pcp-node-collector/run-pmcd.sh

Testing method:

```
# pick a node where it is failing

docker exec -it oso-rhel7-host-monitoring bash

... in docker exec ...

git clone https://github.com/drewandersonnz/openshift-tools.git;
cd openshift-tools;
git checkout pmcd-start;
docker/oso-host-monitoring/centos7/root/start-pmcd.bash;

... <another docker exec instance> ...

run scripts which rely on PCP data and confirm validity

```
Note: ignoring @blrm Merge to stg.