### PR TITLE
Include playbooks/aws and playbooks/gce in vendored openshift-ansible

### DIFF
--- a/ansible/roles/vendor_openshift_ansible_rpms/tasks/main.yml
+++ b/ansible/roles/vendor_openshift_ansible_rpms/tasks/main.yml
@@ -53,8 +53,6 @@
   with_items:
   - usr
   - playbooks/adhoc
-  - playbooks/aws
-  - playbooks/gce
   - playbooks/libvirt
   - playbooks/openstack
   - roles/ansible


### PR DESCRIPTION
:+1: by @mwoodson in #3477 