### PR TITLE
Adding non-supported zabbix repo to resolve dep issue

### DIFF
--- a/docker/oso-zabbix-server/centos7/zabbix.repo
+++ b/docker/oso-zabbix-server/centos7/zabbix.repo
@@ -4,3 +4,10 @@ baseurl=https://repo.zabbix.com/zabbix/3.0/rhel/7/x86_64/
 gpgkey=https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
 gpgcheck=1
 enabled=1
+
+[zabbix-non-supported]
+name=Zabbix non-supported repo
+baseurl=https://repo.zabbix.com/non-supported/rhel/7/x86_64/
+gpgkey=https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
+gpgcheck=1
+enabled=1

--- a/docker/oso-zabbix-server/rhel7/zabbix.repo
+++ b/docker/oso-zabbix-server/rhel7/zabbix.repo
@@ -4,3 +4,10 @@ baseurl=https://repo.zabbix.com/zabbix/3.0/rhel/7/x86_64/
 gpgkey=https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
 gpgcheck=1
 enabled=1
+
+[zabbix-non-supported]
+name=Zabbix non-supported repo
+baseurl=https://repo.zabbix.com/non-supported/rhel/7/x86_64/
+gpgkey=https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
+gpgcheck=1
+enabled=1

--- a/docker/oso-zabbix-server/src/zabbix.repo
+++ b/docker/oso-zabbix-server/src/zabbix.repo
@@ -4,3 +4,10 @@ baseurl=https://repo.zabbix.com/zabbix/3.0/rhel/7/x86_64/
 gpgkey=https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
 gpgcheck=1
 enabled=1
+
+[zabbix-non-supported]
+name=Zabbix non-supported repo
+baseurl=https://repo.zabbix.com/non-supported/rhel/7/x86_64/
+gpgkey=https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
+gpgcheck=1
+enabled=1


### PR DESCRIPTION
iksemel was removed from EPEL (https://bugzilla.redhat.com/show_bug.cgi?id=1600897), but this is a dependency of the zabbix-server-mysql for our version of Zabbix (v.3.0.8). This adds a non-supported repository provided by Zabbix which includes the iksemel rpm: http://repo.zabbix.com/non-supported/rhel/7/x86_64/