### PR TITLE
Refactored how ansible_inventory manages known_hosts

### DIFF
--- a/ansible/roles/ansible_inventory/tasks/known_hosts.yml
+++ b/ansible/roles/ansible_inventory/tasks/known_hosts.yml
@@ -1,0 +1,13 @@
+---
+# because you can't do with_items on a block, having a separate file for this
+# otherwise ansible either always or never reports a change (based on changed_when)
+- name: "check known_hosts for {{ item }}"
+  shell: "grep {{ item }} /root/.ssh/known_hosts > /dev/null"
+  ignore_errors: yes
+  changed_when: false
+  register: known_hosts_out
+- name: "add {{ item }} to known_hosts"
+  shell: "ssh-keyscan -t ecdsa-sha2-nistp256 {{ item }},`host {{ item }} | awk '{print $4}'` 2> /dev/null >> /root/.ssh/known_hosts"
+  when: known_hosts_out.rc != 0
+
+

--- a/ansible/roles/ansible_inventory/tasks/main.yml
+++ b/ansible/roles/ansible_inventory/tasks/main.yml
@@ -56,9 +56,8 @@
         mode: 0600
       when: oo_rsync_private_key is defined
 
-    # would liked to use known_hosts but it requires knowing the host keys up front. cleaner to scan for it one time
-    - name: put rsync target hosts into known_hosts
-      command: "grep {{ item }} /root/.ssh/known_hosts > /dev/null || ssh-keyscan -t ecdsa-sha2-nistp256 {{ item }},`host {{ item }} | awk '{print $4}'` 2> /dev/null >> /root/.ssh/known_hosts"
+    - name: setup known_hosts
+      include_tasks: known_hosts.yml
       with_items: "{{ oo_rsync_cache_targets }}"
       when: oo_rsync_cache_targets is defined
 


### PR DESCRIPTION
Found first that command wouldn't cut it.
Next, if you have a single shell that does it all, it's always reported as a change.
Alternative is changed_when: false, so never a changes.
To check each host, have to put in task file that is included, as
block doesn't support with_items.

So now, it will change known_hosts only when it needs to and report each update as a change.