### PR TITLE
Adjust Zabbix alert thresholds for ES disks

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
@@ -92,7 +92,7 @@ g_template_logging:
 
   ztriggerprototypes:
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is too low  {HOST.NAME}{% endraw %}"
-    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<13) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<19){% endraw %}"
+    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<29) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<34){% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_logging.asciidoc"
     priority: high
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is critical low {HOST.NAME}{% endraw %}"


### PR DESCRIPTION
With the settings in ElasticSearch now configured to auto-balance the
disk usage across the 3 disks, Zabbix will only alert *after* that
balancing has been done. This corresponds with the ES setting:

`cluster.routing.allocation.disk.watermark.low: 70%`

At 29% disk free, ES will stop placing indexes on the node and instead
place them on nodes with more space. Zabbix will alert at 28% disk free.

Approved in PR #4067 