### PR TITLE
docker_storage_to_overlay2: Stop and restart API service

### DIFF
--- a/ansible/roles/docker_storage_to_overlay2/vars/main.yml
+++ b/ansible/roles/docker_storage_to_overlay2/vars/main.yml
@@ -6,8 +6,10 @@ docker_storage_to_overlay2_storage_setup_path: "/etc/sysconfig/docker-storage-se
 docker_storage_to_overlay2_service_names:
 - "docker.service"
 
+# Optional services are started in reverse order.
 docker_storage_to_overlay2_optional_service_names:
 - "atomic-openshift-node.service"
+- "atomic-openshift-master-api.service"
 
 docker_storage_to_overlay2_package_requirements:
 


### PR DESCRIPTION
Add `atomic-openshift-master-api.service` to the list of services to stop and restart, if available on a host.

On master nodes, we want to start the API service before the node service.