### PR TITLE
docker_storage_to_overlay2: Allow setting overlay2.size explicitly

### DIFF
--- a/ansible/roles/docker_storage_to_overlay2/README.md
+++ b/ansible/roles/docker_storage_to_overlay2/README.md
@@ -12,7 +12,8 @@ to wipe all local Docker storage.
 ## NOTE
 
 If the existing storage configuration includes a `dm.basesize` option,
-it will be replaced with an `overlay2.size` option with the same value.
+it will be replaced with an `overlay2.size` option with the same value
+(unless overridden by docker_storage_to_overlay2_size).
 
 The `overlay2.size` option, however, requires overlay2 storage driver
 features beyond Docker 1.12.  See:
@@ -51,6 +52,10 @@ Role Variables
 * Reboot host after changing Docker storage to overlay2.  This will
   verify that `docker-storage-setup.service` can successfully mount
   the reconfigured logical volume during boot.
+
+`docker_storage_to_overlay2_size` (no default)
+
+* Overrides `dm.basesize` as the value to apply to `overlay2.size`.
 
 Dependencies
 ------------

--- a/ansible/roles/docker_storage_to_overlay2/tasks/main.yml
+++ b/ansible/roles/docker_storage_to_overlay2/tasks/main.yml
@@ -23,6 +23,11 @@
   set_fact:
     disk_quota: "{{ storage_setup['content'] | b64decode | regex_search('(?<=dm.basesize=)(\\w+)', '\\1', multiline=True) }}"
 
+- name: Override disk quota with explicit value
+  set_fact:
+    disk_quota: "[ '{{ docker_storage_to_overlay2_size }}' ]"
+  when: docker_storage_to_overlay2_size is defined
+
 - name: Check package versions for overlay2 disk quota support
   when: disk_quota|length > 0
   block:


### PR DESCRIPTION
Introduces a `docker_storage_to_overlay2_size` variable as a way to override `dm.basesize` as the value to apply to `overlay2.size`.

:+1: @mwoodson #3601 