### PR TITLE
Specify namespace for zagg service

### DIFF
--- a/docker/oso-host-monitoring/src/root/config.yml.j2
+++ b/docker/oso-host-monitoring/src/root/config.yml.j2
@@ -71,7 +71,7 @@
     - name: get service IP for the service
       command: >
         /usr/bin/oc --config={{ '{{' }} files.files.0['path'] }}
-        get svc zagg-service
+        get svc zagg-service -n default
         --template='{{ '{%' }} raw %}{{ '{{' }}.spec.clusterIP}}{{ '{%' }} endraw %}'
       register: svcipout
 {% raw %}


### PR DESCRIPTION
This should fix an error encountered when the service is not found.