### PR TITLE
Enable monitoring container to see cluster tier

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
+++ b/ansible/roles/oso_host_monitoring/templates/oso-rhel7-host-monitoring.service.j2
@@ -56,6 +56,7 @@ ExecStart=/usr/bin/docker run --name {{ osohm_host_monitoring }}                
            -v /:/host:ro,rslave                                                                     \
            -v /var/cache/yum:/host/var/cache/yum:rw                                                 \
            -v /etc/openshift_tools:/container_setup:ro                                              \
+           -e CLUSTERTIER={{ osohm_cluster_tier }}                                                  \
            {{ osohm_docker_registry_url }}{{ osohm_host_monitoring }}:{{ osohm_environment }}
 
 

--- a/scripts/monitoring/cron-send-dedicated-admin.sh
+++ b/scripts/monitoring/cron-send-dedicated-admin.sh
@@ -22,6 +22,15 @@ function zabbix_not_ok {
   ops-metric-client -k openshift.master.service.dedicated.admin.count -o 0
 }
 
+# Check the cluster tier to see if dedicated-admin should be running.
+# Also, since OSD is comprised of `dedicated`, `rhmi` and potentially other tiers,
+# use a blacklist here instead of a whitelist.
+if [ $CLUSTERTIER == "pro" ] || [ $CLUSTERTIER == "osio" ] || [ $CLUSTERTIER == "ipaas" ]; then
+  echo "Exiting because g_cluster_tier $CLUSTERTIER is excluded from dedicated-admin monitoring."
+  zabbix_ok
+  exit
+fi
+
 # Check the `ready` field of the dedicated-admin-operator pod.
 echo "Checking for dedicated-admin-operator pod..."
 pod_ready="$(oc --kubeconfig=/tmp/admin.kubeconfig get pods -n openshift-dedicated-admin -o=custom-columns=STATUS:.status.containerStatuses[*].ready --no-headers=true)"


### PR DESCRIPTION
This change passes an environment variable to the monitoring container,
which will allow us to configure monitoring based on the cluster tier.
For example, only monitor dedicated-admin service on dedicated tier.

Related PR: openshift/openshift-ansible-ops#5617