### PR TITLE
Allow same certs to be uploaded next time playbook runs

### DIFF
--- a/ansible/roles/openshift_aws_iam_cert/tasks/main.yml
+++ b/ansible/roles/openshift_aws_iam_cert/tasks/main.yml
@@ -14,6 +14,7 @@
   iam_cert:
     name: "{{ osaic_iam_certname }}"
     state: present
+    dup_ok: yes
     cert: "{{ osaic_cert }}"
     key: "{{ osaic_key }}"
     cert_chain: "{{ osaic_chain_cert | default(omit, True) }}"


### PR DESCRIPTION
Right now running the cert update playbook multiple times fails if the certificate itself has not changed. This change allows us to upload same certificate again.

https://docs.ansible.com/ansible/2.5/modules/iam_cert_module.html