### PR TITLE
a ansible/python module to calcuate subnets needed for OSD 3.11 install

### DIFF
--- a/ansible/roles/lib_utils/library/oo_vpc_subnets_calc.py
+++ b/ansible/roles/lib_utils/library/oo_vpc_subnets_calc.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+# vim: expandtab:tabstop=2:shiftwidth=2
+
+import boto3
+import netaddr
+import math
+
+''' vpc_subnets_calc module
+
+    The purpose of this module is to cat the contents of a file into an Ansible fact for use later.
+    
+    
+Test Playbook:
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - include_role:
+      name: ../../roles/lib_utils
+    static: true
+  - oo_vpc_subnets_calc:
+      cidr_block: "172.16.0.0/24"
+      region: "us-east-1"
+      number_of_subnets: 3
+    register: out
+  - debug:
+      msg: "{{ item }}"
+    with_items:
+    - "{{ out.results }}"    
+    
+'''
+
+def calc_subnets(module, cidr_block, num_of_subnets, num_avail_zones_in_region):
+    max_hosts_per_subnet = 2048
+    min_hosts_per_subnet = 14
+    ip = netaddr.IPNetwork(cidr_block)
+    num_of_hosts_per_subnet = 0
+    results = []
+
+    if ip.size < min_hosts_per_subnet:
+        if module is None:
+            module.fail_json(msg='CIDR block is too small.')
+        else:
+            print("CIDR block is too small.")
+            return results
+
+    if ip.size >= (max_hosts_per_subnet * 3) and num_avail_zones_in_region >= num_of_subnets:
+        num_of_hosts_per_subnet = max_hosts_per_subnet
+    else:
+        num_of_hosts_per_subnet = int(ip.size / 4)
+
+    if num_of_hosts_per_subnet >= max_hosts_per_subnet:
+        num_of_hosts_per_subnet = max_hosts_per_subnet
+    else:
+        if num_of_hosts_per_subnet < min_hosts_per_subnet:
+            num_of_hosts_per_subnet = min_hosts_per_subnet
+
+    bits = 32 - int(round(math.log(num_of_hosts_per_subnet, 2)))
+    subnets = list(ip.subnet(bits))
+
+    if num_avail_zones_in_region >= num_of_subnets:
+        subnets = subnets[:3]
+    else:
+        subnets = subnets[:1]
+
+    for item in subnets:
+        results.append(str(item)) 
+
+    return results
+
+
+def main():
+    
+    module = AnsibleModule(
+        argument_spec=dict(
+            cidr_block=dict(required=True, type='str'),
+            region=dict(default=None, required=True, type='str'),
+            aws_access_key_id=dict(default=None, type='str'),
+            aws_secret_access_key=dict(default=None, type='str'),
+            number_of_subnets=dict(default=3, choices=[1, 3], type='int'),
+        ),
+        supports_check_mode=True
+    )
+
+    cidr_block = module.params.get('cidr_block')
+    region_name = module.params.get('region')
+    aws_access_key_id = module.params.get('aws_access_key_id')
+    aws_secret_access_key = module.params.get('aws_secret_access_key')
+    number_of_subnets = module.params.get('number_of_subnets')
+
+    if aws_access_key_id and aws_secret_access_key:
+        boto3.setup_default_session(aws_access_key_id=aws_access_key_id,
+                                    aws_secret_access_key=aws_secret_access_key,
+                                    region_name=region_name)
+    else:
+        boto3.setup_default_session(region_name=region_name)
+
+    boto_client = boto3.client('ec2')
+    response = boto_client.describe_availability_zones()
+    num_avail_zones_in_region = len(response['AvailabilityZones'])
+    results = calc_subnets(module, cidr_block, number_of_subnets, num_avail_zones_in_region)
+    module.exit_json(changed=False, ansible_facts={}, results=results)
+
+
+if __name__ == '__main__':
+    # pylint: disable=redefined-builtin, unused-wildcard-import, wildcard-import
+    from ansible.module_utils.basic import *
+
+    main()

--- a/ansible/roles/lib_utils/library/oo_vpc_subnets_calc_unittests.py
+++ b/ansible/roles/lib_utils/library/oo_vpc_subnets_calc_unittests.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# vim: expandtab:tabstop=2:shiftwidth=2
+
+import unittest
+from oo_vpc_subnets_calc import *
+
+class TestSubnetCalc(unittest.TestCase):
+
+    def test_large_cidr_3az_3subnet(self):
+        cidr_block = "172.16.0.0/16"
+        num_of_subnets = 3
+        num_avail_zones_in_region = 3
+        expected_result = ["172.16.0.0/21", "172.16.8.0/21", "172.16.16.0/21"]
+        results = calc_subnets(None, cidr_block, num_of_subnets, num_avail_zones_in_region)
+        self.assertItemsEqual(expected_result, results, "Enough AZs for 3 subnet and large enough CIDR block")
+
+    def test_small_cidr_3az_3subnet(self):
+        cidr_block = "172.16.0.0/24"
+        num_of_subnets = 3
+        num_avail_zones_in_region = 3
+        expected_result = ["172.16.0.0/26", "172.16.0.64/26", "172.16.0.128/26"]
+        results = calc_subnets(None, cidr_block, num_of_subnets, num_avail_zones_in_region)
+        self.assertItemsEqual(expected_result, results, "Enough AZs for 3 subnet and large enough CIDR block")
+
+    def test_large_cidr_2az_3subnet(self):
+        cidr_block = "172.16.0.0/16"
+        num_of_subnets = 3
+        num_avail_zones_in_region = 2
+        expected_result = ["172.16.0.0/21"]
+        results = calc_subnets(None, cidr_block, num_of_subnets, num_avail_zones_in_region)
+        self.assertItemsEqual(expected_result, results, "Not enough AZs for 3 subnet but large enough CIDR block")
+
+    def test_small_cidr_2az_3subnet(self):
+        cidr_block = "172.16.0.0/24"
+        num_of_subnets = 3
+        num_avail_zones_in_region = 2
+        expected_result = ["172.16.0.0/26"]
+        results = calc_subnets(None, cidr_block, num_of_subnets, num_avail_zones_in_region)
+        self.assertItemsEqual(expected_result, results, "Not enough AZs for 3 subnet but large enough CIDR block")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
STG PR: https://github.com/openshift/openshift-tools/pull/3786

An ansible module to calculate subnets based on VPC CIDR block, number of availability zones in the deployment AWS region and desired number of subnets (1 or 3). Maximum hosts supported per subnet is 2048. Minimum hosts subnet must be able to support is 14. If the CIDR block provided is too small, module will throw error.

Scenario 1:
Deployment region has at least 3 availability zones, CIDR block is 172.16.0.0/16 and we want 3 subnets. Calculator will return subnets "172.16.0.0/21", "172.16.8.0/21", "172.16.16.0/21".

Scenario 2:
Deployment region has 2 availability zones, CIDR block is 172.16.0.0/16 and we want 3 subnets. Calculator will return only 1 subnet with CIDR "172.16.0.0/21".

Scenario 3:
Deployment region has 3 availability zones, CIDR block is 172.16.0.0/24 and we want 3 subnets. Calculator will return subnets "172.16.0.0/26", "172.16.0.64/26", "172.16.0.128/26".

Scenario 4:
Deployment region has 3 availability zones, CIDR block is 172.16.0.0/29 and we want 3 subnets. Calculator will return error as the CIDR block is too small. We require CIDR for each subnet to support at least 14 hosts.