### PR TITLE
oso-zabbix-server: Add ops-rpm.repo

### DIFF
--- a/docker/oso-zabbix-server/rhel7/Dockerfile
+++ b/docker/oso-zabbix-server/rhel7/Dockerfile
@@ -13,6 +13,7 @@ EXPOSE 10050 10051
 
 ADD zabbix.repo /etc/yum.repos.d/
 ADD pdagent.repo /etc/yum.repos.d/
+ADD ops-rpm.repo /etc/yum.repos.d/
 
 # Install zabbix (and supporting tools) from zabbix repo
 

--- a/docker/oso-zabbix-server/rhel7/ops-rpm.repo
+++ b/docker/oso-zabbix-server/rhel7/ops-rpm.repo
@@ -1,0 +1,10 @@
+[ops-rpm]
+baseurl = https://mirror.ops.rhcloud.com/libra/ops-rpm-7/$basearch/
+enabled = 1
+gpgcheck = 1
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-openshift-ops-2014
+        https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-openshift-ops-2017
+name = Ops RPM Repo - Prod
+sslclientcert = /var/lib/yum/client-cert.pem
+sslclientkey = /var/lib/yum/client-key.pem
+sslverify = 0


### PR DESCRIPTION
For installing `openshift-tools-scripts-monitoring-zabbix-heal`.

Builds occur on compute nodes and compute nodes do not have all the necessary yum repos in `/etc/pki/entitlement` to mount into containers' `/run/secrets/etc-pki-entitlements`.