### PR TITLE
Enable tiered access on scalegroup nodes

### DIFF
--- a/ansible/roles/daemonset_pods/files/tiered_access/authorized_keys.j2
+++ b/ansible/roles/daemonset_pods/files/tiered_access/authorized_keys.j2
@@ -1,0 +1,3 @@
+{% raw %}{% for user in tar_users %}
+command="/usr/bin/devaccess_wrap READ_SSH {{ user.username }}" {{ user.pub_key }}
+{% endfor %}{% endraw %}

--- a/ansible/roles/daemonset_pods/files/tiered_access/devaccess_users.j2
+++ b/ansible/roles/daemonset_pods/files/tiered_access/devaccess_users.j2
@@ -1,0 +1,16 @@
+roles:
+
+users:
+{% raw %}
+{% for user in tar_users %}
+- username: {{ user.username }}
+{% if user.has_key('roles') %}
+  roles:
+{%   for role in user.roles %}
+  - {{ role }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endraw %}
+
+user_roles:

--- a/ansible/roles/daemonset_pods/files/tiered_access/tiered_access_tasks.yml
+++ b/ansible/roles/daemonset_pods/files/tiered_access/tiered_access_tasks.yml
@@ -1,0 +1,54 @@
+---
+- name: import lib_utils for yedit
+  import_role:
+    name: /usr/share/ansible/openshift-ansible/roles/lib_utils
+
+- name: Load tiered_access variables
+  include_vars: /opt/config/tiered_access_vars.yml
+
+- name: Setup authorized keys for developer user
+  template:
+    src: /opt/config/devaccess_authorized_keys.j2
+    dest: "/host/home/{{ tar_username }}/.ssh/authorized_keys"
+    owner: "{{ tar_uid }}"
+    group: "{{ tar_gid }}"
+    mode: "0400"
+
+# The config pod doesn't know about the devaccess user or the
+# libra_ops group, so we need to set permissions on those using
+# their uids and gids.
+- name: configure user access
+  template:
+    src: /opt/config/devaccess_users.j2
+    dest: "/host/etc/openshift_tools/devaccess_users.yaml"
+    owner: "{{ tar_uid }}"
+    group: "1000"
+    mode: "0440"
+
+- name: and then yedit the configure user access
+  yedit:
+    src: "/host/etc/openshift_tools/devaccess_users.yaml"
+    key: roles
+    value: "{{ tar_roles }}"
+
+- name: add user_roles to the config file
+  yedit:
+    src: "/host/etc/openshift_tools/devaccess_users.yaml"
+    key: user_roles
+    value: "{{ tar_user_roles }}"
+
+- name: find regular node kubeconfig
+  find:
+    path:
+    - /host/etc/origin/node
+    patterns: "*node*kubeconfig"
+  register: node_kube
+
+- name: use node kubeconfig if not a master
+  copy:
+    remote_src: True
+    src: "{{ node_kube['files'] | map(attribute='path') | list | sort(reverse=True) | first }}"
+    dest: "/host/home/{{ tar_username }}/devaccess.kubeconfig"
+    owner: "{{ tar_uid }}"
+    group: "{{ tar_gid }}"
+    mode: "0600"

--- a/ansible/roles/daemonset_pods/files/tiered_access/tiered_access_tasks.yml
+++ b/ansible/roles/daemonset_pods/files/tiered_access/tiered_access_tasks.yml
@@ -6,49 +6,56 @@
 - name: Load tiered_access variables
   include_vars: /opt/config/tiered_access_vars.yml
 
-- name: Setup authorized keys for developer user
-  template:
-    src: /opt/config/devaccess_authorized_keys.j2
-    dest: "/host/home/{{ tar_username }}/.ssh/authorized_keys"
-    owner: "{{ tar_uid }}"
-    group: "{{ tar_gid }}"
-    mode: "0400"
+- name: Check if the devaccess user is present on the host system
+  stat:
+    path: "/host/home/{{ tar_username }}"
+  register: tar_user_homedir
 
-# The config pod doesn't know about the devaccess user or the
-# libra_ops group, so we need to set permissions on those using
-# their uids and gids.
-- name: configure user access
-  template:
-    src: /opt/config/devaccess_users.j2
-    dest: "/host/etc/openshift_tools/devaccess_users.yaml"
-    owner: "{{ tar_uid }}"
-    group: "1000"
-    mode: "0440"
+- when: tar_user_homedir.stat.exists == True
+  block:
+  - name: Setup authorized keys for developer user
+    template:
+      src: /opt/config/devaccess_authorized_keys.j2
+      dest: "/host/home/{{ tar_username }}/.ssh/authorized_keys"
+      owner: "{{ tar_uid }}"
+      group: "{{ tar_gid }}"
+      mode: "0400"
 
-- name: and then yedit the configure user access
-  yedit:
-    src: "/host/etc/openshift_tools/devaccess_users.yaml"
-    key: roles
-    value: "{{ tar_roles }}"
+  # The config pod doesn't know about the devaccess user or the
+  # libra_ops group, so we need to set permissions on those using
+  # their uids and gids.
+  - name: configure user access
+    template:
+      src: /opt/config/devaccess_users.j2
+      dest: "/host/etc/openshift_tools/devaccess_users.yaml"
+      owner: "{{ tar_uid }}"
+      group: "1000"
+      mode: "0440"
 
-- name: add user_roles to the config file
-  yedit:
-    src: "/host/etc/openshift_tools/devaccess_users.yaml"
-    key: user_roles
-    value: "{{ tar_user_roles }}"
+  - name: and then yedit the configure user access
+    yedit:
+      src: "/host/etc/openshift_tools/devaccess_users.yaml"
+      key: roles
+      value: "{{ tar_roles }}"
 
-- name: find regular node kubeconfig
-  find:
-    path:
-    - /host/etc/origin/node
-    patterns: "*node*kubeconfig"
-  register: node_kube
+  - name: add user_roles to the config file
+    yedit:
+      src: "/host/etc/openshift_tools/devaccess_users.yaml"
+      key: user_roles
+      value: "{{ tar_user_roles }}"
 
-- name: use node kubeconfig if not a master
-  copy:
-    remote_src: True
-    src: "{{ node_kube['files'] | map(attribute='path') | list | sort(reverse=True) | first }}"
-    dest: "/host/home/{{ tar_username }}/devaccess.kubeconfig"
-    owner: "{{ tar_uid }}"
-    group: "{{ tar_gid }}"
-    mode: "0600"
+  - name: find regular node kubeconfig
+    find:
+      path:
+      - /host/etc/origin/node
+      patterns: "*node*kubeconfig"
+    register: node_kube
+
+  - name: use node kubeconfig if not a master
+    copy:
+      remote_src: True
+      src: "{{ node_kube['files'] | map(attribute='path') | list | sort(reverse=True) | first }}"
+      dest: "/host/home/{{ tar_username }}/devaccess.kubeconfig"
+      owner: "{{ tar_uid }}"
+      group: "{{ tar_gid }}"
+      mode: "0600"

--- a/ansible/roles/daemonset_pods/tasks/main.yml
+++ b/ansible/roles/daemonset_pods/tasks/main.yml
@@ -84,6 +84,27 @@
       name: dnsmasq_vars.yml
       contents: "{{ {'dns_proxy_map': dsp_dns_proxy_map } | to_yaml }}"
 
+    # devaccess authorized_keys
+    - path: /tmp/devaccess_authorized_keys.j2
+      name: devaccess_authorized_keys.j2
+      contents: |
+        {{ lookup('file', '../files/tiered_access/authorized_keys.j2') }}
+
+    - path: /tmp/tiered_access_vars.yml
+      name: tiered_access_vars.yml
+      contents: "{{ {'tar_users': dsp_tar_users,
+                     'tar_username': 'devaccess',
+                     'tar_roles': dsp_tar_roles,
+                     'tar_uid': dsp_tar_uid,
+                     'tar_gid': dsp_tar_gid,
+                     'tar_user_roles': dsp_tar_user_roles } | to_yaml }}"
+
+    # devaccess_users
+    - path: /tmp/devaccess_users.j2
+      name: devaccess_users.j2
+      contents: |
+        {{ lookup('file', '../files/tiered_access/devaccess_users.j2') }}
+
     # end authorized_keys
 
     openshift_daemonset_config_configmap_literals:
@@ -101,6 +122,8 @@
         {{ lookup('file', '../files/operations/operations_tasks.yml') }}
       dnsmasq_tasks.yml: |
         {{ lookup('file', '../files/dnsmasq/dnsmasq_tasks.yml') }}
+      tiered_access_tasks.yml: |
+        {{ lookup('file', '../files/tiered_access/tiered_access_tasks.yml') }}
 
       # this requires clusterid to be translated and cannot be moved to files unless that is solved
       monitoring_config_tasks.yml: |
@@ -116,7 +139,7 @@
             file:
               state: directory
               path: /host/etc/openshift_tools
-              mode: "0740"
+              mode: "0775"
               owner: root
               group: root
 
@@ -140,6 +163,10 @@
 
           - name: setup dnsmasq tasks
             import_tasks: /opt/config/dnsmasq_tasks.yml
+
+          - name: setup tiered_access tasks
+            import_tasks: /opt/config/tiered_access_tasks.yml
+            when: "{{ dsp_tar_enabled }}"
 
       operations_config.sh: |
         #!/bin/bash


### PR DESCRIPTION
This PR enables tiered access on compute and infra nodes in 3.11 clusters. This work depends on the compute/infra nodes using an AMI that has a "devaccess" user. If the user is not present, the other steps to enable tiered access will not run. I tested this PR against two 3.11 clusters: one with a devaccess user, and one without:

```
##################################################
TESTING on an AMI without a devaccess user present
##################################################

...
TASK [Check if the devaccess user is present on the host system] ***************
Wednesday 06 February 2019  22:01:49 +0000 (0:00:00.099)       0:00:03.000 **** 
ok: [localhost] => {"changed": false, "stat": {"exists": false}}

TASK [Setup authorized keys for developer user] ********************************
Wednesday 06 February 2019  22:01:49 +0000 (0:00:00.100)       0:00:03.100 **** 
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [configure user access] ***************************************************
Wednesday 06 February 2019  22:01:49 +0000 (0:00:00.019)       0:00:03.119 **** 
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [and then yedit the configure user access] ********************************
Wednesday 06 February 2019  22:01:49 +0000 (0:00:00.019)       0:00:03.139 **** 
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [add user_roles to the config file] ***************************************
Wednesday 06 February 2019  22:01:49 +0000 (0:00:00.019)       0:00:03.158 **** 
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [find regular node kubeconfig] ********************************************
Wednesday 06 February 2019  22:01:49 +0000 (0:00:00.019)       0:00:03.178 **** 
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [use node kubeconfig if not a master] *************************************
Wednesday 06 February 2019  22:01:49 +0000 (0:00:00.018)       0:00:03.196 **** 
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

PLAY RECAP *********************************************************************
localhost                  : ok=18   changed=6    unreachable=0    failed=0   


###############################################
TESTING on an AMI with a devaccess user present
###############################################

...

TASK [Check if the devaccess user is present on the host system] ***************
Wednesday 06 February 2019  22:01:17 +0000 (0:00:00.092)       0:00:02.903 **** 
ok: [localhost] => REDACTED

TASK [Setup authorized keys for developer user] ********************************
Wednesday 06 February 2019  22:01:17 +0000 (0:00:00.099)       0:00:03.003 **** 
ok: [localhost] => REDACTED

TASK [configure user access] ***************************************************
Wednesday 06 February 2019  22:01:17 +0000 (0:00:00.205)       0:00:03.208 **** 
changed: [localhost] => REDACTED

TASK [and then yedit the configure user access] ********************************
Wednesday 06 February 2019  22:01:17 +0000 (0:00:00.208)       0:00:03.417 **** 
changed: [localhost] => REDACTED

TASK [add user_roles to the config file] ***************************************
Wednesday 06 February 2019  22:01:18 +0000 (0:00:00.420)       0:00:03.837 **** 
changed: [localhost] => REDACTED

TASK [find regular node kubeconfig] ********************************************
Wednesday 06 February 2019  22:01:18 +0000 (0:00:00.352)       0:00:04.190 **** 
ok: [localhost] => REDACTED

TASK [use node kubeconfig if not a master] *************************************
Wednesday 06 February 2019  22:01:18 +0000 (0:00:00.222)       0:00:04.412 **** 
ok: [localhost] => REDACTED

PLAY RECAP *********************************************************************
localhost                  : ok=24   changed=6    unreachable=0    failed=0   
```

Both cases show the correct behavior. Once this is merged into stage, we can have CEE confirm this satisfies their needs for the ceesos tool that depends on tiered access.