### PR TITLE
Add k8s node labels to BYO generator template

### DIFF
--- a/ansible/roles/openshift_byo_generator/templates/byo.yml.j2
+++ b/ansible/roles/openshift_byo_generator/templates/byo.yml.j2
@@ -400,23 +400,23 @@ openshift_aws_subnet_az={{ obg_availability_zone }}
 [nodes]
 {% for master in obg_masters %}
 {%     if obg_location == 'gcp' %}
-{{ hostvars[master][obg_ip_choice] }}        openshift_hostname={{ master }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'master'}" openshift_node_group_name=node-config-master
+{{ hostvars[master][obg_ip_choice] }}        openshift_hostname={{ master }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'master', 'node-role.kubernetes.io/master': 'true' }" openshift_node_group_name=node-config-master
 {%     else %}
-{{ hostvars[master][obg_ip_choice] }}        openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'master', 'hostname': '{{ master }}'}" openshift_node_group_name=node-config-master
+{{ hostvars[master][obg_ip_choice] }}        openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'master', 'hostname': '{{ master }}', 'node-role.kubernetes.io/master': 'true' }" openshift_node_group_name=node-config-master
 {%     endif %}
 {% endfor %}
 {% for infra in obg_infra_nodes %}
 {%     if obg_location == 'gcp' %}
-{{ hostvars[infra][obg_ip_choice] }}        openshift_hostname={{ infra }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'ops_node': 'old', 'logging-infra-fluentd': 'true'}" openshift_node_group_name=node-config-infra
+{{ hostvars[infra][obg_ip_choice] }}        openshift_hostname={{ infra }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'ops_node': 'old', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/infra': 'true' }" openshift_node_group_name=node-config-infra
 {%     else %}
-{{ hostvars[infra][obg_ip_choice] }}        openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'hostname': '{{ infra }}', 'ops_node': 'old', 'logging-infra-fluentd': 'true'}" openshift_node_group_name=node-config-infra
+{{ hostvars[infra][obg_ip_choice] }}        openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'hostname': '{{ infra }}', 'ops_node': 'old', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/infra': 'true' }" openshift_node_group_name=node-config-infra
 {%     endif %}
 {% endfor %}
 {% for compute in obg_compute_nodes %}
 {%     if obg_location == 'gcp' %}
-{{ hostvars[compute][obg_ip_choice] }}       openshift_hostname={{ compute }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'ops_node': 'old', 'logging-infra-fluentd': 'true'}" openshift_node_group_name=node-config-compute
+{{ hostvars[compute][obg_ip_choice] }}       openshift_hostname={{ compute }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'ops_node': 'old', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/compute': 'true' }" openshift_node_group_name=node-config-compute
 {%     else %}
-{{ hostvars[compute][obg_ip_choice] }}       openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'hostname': '{{ compute }}', 'ops_node': 'old', 'logging-infra-fluentd': 'true'}" openshift_node_group_name=node-config-compute
+{{ hostvars[compute][obg_ip_choice] }}       openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'hostname': '{{ compute }}', 'ops_node': 'old', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/compute': 'true' }" openshift_node_group_name=node-config-compute
 {%     endif %}
 {% endfor %}
 
@@ -424,16 +424,16 @@ openshift_aws_subnet_az={{ obg_availability_zone }}
 [new_nodes]
 {%     for infra in obg_new_infra_nodes %}
 {%         if obg_location == 'gcp' %}
-{{ hostvars[infra][obg_ip_choice] }}        openshift_hostname={{ infra }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'ops_node': 'new', 'logging-infra-fluentd': 'true'}" openshift_schedulable=false openshift_node_group_name=node-config-infra
+{{ hostvars[infra][obg_ip_choice] }}        openshift_hostname={{ infra }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'ops_node': 'new', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/infra': 'true' }" openshift_schedulable=false openshift_node_group_name=node-config-infra
 {%         else %}
-{{ hostvars[infra][obg_ip_choice] }}        openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'hostname': '{{ infra }}', 'ops_node': 'new', 'logging-infra-fluentd': 'true'}" openshift_schedulable=false openshift_node_group_name=node-config-infra
+{{ hostvars[infra][obg_ip_choice] }}        openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'infra', 'hostname': '{{ infra }}', 'ops_node': 'new', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/infra': 'true' }" openshift_schedulable=false openshift_node_group_name=node-config-infra
 {%         endif %}
 {%     endfor %}
 {%     for compute in obg_new_compute_nodes %}
 {%         if obg_location == 'gcp' %}
-{{ hostvars[compute][obg_ip_choice] }}       openshift_hostname={{ compute }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'ops_node': 'new', 'logging-infra-fluentd': 'true'}" openshift_schedulable=false openshift_node_group_name=node-config-compute
+{{ hostvars[compute][obg_ip_choice] }}       openshift_hostname={{ compute }} openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'ops_node': 'new', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/compute': 'true' }" openshift_schedulable=false openshift_node_group_name=node-config-compute
 {%         else %}
-{{ hostvars[compute][obg_ip_choice] }}       openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'hostname': '{{ compute }}', 'ops_node': 'new', 'logging-infra-fluentd': 'true'}" openshift_schedulable=false openshift_node_group_name=node-config-compute
+{{ hostvars[compute][obg_ip_choice] }}       openshift_node_labels="{'region': '{{ obg_sublocation }}', 'type': 'compute', 'hostname': '{{ compute }}', 'ops_node': 'new', 'logging-infra-fluentd': 'true', 'node-role.kubernetes.io/compute': 'true' }" openshift_schedulable=false openshift_node_group_name=node-config-compute
 {%         endif %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
This adds node labels to the BYO generator so they will be set in node-config.yaml. Currently a node can lose these labels on 3.9 if it leaves the cluster due to a restart. This makes sure the label persists in that situation.