### PR TITLE
Tiered access for scalegroup nodes

### DIFF
--- a/ansible/roles/daemonset_pods/files/tiered_access/authorized_keys.j2
+++ b/ansible/roles/daemonset_pods/files/tiered_access/authorized_keys.j2
@@ -1,0 +1,3 @@
+{% raw %}{% for user in tar_users %}
+command="/usr/bin/devaccess_wrap READ_SSH {{ user.username }}" {{ user.pub_key }}
+{% endfor %}{% endraw %}

--- a/ansible/roles/daemonset_pods/files/tiered_access/devaccess_users.j2
+++ b/ansible/roles/daemonset_pods/files/tiered_access/devaccess_users.j2
@@ -1,0 +1,16 @@
+roles:
+
+users:
+{% raw %}
+{% for user in tar_users %}
+- username: {{ user.username }}
+{% if user.has_key('roles') %}
+  roles:
+{%   for role in user.roles %}
+  - {{ role }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endraw %}
+
+user_roles:

--- a/ansible/roles/daemonset_pods/files/tiered_access/tiered_access_tasks.yml
+++ b/ansible/roles/daemonset_pods/files/tiered_access/tiered_access_tasks.yml
@@ -1,0 +1,54 @@
+---
+- name: import lib_utils for yedit
+  import_role:
+    name: /usr/share/ansible/openshift-ansible/roles/lib_utils
+
+- name: Load tiered_access variables
+  include_vars: /opt/config/tiered_access_vars.yml
+
+- name: Setup authorized keys for developer user
+  template:
+    src: /opt/config/devaccess_authorized_keys.j2
+    dest: "/host/home/{{ tar_username }}/.ssh/authorized_keys"
+    owner: "{{ tar_uid }}"
+    group: "{{ tar_gid }}"
+    mode: "0400"
+
+# The config pod doesn't know about the devaccess user or the
+# libra_ops group, so we need to set permissions on those using
+# their uids and gids.
+- name: configure user access
+  template:
+    src: /opt/config/devaccess_users.j2
+    dest: "/host/etc/openshift_tools/devaccess_users.yaml"
+    owner: "{{ tar_uid }}"
+    group: "1000"
+    mode: "0440"
+
+- name: and then yedit the configure user access
+  yedit:
+    src: "/host/etc/openshift_tools/devaccess_users.yaml"
+    key: roles
+    value: "{{ tar_roles }}"
+
+- name: add user_roles to the config file
+  yedit:
+    src: "/host/etc/openshift_tools/devaccess_users.yaml"
+    key: user_roles
+    value: "{{ tar_user_roles }}"
+
+- name: find regular node kubeconfig
+  find:
+    path:
+    - /host/etc/origin/node
+    patterns: "*node*kubeconfig"
+  register: node_kube
+
+- name: use node kubeconfig if not a master
+  copy:
+    remote_src: True
+    src: "{{ node_kube['files'] | map(attribute='path') | list | sort(reverse=True) | first }}"
+    dest: "/host/home/{{ tar_username }}/devaccess.kubeconfig"
+    owner: "{{ tar_uid }}"
+    group: "{{ tar_gid }}"
+    mode: "0600"

--- a/ansible/roles/daemonset_pods/tasks/main.yml
+++ b/ansible/roles/daemonset_pods/tasks/main.yml
@@ -84,6 +84,27 @@
       name: dnsmasq_vars.yml
       contents: "{{ {'dns_proxy_map': dsp_dns_proxy_map } | to_yaml }}"
 
+    # devaccess authorized_keys
+    - path: /tmp/devaccess_authorized_keys.j2
+      name: devaccess_authorized_keys.j2
+      contents: |
+        {{ lookup('file', '../files/tiered_access/authorized_keys.j2') }}
+
+    - path: /tmp/tiered_access_vars.yml
+      name: tiered_access_vars.yml
+      contents: "{{ {'tar_users': dsp_tar_users,
+                     'tar_username': 'devaccess',
+                     'tar_roles': dsp_tar_roles,
+                     'tar_uid': dsp_tar_uid,
+                     'tar_gid': dsp_tar_gid,
+                     'tar_user_roles': dsp_tar_user_roles } | to_yaml }}"
+
+    # devaccess_users
+    - path: /tmp/devaccess_users.j2
+      name: devaccess_users.j2
+      contents: |
+        {{ lookup('file', '../files/tiered_access/devaccess_users.j2') }}
+
     # end authorized_keys
 
     openshift_daemonset_config_configmap_literals:
@@ -101,6 +122,8 @@
         {{ lookup('file', '../files/operations/operations_tasks.yml') }}
       dnsmasq_tasks.yml: |
         {{ lookup('file', '../files/dnsmasq/dnsmasq_tasks.yml') }}
+      tiered_access_tasks.yml: |
+        {{ lookup('file', '../files/tiered_access/tiered_access_tasks.yml') }}
 
       # this requires clusterid to be translated and cannot be moved to files unless that is solved
       monitoring_config_tasks.yml: |
@@ -116,7 +139,7 @@
             file:
               state: directory
               path: /host/etc/openshift_tools
-              mode: "0740"
+              mode: "0775"
               owner: root
               group: root
 
@@ -140,6 +163,10 @@
 
           - name: setup dnsmasq tasks
             import_tasks: /opt/config/dnsmasq_tasks.yml
+
+          - name: setup tiered_access tasks
+            import_tasks: /opt/config/tiered_access_tasks.yml
+            when: "{{ dsp_tar_enabled }}"
 
       operations_config.sh: |
         #!/bin/bash

--- a/openshift_tools/python-openshift-tools.spec
+++ b/openshift_tools/python-openshift-tools.spec
@@ -1,6 +1,6 @@
 Summary:       OpenShift Tools Python Package
 Name:          python-openshift-tools
-Version:       0.0.142
+Version:       0.0.143
 Release:       1%{?dist}
 License:       ASL 2.0
 URL:           https://github.com/openshift/openshift-tools
@@ -315,6 +315,10 @@ Adds GCP specific python modules
 %{python_sitelib}/openshift_tools/cloud/gcp/*.py[co]
 
 %changelog
+* Thu Jan 17 2019 Matt Woodson <mwoodson@redhat.com> 0.0.143-1
+- updated the playbook executor code (mwoodson@redhat.com)
+- updated sre-bot for new weekend only on call (mail@rafaelazevedo.me)
+
 * Thu Nov 29 2018 Matt Woodson <mwoodson@redhat.com> 0.0.142-1
 - changed the version rpm check to look at atomic-openshift-clients
   (mwoodson@redhat.com)

--- a/rel-eng/packages/python-openshift-tools
+++ b/rel-eng/packages/python-openshift-tools
@@ -1,1 +1,1 @@
-0.0.142-1 openshift_tools/
+0.0.143-1 openshift_tools/


### PR DESCRIPTION
This PR adds support for tiered_access to the config_pods running on scalegroup nodes. This code depends on the changes to the AMI build made [here](https://github.com/openshift/openshift-ansible-ops/pull/5127). 

Before this PR can be merged:
1. [PR #5127](https://github.com/openshift/openshift-ansible-ops/pull/5127) needs to be merged.
2. A new AMI needs to be baked.
3. The new AMI needs to be rolled out everywhere.

Once that is done, this PR is safe to merge. The dependency on PR #5127 exists because the devaccess user and group must be present. 