### PR TITLE
Fix the logging alert so that it clears at 20%

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
@@ -92,11 +92,11 @@ g_template_logging:
 
   ztriggerprototypes:
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is too low  {HOST.NAME}{% endraw %}"
-    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<13) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}>19){% endraw %}"
+    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<13) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<19){% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_logging.asciidoc"
     priority: high
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is critical low {HOST.NAME}{% endraw %}"
-    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<8) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}>13){% endraw %}"
+    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<8) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<13){% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_logging.asciidoc"
     priority: high
   


### PR DESCRIPTION
I had my less-than/greater-than operators mixed up, even though it was
tested, there were certain cases where the alert wasn't clearing. For
reference, see the example at the bottom of this page:

https://www.zabbix.com/documentation/3.0/manual/config/triggers/expression#hysteresis