### PR TITLE
Update openshift_udp_limits to not delegate to master

### DIFF
--- a/ansible/roles/openshift_firstboot_scripts/files/enable-tcp-logs-and-udp-limits.yml
+++ b/ansible/roles/openshift_firstboot_scripts/files/enable-tcp-logs-and-udp-limits.yml
@@ -1,0 +1,20 @@
+#!/usr/bin/ansible-playbook
+---
+- hosts: localhost
+  connection: local
+  gather_facts: yes
+  user: root
+  tasks:
+  - name: Gather EC2 metadata for instance
+    ec2_metadata_facts:
+
+  - name: Configure outbound TCP logging
+    include_role:
+      name: tools_roles/openshift_outbound_tcp_logging
+
+  - name: Configure outbound UDP limits
+    include_role:
+      name: tools_roles/openshift_udp_limits
+    vars:
+      oudp_node_name: "{{ ansible_ec2_local_hostname }}"
+      oudp_node_ip: "{{ ansible_ec2_local_ipv4 }}"

--- a/ansible/roles/openshift_firstboot_scripts/tasks/main.yml
+++ b/ansible/roles/openshift_firstboot_scripts/tasks/main.yml
@@ -1,9 +1,12 @@
 ---
 - name: create the firstboot dir to store the scripts
   file:
-    path: "{{ osfbs_dir }}"
+    path: "{{ item }}"
     state: directory
     mode: 0700
+  with_items:
+  - "{{ osfbs_dir }}"
+  - "{{ osfbs_dir }}/tools_roles"
 
 - name: Copy scripts into firstboot dir
   copy:
@@ -17,6 +20,7 @@
   - rhsm-unregister.sh
   - insights-register.sh
   - disable-hyperthreading.sh
+  - enable-tcp-logs-and-udp-limits.yml
 
 - name: Copy templates into the firstboot dir
   template:
@@ -27,3 +31,19 @@
     mode: '0700'
   with_items:
   - rhsm-register.sh.j2
+  - expose-router-healthcheck-port.yml.j2
+
+- name: Copy ansible roles into firstboot/roles dir
+  copy:
+    src: "{{ item }}"
+    dest: "{{ osfbs_dir }}/tools_roles"
+    owner: root
+    group: root
+    mode: '0700'
+  with_items:
+  - tools_roles/openshift_udp_limits
+  - tools_roles/openshift_outbound_tcp_logging
+  - tools_roles/lib_ops_utils
+  - tools_roles/lib_openshift
+  - tools_roles/lib_aos_modules
+  - tools_roles/ops_os_firewall

--- a/ansible/roles/openshift_firstboot_scripts/templates/expose-router-healthcheck-port.yml.j2
+++ b/ansible/roles/openshift_firstboot_scripts/templates/expose-router-healthcheck-port.yml.j2
@@ -1,0 +1,11 @@
+#!/usr/bin/ansible-playbook
+---
+- hosts: localhost
+  connection: local
+  gather_facts: yes
+  user: root
+  tasks:
+  - include_role:
+      name: tools_roles/ops_os_firewall
+    vars:
+      oof_firewall_allow: "{{ osfbs_firewall_allow }}"

--- a/ansible/roles/openshift_udp_limits/tasks/main.yml
+++ b/ansible/roles/openshift_udp_limits/tasks/main.yml
@@ -1,15 +1,10 @@
 ---
-- name: Choose a master on which to run
-  set_fact:
-    cluster_master: "{{ groups['oo_hosttype_master'] | intersect(groups['oo_clusterid_' ~ oo_clusterid]) | first }}"
-  run_once: true
-
 - name: "Get the host's pod network subnet"
   oc_obj:
     state: list
     kind: hostsubnet
+    kubeconfig: /etc/origin/node/node.kubeconfig
   register: hostsubnets
-  delegate_to: "{{ cluster_master }}"
   run_once: true
 
 - set_fact:

--- a/ansible/roles/os_utils/tasks/main.yaml
+++ b/ansible/roles/os_utils/tasks/main.yaml
@@ -26,3 +26,5 @@
   - pv
   - lftp
   - insights-client
+  - python-netaddr
+  - nvme-cli


### PR DESCRIPTION
This updates the udp_limits role to make its oc call from the node it is running from instead of delegating to a master. This will allow this role to run inside a scalegroup compute node without having to have any masters in its ansible inventory.