### PR TITLE
Allow vendored versions of openshift-ansible to include playbooks/aws

### DIFF
--- a/openshift/installer/vendor-github.yml
+++ b/openshift/installer/vendor-github.yml
@@ -69,7 +69,6 @@
     - Vagrantfile
     - usr
     - playbooks/adhoc
-    - playbooks/aws
     - playbooks/gce
     - playbooks/libvirt
     - playbooks/openstack


### PR DESCRIPTION
Currently we blacklist some files and directories when we vendor openshift-ansible. This removes "playbooks/aws" from that blacklist so that we can use those provisioning playbooks.