### PR TITLE
ops-docker-loopback-to-direct-lvm.yml: Load docker_storage_setup defaults

### DIFF
--- a/ansible/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
+++ b/ansible/playbooks/adhoc/docker_loopback_to_lvm/ops-docker-loopback-to-direct-lvm.yml
@@ -96,6 +96,10 @@
       state: absent
       path: /var/lib/docker
 
+  - name: load defaults from docker_storage_setup
+    include_vars:
+      file: ../../../roles/docker_storage_setup/defaults/main.yml
+
   - name: copy the docker-storage-setup config file
     template:
       # TODO: fix this, this sucks. Right now we can't use that role directly :(


### PR DESCRIPTION
Need `dss_docker_storage_dm_basesize` defined for the template file.