### PR TITLE
cloud_storage_udev_rules: Rename "sd*" devices to "xvd*"

### DIFF
--- a/ansible/roles/cloud_storage_udev_rules/files/cloud_aws_ebs_nvme_id
+++ b/ansible/roles/cloud_storage_udev_rules/files/cloud_aws_ebs_nvme_id
@@ -21,6 +21,11 @@ devname() {
     check_udev_aws
     RAWVOL=$(/usr/sbin/nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
     VOL="${RAWVOL#/dev/}"
+
+    # Rename "sd*" volume names to "xvd*" for
+    # consistency with infra (R4) instances.
+    VOL=${VOL/#sd/xvd}
+
     if [[ -n "$VOL" ]]; then
         echo "${VOL}"
     else


### PR DESCRIPTION
For consistency with infra (R4) instances.