### PR TITLE
Revert "Adjust Zabbix alert thresholds for ES disks"

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_logging.yml
@@ -92,7 +92,7 @@ g_template_logging:
 
   ztriggerprototypes:
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is too low  {HOST.NAME}{% endraw %}"
-    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<29) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<34){% endraw %}"
+    expression: "{% raw %}({TRIGGER.VALUE}=0 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<13) or ({TRIGGER.VALUE}=1 and {Template OpenShift Logging:openshift.logging.elasticsearch.disk_free_pct[{{ '{#' }}OSO_METRICS}].last()}<19){% endraw %}"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_logging.asciidoc"
     priority: high
   - name: "{% raw %}Logging: {{ '{#' }}OSO_METRICS} ES Cluster disk free is critical low {HOST.NAME}{% endraw %}"


### PR DESCRIPTION
Reverts openshift/openshift-tools#4068

We tried these settings for a week, and found Zabbix to be alerting us around 72%. At that point, ES isn't moving any data off of the disks, so the alert remains triggered. Basically it made for a noisy, unactionable alert. Here's one for example:

```
# for pod in $(oc get pods -n openshift-logging -l component=es -o name | awk -F/ '{print $2}'); do oc exec ${pod} -n openshift-logging -- df -lh |  grep /elasticsearch/persistent; done
/dev/xvdbd                              493G  220G  273G  45% /elasticsearch/persistent
/dev/xvdbl                              493G  137G  356G  28% /elasticsearch/persistent
/dev/xvdcy                              493G  354G  139G  72% /elasticsearch/persistent
```

So in this case, /dev/xvdcy triggered the alert. New indexes are not being created on /dev/xvdcy, and instead the indexes are created on the other two nodes. This is good, but a human should not be involved yet. Not until all 3 disks are closer to being full.