### PR TITLE
Add dedicated-admin script to sub-package monitoring-openshift

### DIFF
--- a/scripts/openshift-tools-scripts.spec
+++ b/scripts/openshift-tools-scripts.spec
@@ -421,7 +421,7 @@ OpenShift Tools Openshift Product Scripts
 /usr/bin/cron-send-zabbix-inventory-check
 /usr/bin/cron-send-node-pods-status
 /usr/bin/cron-send-console-check
-
+/usr/bin/cron-send-dedicated-admin.sh
 
 # ----------------------------------------------------------------------------------
 # openshift-tools-scripts-monitoring-zabbix-heal subpackage


### PR DESCRIPTION
This is required for the openshift-tools-scripts rpm build, part of PR #4077.

Approved in PR #4078 