### PR TITLE
Updates to grow var script for m5

### DIFF
--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5-recreate-partition.sh.j2
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5-recreate-partition.sh.j2
@@ -12,17 +12,17 @@
 # p - print
 # w - write
 
-cat << EOF | fdisk {{ vol_instance.fullname }}
+cat << EOF | fdisk {{ partition_name }}
 p
 d
-2
+{{ partition_number|int }}
 n
 p
-2
-{{ parted_info.partitions[1].begin|int }}
-{{ (parted_info.disk.size|int - cli_reserved_sector_count|int) }}
+{{ partition_number|int }}
+{{ partition_begin|int }}
+{{ partition_end|int }}
 t
-2
+{{ partition_number|int }}
 8e
 p
 w

--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5-revert.yml
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5-revert.yml
@@ -1,0 +1,101 @@
+---
+# This playbook grows the root VG on a node by:
+#  * expanding /dev/nvme0n1
+#  * using fdisk to expand the rootvg partition
+#  * grow /var to 64GB
+#
+#  To run:
+#  1. Source your AWS credentials (make sure it's the corresponding AWS account) into your environment
+#    export AWS_PROFILE=<aws account>
+#
+# 2. run the playbook:
+#   ansible-playbook -e 'cli_tag_name=<tag-name>' grow_root_vg-m5.yml
+#
+#  Example:
+#   ansible-playbook -e 'cli_tag_name=ops-compute-12345' grow_root_vg-m5.yml
+#
+#  Notes:
+#  * By default this will do a 90GB GP2 volume.  The volume size can be overidden with the "-e 'cli_volume_size=something'" variable
+#  * This can be done with NO downtime on the host, but you probably ought to test a reboot. 
+#  * cli_reserved_sector_count exists because for NVMe EBS volumes Host Protected Area (HPA) is enabled, but we cannot determine the number of sectors reserved with hdparm -N
+#
+
+- name: Grow the rootvg volume group
+  hosts: "oo_name_{{ cli_tag_name }}"
+  user: root
+  connection: ssh
+  gather_facts: no
+
+  vars:
+    os_size_min: 20
+
+  tasks:
+  - name: "Check for required variables" 
+    fail:
+      msg: "This playbook requires {{item}} to be set."
+    when: "{{ item }} is not defined or {{ item }} == ''"
+    with_items:
+    - cli_tag_name
+
+  - name: Install nvme-cli
+    yum:
+      name: nvme-cli
+      state: installed
+
+  - name: Attempt to find the physical device that rootvg is using (NVMe)
+    shell: >
+      for DEV_NVME in `nvme list | grep "^/dev" | awk '{print $1}'`;
+      do
+        if [ "$(lsblk $DEV_NVME | grep rootvg)" != "" ]; then
+          echo $DEV_NVME
+          break
+        fi
+      done
+    changed_when: false
+    register: rootvg_instance
+    ignore_errors: yes
+
+  - name: fail if we don't find a single rootvg physical volume
+    fail:
+      msg:  Unable to find single rootvg physical volume. Please investigate manually.
+    when: rootvg_instance.stdout_lines|length != 1
+
+  - name: set vol_instance volume attributes
+    set_fact:
+      vol_instance: "{{ rootvg_instance.stdout | vol_attrs }}"
+
+  - debug: var=vol_instance
+
+  - name: Get partition info
+    parted: 
+      device: "{{ vol_instance.fullname }}"
+      number: 2
+      state: info
+      unit: s
+    register: parted_info
+
+  - name: set params for partition script
+    set_fact:
+      partition_name: "{{ vol_instance.fullname }}"
+      partition_begin: "{{ parted_info.partitions[1].begin|int }}"
+      partition_end: 54525951
+      partition_number: "{{ partition_number }}"
+
+  - name: Create script to recreate partition
+    template:
+      src: grow_root_vg-m5-recreate-partition.sh.j2
+      dest: /root/grow_root_vg-m5-recreate-partition.sh
+      mode: 0700
+
+  - name: Recreate partition
+    shell: /root/grow_root_vg-m5-recreate-partition.sh
+    ignore_errors: yes
+
+  - name: Run partprobe
+    command: partprobe
+
+  - name: Remove recreate script
+    file:
+      path: /root/grow_root_vg-m5-recreate-partition.sh
+      state: absent
+

--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5.yml
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5.yml
@@ -257,5 +257,11 @@
       path: /root/grow_root_vg-m5-recreate-partition.sh
       state: absent
 
-  - name: Trigger filesystem metrics
+  - name: Trigger filesystem metrics (master or infra)
     shell: "docker exec -ti oso-rhel7-host-monitoring /usr/bin/cron-send-filesystem-metrics -v"
+    when: "('oo_hosttype_master' in group_names or 'oo_subhosttype_infra' in group_names)"
+
+  - name: Trigger filesystem metrics (compute)
+    shell: "docker exec -ti oso-rhel7-host-monitoring /usr/bin/cron-send-filesystem-metrics --filter-pod-pv -v"
+    when: "'oo_subhosttype_compute' in group_names"
+

--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5.yml
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg-m5.yml
@@ -29,8 +29,9 @@
   vars:
     cli_volume_size: 90
     cli_var_size: 64
-    cli_reserved_sector_count: 5000
+    cli_reserved_sector_count: 0
     os_size_min: 20
+    cli_var_partition_number: 2
 
   tasks:
   - name: "Check for required variables" 
@@ -145,11 +146,12 @@
       description: "Snapshot of {{ cli_tag_name }} {{ vol_instance.device }} before resize"
       wait: no ## don't wait for the snapshot to complete pushing to S3, it still exists and waiting can take hours
     when: cli_volume_size|int > rootvg_volume_size|int
+    register: ebs_snapshot_out
 
   - name: Get partition info
     parted: 
       device: "{{ vol_instance.fullname }}"
-      number: 2
+      number: "{{ cli_var_partition_number }}"
       state: info
       unit: s
     register: parted_info
@@ -179,6 +181,14 @@
   - name: Run partprobe to see if the size changed
     command: partprobe
 
+  - name: Get partition info (updated)
+    parted: 
+      device: "{{ vol_instance.fullname }}"
+      number: "{{ cli_var_partition_number }}"
+      state: info
+      unit: s
+    register: parted_info
+
   - name: Get available sectors (minus reserved sector count)
     shell: "echo $(( $(fdisk -l {{ vol_instance.fullname }} | grep sectors$ | cut -d' ' -f7) - 1 - {{ cli_reserved_sector_count|int }} ))"
     changed_when: false
@@ -192,6 +202,23 @@
   - name: Resize partition
     when: sectors_available.stdout|int > sectors_used.stdout|int
     block:
+      - name: set params for partition script
+        set_fact:
+          partition_name: "{{ vol_instance.fullname }}"
+          partition_begin: "{{ parted_info.partitions[1].begin|int }}"
+          partition_end: "{{ (parted_info.disk.size|int - cli_reserved_sector_count|int - 1) }}"
+          partition_number: "{{ cli_var_partition_number }}"
+
+      - name: Take snapshot (if didn't already)
+        delegate_to: localhost
+        ec2_snapshot:
+          region: "{{ ec2_region }}"
+          volume_id: "{{ rootvg_volume_id }}"
+          description: "Snapshot of {{ cli_tag_name }} {{ vol_instance.device }} before resize"
+          wait: no ## don't wait for the snapshot to complete pushing to S3, it still exists and waiting can take hours
+        when: ebs_snapshot_out is not defined
+        register: ebs_snapshot_out
+
       - name: Create script to recreate partition
         template:
           src: grow_root_vg-m5-recreate-partition.sh.j2
@@ -204,11 +231,6 @@
 
       - name: Run partprobe
         command: partprobe
-
-  - name: Remove recreate script
-    file:
-      path: /root/grow_root_vg-m5-recreate-partition.sh
-      state: absent
 
   - name: Resize the pv 
     shell: "pvresize $(pvs|grep rootvg|awk '{print $1}')"
@@ -225,7 +247,15 @@
     changed_when: false
     register: new_var_size
 
-  - name: Fail if didn't resize
+  - name: Fail when var is not bigger than or equal to target size
     fail:
       msg: "New /var size ({{ new_var_size.stdout }}G) isn't expected size ({{ cli_var_size }}G)"
-    when: new_var_size.stdout|int != cli_var_size|int
+    when: new_var_size.stdout|int < cli_var_size|int
+
+  - name: Remove recreate script when successful
+    file:
+      path: /root/grow_root_vg-m5-recreate-partition.sh
+      state: absent
+
+  - name: Trigger filesystem metrics
+    shell: "docker exec -ti oso-rhel7-host-monitoring /usr/bin/cron-send-filesystem-metrics -v"

--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg.yml
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg.yml
@@ -163,3 +163,6 @@
 
   - name: Resize /var
     command: "xfs_growfs /var "
+
+  - name: Trigger filesystem metrics
+    shell: "docker exec -ti oso-rhel7-host-monitoring /usr/bin/cron-send-filesystem-metrics -v"

--- a/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg.yml
+++ b/ansible/playbooks/adhoc/grow_root_vg/grow_root_vg.yml
@@ -164,5 +164,10 @@
   - name: Resize /var
     command: "xfs_growfs /var "
 
-  - name: Trigger filesystem metrics
+  - name: Trigger filesystem metrics (master or infra)
     shell: "docker exec -ti oso-rhel7-host-monitoring /usr/bin/cron-send-filesystem-metrics -v"
+    when: "('oo_hosttype_master' in group_names or 'oo_subhosttype_infra' in group_names)"
+
+  - name: Trigger filesystem metrics (compute)
+    shell: "docker exec -ti oso-rhel7-host-monitoring /usr/bin/cron-send-filesystem-metrics --filter-pod-pv -v"
+    when: "'oo_subhosttype_compute' in group_names"


### PR DESCRIPTION
- add reserved sectors option (default is 0)
- repartition script sets explicit end sector
- trigger filesystem metrics at end (also added for m4 script)
- keep repartition script until execution is successful (to help debug)