### PR TITLE
multi_inventory.py: Fix handling of boolean values

### DIFF
--- a/ansible/inventory/multi_inventory.py
+++ b/ansible/inventory/multi_inventory.py
@@ -298,7 +298,7 @@ class MultiInventoryAccount(object):
 
                 # Convert boolean variables to 'True' or 'False'.
                 if to_name in BOOLEAN_CLONE_GROUPS:
-                    if isinstance(val, str):
+                    if isinstance(val, basestring):
                         val = str(val.lower() == 'true')
                     else:  # Mainly for None -> False
                         val = str(bool(val))


### PR DESCRIPTION
Check for string type values with `basestring` instead of `str`.
Turns out they're actually `unicode`, but `basestring` matches both.

:+1: @mwoodson #3575 