### PR TITLE
ops-docker-loopback-to-direct-lvm.yml: Update the template file name

### DIFF
--- a/ansible/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
+++ b/ansible/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
@@ -99,7 +99,7 @@
   - name: copy the docker-storage-setup config file
     template:
       # TODO: fix this, this sucks. Right now we can't use that role directly :(
-      src: ../../../roles/docker_storage_setup/templates/docker-storage-setup.j2
+      src: ../../../roles/docker_storage_setup/templates/devicemapper_dss.j2
       dest: /etc/sysconfig/docker-storage-setup
       owner: root
       group: root


### PR DESCRIPTION
When we added `overlay2` as an alternate storage driver, the `devicemapper` template was renamed from `docker-storage-setup.j2` to `devicemapper_dss.j2`.