### PR TITLE
Raising zabbix server cache size from 512MB to 1GB

### DIFF
--- a/docker/oso-zabbix-server/centos7/zabbix/conf/zabbix_server.conf
+++ b/docker/oso-zabbix-server/centos7/zabbix/conf/zabbix_server.conf
@@ -317,7 +317,7 @@ SNMPTrapperFile=/var/log/snmptt/snmptt.log
 # Range: 128K-8G
 # Default:
 # CacheSize=8M
-CacheSize=512M
+CacheSize=1G
 
 ### Option: CacheUpdateFrequency
 #	How often Zabbix will perform update of configuration cache, in seconds.

--- a/docker/oso-zabbix-server/rhel7/zabbix/conf/zabbix_server.conf
+++ b/docker/oso-zabbix-server/rhel7/zabbix/conf/zabbix_server.conf
@@ -317,7 +317,7 @@ SNMPTrapperFile=/var/log/snmptt/snmptt.log
 # Range: 128K-8G
 # Default:
 # CacheSize=8M
-CacheSize=512M
+CacheSize=1G
 
 ### Option: CacheUpdateFrequency
 #	How often Zabbix will perform update of configuration cache, in seconds.

--- a/docker/oso-zabbix-server/src/zabbix/conf/zabbix_server.conf
+++ b/docker/oso-zabbix-server/src/zabbix/conf/zabbix_server.conf
@@ -317,7 +317,7 @@ SNMPTrapperFile=/var/log/snmptt/snmptt.log
 # Range: 128K-8G
 # Default:
 # CacheSize=8M
-CacheSize=512M
+CacheSize=1G
 
 ### Option: CacheUpdateFrequency
 #	How often Zabbix will perform update of configuration cache, in seconds.


### PR DESCRIPTION
Zabbix server is falling over right now on restart due to running out of space in its cache: 

`  347:20190301:114017.244 __mem_malloc: skipped 6 asked 824008 skip_min 512 skip_max 373944
   347:20190301:114017.244 [file:dbconfig.c,line:89] zbx_mem_realloc(): out of memory (requested 824008 bytes)
   347:20190301:114017.244 [file:dbconfig.c,line:89] zbx_mem_realloc(): please increase CacheSize configuration parameter
   296:20190301:114017.258 One child process died (PID:347,exitcode/signal:1). Exiting ...
   296:20190301:114019.325 syncing history data...
   296:20190301:114019.334 __mem_malloc: skipped 6 asked 824008 skip_min 512 skip_max 373944
   296:20190301:114019.334 [file:dbconfig.c,line:89] zbx_mem_realloc(): out of memory (requested 824008 bytes)
   296:20190301:114019.334 [file:dbconfig.c,line:89] zbx_mem_realloc(): please increase CacheSize configuration parameter`

This PR doubles the cache size for the zabbix container. 