### PR TITLE
Update sopel pip module

### DIFF
--- a/openshift_tools/ircbot/requirements.txt
+++ b/openshift_tools/ircbot/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/sopel-irc/sopel.git#master
+sopel
 pypd


### PR DESCRIPTION
With release 6.6.0, sopel now supports userserv authentication in the officially released version: https://github.com/sopel-irc/sopel/releases/tag/v6.6.0