### PR TITLE
Correcting typo in o-a role: timout to timeout

### DIFF
--- a/openshift/installer/vendored/openshift-ansible-3.9.14-1/roles/openshift_aws/defaults/main.yml
+++ b/openshift/installer/vendored/openshift-ansible-3.9.14-1/roles/openshift_aws/defaults/main.yml
@@ -59,7 +59,7 @@ openshift_aws_elb_dict:
         interval: 30
         unhealthy_threshold: 2
         healthy_threshold: 2
-      idle_timout: 400
+      idle_timeout: 400
       listeners:
       - protocol: tcp
         load_balancer_port: 80
@@ -81,7 +81,7 @@ openshift_aws_elb_dict:
         interval: 30
         unhealthy_threshold: 2
         healthy_threshold: 2
-      idle_timout: 400
+      idle_timeout: 400
       listeners:
       - protocol: tcp
         load_balancer_port: 80
@@ -103,7 +103,7 @@ openshift_aws_elb_dict:
         interval: 30
         unhealthy_threshold: 2
         healthy_threshold: 2
-      idle_timout: 400
+      idle_timeout: 400
       listeners:
       - protocol: tcp
         load_balancer_port: 80

--- a/openshift/installer/vendored/openshift-ansible-3.9.14-1/roles/openshift_aws/tasks/elb_single.yml
+++ b/openshift/installer/vendored/openshift-ansible-3.9.14-1/roles/openshift_aws/tasks/elb_single.yml
@@ -10,7 +10,7 @@
     state: present
     cross_az_load_balancing: "{{ item.value.cross_az_load_balancing }}"
     security_group_names: "{{ l_elb_security_groups[l_elb_dict_item.key] }}"
-    idle_timeout: "{{ item.value.idle_timout }}"
+    idle_timeout: "{{ item.value.idle_timeout }}"
     region: "{{ openshift_aws_region }}"
     subnets:
     - "{{ subnetout.subnets[0].id }}"


### PR DESCRIPTION
I merged a fix for this typo into openshift-ansible as well. This is just to fix it in the vendored version of o-a 3.9.14-1.