### PR TITLE
rename the listener for the new handlers

### DIFF
--- a/ansible/roles/openshift_master_audit_config/handlers/main.yml
+++ b/ansible/roles/openshift_master_audit_config/handlers/main.yml
@@ -8,7 +8,7 @@
   notify:
   - master api less than 3.10
   - master api 3.10 and greater
-  listen: 'restart master services'
+  listen: 'restart openshift master services'
 
 - name: master controllers
   repoquery:
@@ -19,7 +19,7 @@
   notify:
   - master controllers less than 3.10
   - master controllers 3.10 and greater
-  listen: 'restart master services'
+  listen: 'restart openshift master services'
 
 - name: master api less than 3.10
   systemd:


### PR DESCRIPTION
Currently, the handler is listening for `restart master services` but the main task is expecting `restart openshift master services`. This commit fixes that bug.

Approved in PR #3841 