### PR TITLE
Specify namespace for zagg service

### DIFF
--- a/docker/oso-host-monitoring/src/root/config.yml.j2
+++ b/docker/oso-host-monitoring/src/root/config.yml.j2
@@ -71,7 +71,7 @@
     - name: get service IP for the service
       command: >
         /usr/bin/oc --config={{ '{{' }} files.files.0['path'] }}
-        get svc zagg-service
+        get svc zagg-service -n default
         --template='{{ '{%' }} raw %}{{ '{{' }}.spec.clusterIP}}{{ '{%' }} endraw %}'
       register: svcipout
 {% raw %}


### PR DESCRIPTION
This should fix an error encountered when the service is not found.

```
Aug 29 19:04:56 ip-172-31-8-92.us-west-2.compute.internal docker[7130]: ok: [localhost]
Aug 29 19:04:56 ip-172-31-8-92.us-west-2.compute.internal docker[7130]: TASK [get service IP for the service] ******************************************
Aug 29 19:04:56 ip-172-31-8-92.us-west-2.compute.internal docker[7130]: fatal: [localhost]: FAILED! => {"failed": true, "msg": "The task includes an option with an undefined variable. The error was: list object has no element 0\n\nThe error appears to have been in '/root/config.yml': line 78, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    # FIXME: change to use openshift ansible module when it is packaged and installed in host-mon container\n    - name: get service IP for the service\n      ^ here\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: list object has no element 0"}
```