### PR TITLE
Only alert after ES does automated disk balancing

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
@@ -92,11 +92,11 @@ g_template_logging:
 
   ztriggerprototypes:
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is too low  {HOST.NAME}{% endraw %}"
-    expression: "{% raw %}{Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<25{% endraw %}"
+    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<13) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}>19){% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_logging.asciidoc"
     priority: high
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is critical low {HOST.NAME}{% endraw %}"
-    expression: "{% raw %}{Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<20{% endraw %}"
+    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<8) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}>13){% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_logging.asciidoc"
     priority: high
   


### PR DESCRIPTION
In order to prevent humans from being paged for an issue that
automation can solve, set the alert thresholds lower than those of Elastic
Search's watermark thresholds. This will cause the disks to automatically
become more balanced, rather than alerting humans when no action is
needed.

This also changes the expression used in Zabbix to determine whether
there is a disk problem. This is meant to prevent alert flapping, by
setting a specific recovery threshold higher than that of the alert
threshold.

Related documentation on watermark defaults:
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/disk-allocator.html#disk-allocator

Related documentation on Zabbix expression hysteresis:
https://www.zabbix.com/documentation/3.0/manual/config/triggers/expression#hysteresis

This is part of ticket SREP-1095.