### PR TITLE
Switched to using command with ssh-keyscan to populate known_hosts for rsync

### DIFF
--- a/ansible/roles/ansible_inventory/README.md
+++ b/ansible/roles/ansible_inventory/README.md
@@ -15,6 +15,10 @@ oo_inventory_group
 oo_inventory_user
 oo_inventory_accounts
 oo_inventory_cache_max_age
+oo_rsync_cache_targets
+oo_rsync_cache_target_user
+oo_rsync_cache_target_dir
+oo_rsync_private_key
 
 Dependencies
 ------------

--- a/ansible/roles/ansible_inventory/tasks/main.yml
+++ b/ansible/roles/ansible_inventory/tasks/main.yml
@@ -56,15 +56,11 @@
         mode: 0600
       when: oo_rsync_private_key is defined
 
+    # would liked to use known_hosts but it requires knowing the host keys up front. cleaner to scan for it one time
     - name: put rsync target hosts into known_hosts
-      known_hosts:
-        state: present
-        hash_host: no
-        name: "{{ item }}"
-        path: "/root/.ssh/known_hosts"
-        key: "{{ lookup('file', oo_rsync_public_key) }}"
+      command: "grep {{ item }} /root/.ssh/known_hosts > /dev/null || ssh-keyscan -t ecdsa-sha2-nistp256 {{ item }},`host {{ item }} | awk '{print $4}'` 2> /dev/null >> /root/.ssh/known_hosts"
       with_items: "{{ oo_rsync_cache_targets }}"
-      when: oo_rsync_public_key is defined
+      when: oo_rsync_cache_targets is defined
 
     # This cron uses the above location to call its job
     - name: Cron to keep cache fresh


### PR DESCRIPTION
There is a `known_hosts` module but it requires you to provide the literal string that will be dumped in the file.  I didn't want to manage an array of these or have to deal with them long term in configuration.  Instead, this will use ssh-keyscan to grab the host key once then never again.  If it changes, it will have to be managed somewhere else.