### PR TITLE
Package pcp-collector is obsoleted by package pcp

### DIFF
--- a/docker/oso-host-monitoring/src/Dockerfile.j2
+++ b/docker/oso-host-monitoring/src/Dockerfile.j2
@@ -11,8 +11,8 @@ RUN test "$OO_PAUSE_ON_BUILD" = "true" && while sleep 10; do true; done || :
 
 # PCP
 ##################
-# install pcp-collector and it's dependencies, clean the cache.
-RUN yum-install-check.sh -y pcp pcp-conf pcp-collector xz && yum clean all
+# install pcp and its dependencies, clean the cache.
+RUN yum-install-check.sh -y pcp pcp-conf xz && yum clean all
 # Run in the container as root - avoids PCP_USER mismatches
 RUN sed -i -e 's/PCP_USER=.*$/PCP_USER=root/' -e 's/PCP_GROUP=.*$/PCP_GROUP=root/' /etc/pcp.conf
 


### PR DESCRIPTION
Remove reference to pcp-collector, which no longer exists. This resolves an error during container build:

```
Step 4/26 : RUN yum-install-check.sh -y pcp pcp-conf pcp-collector xz && yum clean all
 ---> Running in 3b429f69f2a1

Loaded plugins: ovl, product-id, search-disabled-repos, subscription-manager
Package pcp-collector is obsoleted by pcp, trying to install pcp-4.3.2-2.el7.x86_64 instead

[...]

Error: Package not installed: pcp-collector

The command '/bin/sh -c yum-install-check.sh -y pcp pcp-conf pcp-collector xz && yum clean all' returned a non-zero code: 1
0.02user 0.02system 1:37.41elapsed 0%CPU (0avgtext+0avgdata 13872maxresident)k
0inputs+0outputs (0major+3556minor)pagefaults 0swaps

ERROR: build script failed.
```
