### PR TITLE
Add cloud_storage_udev_rules role

### DIFF
--- a/ansible/roles/cloud_storage_udev_rules/README.md
+++ b/ansible/roles/cloud_storage_udev_rules/README.md
@@ -1,0 +1,34 @@
+cloud_storage_udev_rules
+========================
+
+Installs udev rules to assist with cloud storage configuration.
+
+- Make predictable NVMe device names on AWS.
+  Based on: https://github.com/coreos/init/pull/268
+
+Requirements
+------------
+
+
+Role Variables
+--------------
+
+
+Dependencies
+------------
+
+
+Example Playbook
+----------------
+
+
+License
+-------
+
+Apache 2.0
+
+
+Author Information
+------------------
+
+Openshift Operations

--- a/ansible/roles/cloud_storage_udev_rules/files/90-cloud-storage.rules
+++ b/ansible/roles/cloud_storage_udev_rules/files/90-cloud-storage.rules
@@ -1,0 +1,16 @@
+# Rules to make easy to predict/remember device names on cloud providers.
+
+ACTION=="remove", GOTO="cloud_storage_end"
+SUBSYSTEM!="block", GOTO="cloud_storage_end"
+
+## AWS EBS NVMe names
+## https://github.com/coreos/bugs/issues/2399
+# NVMe devices
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-%n", OPTIONS+="string_escape=replace"
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", PROGRAM="cloud_aws_ebs_nvme_id -d /dev/%k", SYMLINK+="%c"
+# NVMe partitions
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", IMPORT{program}="cloud_aws_ebs_nvme_id -n /dev/%k"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", ENV{_NS_ID}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-$env{_NS_ID}-part%n", OPTIONS+="string_escape=replace"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", ENV{_NS_ID}=="?*", PROGRAM="cloud_aws_ebs_nvme_id -d /dev/%k", SYMLINK+="%c%n"
+
+LABEL="cloud_storage_end"

--- a/ansible/roles/cloud_storage_udev_rules/files/cloud_aws_ebs_nvme_id
+++ b/ansible/roles/cloud_storage_udev_rules/files/cloud_aws_ebs_nvme_id
@@ -19,7 +19,7 @@ namespace_id() {
 # see https://github.com/coreos/bugs/issues/2399.
 devname() {
     check_udev_aws
-    RAWVOL=$(nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
+    RAWVOL=$(/usr/sbin/nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
     VOL="${RAWVOL#/dev/}"
     if [[ -n "$VOL" ]]; then
         echo "${VOL}"
@@ -31,8 +31,8 @@ devname() {
 # Ensure this is run with proper environment populated by udev,
 # and acting on an AWS EBS device.
 check_udev_aws() {
-    if [ "${ID_MODEL}" != "Amazon Elastic Block Store" ]; then
-        echo 'Stopping due to non-matching ID_MODEL env variable'
+    if [[ "${ID_SERIAL}" != "Amazon Elastic Block Store"* ]]; then
+        echo 'Stopping due to non-matching ID_SERIAL env variable'
         exit 1
     fi
 }

--- a/ansible/roles/cloud_storage_udev_rules/files/cloud_aws_ebs_nvme_id
+++ b/ansible/roles/cloud_storage_udev_rules/files/cloud_aws_ebs_nvme_id
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2018 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+usage() {
+    echo "Usage: $0 [-d|-p|-h] <device>" 1>&2
+}
+
+# Get partition ID from device name, e.g. '/dev/nvme0n1p2' -> '1'
+namespace_id() {
+    check_udev_aws
+    NSID=$(echo -n "$1" | cut -f 3 -d 'n' | cut -f 1 -d 'p')
+    echo "_NS_ID=${NSID}"
+}
+
+# Get device name from raw metadata,
+# see https://github.com/coreos/bugs/issues/2399.
+devname() {
+    check_udev_aws
+    RAWVOL=$(nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
+    VOL="${RAWVOL#/dev/}"
+    if [[ -n "$VOL" ]]; then
+        echo "${VOL}"
+    else
+        exit 1
+    fi
+}
+
+# Ensure this is run with proper environment populated by udev,
+# and acting on an AWS EBS device.
+check_udev_aws() {
+    if [ "${ID_MODEL}" != "Amazon Elastic Block Store" ]; then
+        echo 'Stopping due to non-matching ID_MODEL env variable'
+        exit 1
+    fi
+}
+
+while getopts "hd:n:" o; do
+    case "${o}" in
+        d)
+            devname "${OPTARG}"
+            exit 0
+            ;;
+        n)
+            namespace_id "${OPTARG}"
+            exit 0
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+

--- a/ansible/roles/cloud_storage_udev_rules/tasks/main.yml
+++ b/ansible/roles/cloud_storage_udev_rules/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Install nvme-cli package
+  package:
+    name: nvme-cli
+    state: present
+
+- name: Copy cloud_aws_ebs_nvme_id utility
+  copy:
+    src: cloud_aws_ebs_nvme_id
+    dest: /usr/lib/udev/
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Copy 90-cloud-storage.rules
+  copy:
+    src: 90-cloud-storage.rules
+    dest: /usr/lib/udev/rules.d/
+    owner: root
+    group: root
+    mode: '0644'


### PR DESCRIPTION
Installs udev rules to assist with cloud storage configuration.

* Make predictable NVMe device names on AWS.
  Based on: coreos/init#268