### PR TITLE
reduce config loop severity failure from high to average

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_cluster.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_cluster.yml
@@ -28,7 +28,7 @@ g_template_openshift_cluster:
   - name: "Config loop failed on {HOST.NAME}"
     expression: "{Template OpenShift Cluster:openshift.cluster.configloop.exitcode.min(#3)}>0"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_config_loop.asciidoc"
-    priority: high
+    priority: average
 
   zdiscoveryrules:
   - name: disc.openshift.cluster.router


### PR DESCRIPTION
Reason: a config loop failure does not impact a customer so it's not worth waking someone up. It's important to fix but should be addressed by better CI. Without CI it isn't fair to wake an engineer.

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>