### PR TITLE
Pod start time undefined

### DIFF
--- a/scripts/monitoring/cron-send-metrics-checks.py
+++ b/scripts/monitoring/cron-send-metrics-checks.py
@@ -104,11 +104,9 @@ class OpenshiftMetricsStatus(object):
                 pod_report[pod_pretty_name]['restarts'] = pod['status']['containerStatuses'][0]['restartCount']
 
                 # Get the time the pod was started, otherwise return 0
-                if 'state' in pod['status']['containerStatuses'][0]:
-                    if 'running' in pod['status']['containerStatuses'][0]['state']:
-                        if 'startedAt' in pod['status']['containerStatuses'][0]['state']['running']:
-                            pod_start_time = pod['status']['containerStatuses'][0]['state']['running']['startedAt']
-                else:
+                try:
+                    pod_start_time = pod['status']['containerStatuses'][0]['state']['running']['startedAt']
+                except KeyError:
                     pod_start_time = 0
 
                 # Since we convert to seconds it is an INT but pylint still complains. Only disable here


### PR DESCRIPTION
I was debugging an `aws_cluster_verify.sh` failure by running `cron-send-metrics-checks` manually and getting this back:
```
Running command: ['oc', '--config', '/tmp/Q3D2T2Y', '-n', 'openshift-infra', 'get', 'pods', '-o', 'yaml']
Traceback (most recent call last):
  File "/usr/bin/cron-send-metrics-checks", line 342, in <module>
    OSMS.run()
  File "/usr/bin/cron-send-metrics-checks", line 325, in run
    pod_report = self.check_pods()
  File "/usr/bin/cron-send-metrics-checks", line 117, in check_pods
    pod_report[pod_pretty_name]['starttime'] = int(pod_start_time.strftime("%s"))
UnboundLocalError: local variable 'pod_start_time' referenced before assignment
```

One of the inner `if` statements must be failing.  This fixes the unbound variable.