### PR TITLE
ohi: Fix TypeError in --get-cluster-var and --get-node-var

### DIFF
--- a/scripts/inventory-clients/ohi
+++ b/scripts/inventory-clients/ohi
@@ -64,7 +64,7 @@ class Ohi(object):
                 if var_result is None:
                     print "Unable to determine variable.  node: %s   variable: %s" %(self.args.node, var_name)
                     return 1
-                node_vars.append(var_result)
+                node_vars.append(str(var_result))
             print delimiter.join(node_vars)
             return 0
 
@@ -80,7 +80,7 @@ class Ohi(object):
                 if var_result is None:
                     print "Unable to determine cluster variable: %s" % var_name
                     return 1
-                cluster_vars.append(var_result)
+                cluster_vars.append(str(var_result))
             print delimiter.join(cluster_vars)
             return 0
 


### PR DESCRIPTION
Fetching numeric variables recently started throwing a TypeError exception:
```
$ ohi -c $CLUSTERID --get-cluster-var oo_accountid
Traceback (most recent call last):
  File "/usr/bin/ohi", line 248, in <module>
    main()
  File "/usr/bin/ohi", line 242, in main
    exitcode = ohi.run()
  File "/usr/bin/ohi", line 84, in run
    print delimiter.join(cluster_vars)
TypeError: sequence item 0: expected string, int found
```