### PR TITLE
yum_repos: Ensure reposdir is default path

### DIFF
--- a/ansible/roles/yum_repos/tasks/main.yml
+++ b/ansible/roles/yum_repos/tasks/main.yml
@@ -19,6 +19,14 @@
   when: yr_yum_cert_content is defined
   no_log: true
 
+- name: Ensure yum reposdir is default path
+  ini_file:
+    create: no
+    path: /etc/yum.conf
+    section: main
+    option: reposdir
+    state: absent
+
 - name: Manage yum repositories
   yum_repository:
     name: "{{ item.name }}"


### PR DESCRIPTION
Removes the `reposdir` override in `/etc/yum.conf` (for config loop).