### PR TITLE
Updated grow_root_vg-m5.yml to reserve 5000 sectors

### DIFF
--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5-recreate-partition.sh.j2
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5-recreate-partition.sh.j2
@@ -19,8 +19,8 @@ d
 n
 p
 2
-{{ parted_info.partitions[1].begin | int }}
-
+{{ parted_info.partitions[1].begin|int }}
+{{ (parted_info.disk.size|int - cli_reserved_sector_count|int) }}
 t
 2
 8e

--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5.yml
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5.yml
@@ -17,6 +17,7 @@
 #  Notes:
 #  * By default this will do a 90GB GP2 volume.  The volume size can be overidden with the "-e 'cli_volume_size=something'" variable
 #  * This can be done with NO downtime on the host, but you probably ought to test a reboot. 
+#  * cli_reserved_sector_count exists because for NVMe EBS volumes Host Protected Area (HPA) is enabled, but we cannot determine the number of sectors reserved with hdparm -N
 #
 
 - name: Grow the rootvg volume group
@@ -28,6 +29,7 @@
   vars:
     cli_volume_size: 90
     cli_var_size: 64
+    cli_reserved_sector_count: 5000
     os_size_min: 20
 
   tasks:
@@ -61,6 +63,7 @@
           nvme id-ctrl --raw-binary $DEV_NVME 2> /dev/null | cut -c3073-3104 | tr -s ' ' | sed 's#\(^[^/].*\)#/dev/\1#g' | sed 's/sda/xvda/g'
         fi
       done
+    changed_when: false
     register: rootvg_aws
     ignore_errors: yes
 
@@ -73,6 +76,7 @@
           break
         fi
       done
+    changed_when: false
     register: rootvg_instance
     ignore_errors: yes
 
@@ -112,6 +116,11 @@
       msg: Unable to find any attached volumes. Please ensure that AWS_PROFILE and AWS_DEFAULT_REGION env vars are set.
     when: attached_volumes.volumes | length < 1
 
+  # didn't want to unwind all the use of vol_aws, but this is a way to get the volume device id directly from the instance
+#  - name: get ebs volume id using smartctl
+#    shell: "smartctl -i {{ vol_instance.fullname }} | grep 'Serial Number' | sed 's/.*vol\\(.*\\)/vol-\\1/g'"
+#    register: rootvg_volume_id_out
+
   - name: get volume id of current rootvg volume
     set_fact:
       rootvg_volume_id: "{{ attached_volumes.volumes | get_volume_id_by_linux_device(vol_aws.device, true) }}"
@@ -135,20 +144,32 @@
       volume_id: "{{ rootvg_volume_id }}"
       description: "Snapshot of {{ cli_tag_name }} {{ vol_instance.device }} before resize"
       wait: no ## don't wait for the snapshot to complete pushing to S3, it still exists and waiting can take hours
-    when: cli_volume_size > rootvg_volume_size|int
+    when: cli_volume_size|int > rootvg_volume_size|int
+
+  - name: Get partition info
+    parted: 
+      device: "{{ vol_instance.fullname }}"
+      number: 2
+      state: info
+      unit: s
+    register: parted_info
+
+  - name: set target ebs volume size (add in reserved sector size)
+    set_fact:
+      ebs_volume_size: "{{ ( cli_volume_size|int + ( parted_info.disk.physical_block|int * cli_reserved_sector_count|int ) / 1024 / 1024 ) | round(0, 'ceil') | int }}"
 
   - name: Resize EBS volume 
     delegate_to: localhost
     ## afaict the ansible ec2 modules don't offer resize
-    command: "aws ec2 modify-volume --volume-id {{ rootvg_volume_id }} --size {{ cli_volume_size }} --region {{ ec2_region }}"
-    when: cli_volume_size > rootvg_volume_size|int
+    command: "aws ec2 modify-volume --volume-id {{ rootvg_volume_id }} --size {{ ebs_volume_size }} --region {{ ec2_region }}"
+    when: cli_volume_size|int > rootvg_volume_size|int
     register: resize_volume
 
   - debug: var=resize_volume
 
   - wait_for: 
       timeout: 10 
-    when: cli_volume_size > rootvg_volume_size|int
+    when: cli_volume_size|int > rootvg_volume_size|int
 
   - name: Fail when problems extending
     fail:
@@ -158,30 +179,19 @@
   - name: Run partprobe to see if the size changed
     command: partprobe
 
-  - name: Get available sectors
-    shell: "echo $(( $(echo p | fdisk {{ vol_instance.fullname }} | grep sectors$ | cut -d' ' -f7) - 1 ))"
+  - name: Get available sectors (minus reserved sector count)
+    shell: "echo $(( $(fdisk -l {{ vol_instance.fullname }} | grep sectors$ | cut -d' ' -f7) - 1 - {{ cli_reserved_sector_count|int }} ))"
+    changed_when: false
     register: sectors_available
 
   - name: Get used sectors
-    shell: "echo p | fdisk {{ vol_instance.fullname }}| grep {{ vol_instance.fullname }} | tail -n1 | awk '{print $3}'"
+    shell: "fdisk -l {{ vol_instance.fullname }}| grep {{ vol_instance.fullname }} | tail -n1 | awk '{print $3}'"
+    changed_when: false
     register: sectors_used
 
-  - name: Test if resize needed (error means resize is needed)
-    shell: "test {{ sectors_available.stdout }} -eq {{ sectors_used.stdout }}"
-    register: resize_needed
-    ignore_errors: yes
-
   - name: Resize partition
-    when: resize_needed.failed
+    when: sectors_available.stdout|int > sectors_used.stdout|int
     block:
-      - name: Get partition info
-        parted: 
-          device: "{{ vol_instance.fullname }}"
-          number: 2
-          state: info
-          unit: s
-        register: parted_info
-
       - name: Create script to recreate partition
         template:
           src: grow_root_vg-m5-recreate-partition.sh.j2
@@ -211,7 +221,8 @@
     command: "xfs_growfs /var"
 
   - name: New /var size
-    shell: "lvs rootvg | grep '^[ ]*var' | lvs rootvg | grep '^[ ]*var' | awk '{print $4}' | cut -d. -f1"
+    shell: "lvs rootvg | grep '^[ ]*var' | awk '{print $4}' | cut -d. -f1"
+    changed_when: false
     register: new_var_size
 
   - name: Fail if didn't resize


### PR DESCRIPTION
This is caused by Host Protection Area (HPA) enabled on m5 instances.  And for some subset of hosts there appears to be some reserved sectors.  The 5000 sectors is 100% arbitrary and works out to 2.43GB of extra space, rounded up, which will be added to the EBS volume resize.