### PR TITLE
Update check-tags for 3.11

### DIFF
--- a/scripts/monitoring/ops-ec2-check-tags.py
+++ b/scripts/monitoring/ops-ec2-check-tags.py
@@ -85,6 +85,16 @@ class AWSTagsMonitorCLI(object):
         # This will print out a list of instances
         #  and the tags associated with them
         for v in instances.itervalues():
+            # Skip scale group nodes because they don't have names, 
+            # and their tags are managed by the scale group
+            if v.tags.get('scalegroup') == 'True':
+                continue
+
+            # Pre-3.11 masters will have 'Name' tags, but newer ones won't.
+            if 'Name' not in v.tags:
+                # If the Name tag is missing, add one. 
+                v.tags['Name'] = "{}-{}-{}".format(v.tags['clusterid'], v.tags['host-type'], v.private_dns_name)
+
             print v.id + ":"
             for name, value in v.tags.iteritems():
                 print "  %s: %s" %(name, value)


### PR DESCRIPTION
This updates the script that checks tags on our EC2 instances. This started failing in 3.11 because nodes for those clusters do not have "Name" tags. This PR updates the script to only report on nodes that aren't in scale groups and creates a Name tag for masters that are missing it. This allows the script to report whether or not config loop is enabled on those nodes, which is the only information this script reports to zabbix. 

A follow-up PR will update the node-label check to report whether scale group nodes have config loop enabled by checking for the "config_pod" label.