### PR TITLE
[stg] remove the check for the un-used path/cert for internal ssl

### DIFF
--- a/ansible/roles/daemonset_pods/templates/monitoring-config.yml.j2
+++ b/ansible/roles/daemonset_pods/templates/monitoring-config.yml.j2
@@ -418,7 +418,7 @@ host_monitoring_cron:
 - name: "Report on certificate expiration dates"
   hour: "1"
   minute: "1"
-  job: ops-runner -f -s 30 -n ccexp.openshift.master.certificates /usr/bin/cron-certificate-expirations --cert-list=/etc/origin/master,/etc/origin/node,/etc/etcd
+  job: ops-runner -f -s 30 -n ccexp.openshift.master.certificates /usr/bin/cron-certificate-expirations --cert-list=/etc/origin/master,/etc/origin/node/client-ca.crt,/etc/etcd
 
 - name: "Report counts of builds"
   minute: "*/10"

--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -471,7 +471,7 @@ host_monitoring_cron:
 - name: "Report on certificate expiration dates"
   hour: "15"
   minute: "1"
-  job: ops-runner -f -s 30 -n ccexp.openshift.master.certificates /usr/bin/cron-certificate-expirations --cert-list=/etc/origin/master,/etc/origin/node,/etc/etcd
+  job: ops-runner -f -s 30 -n ccexp.openshift.master.certificates /usr/bin/cron-certificate-expirations --cert-list=/etc/origin/master,/etc/origin/node/client-ca.crt,/etc/etcd
 
 - name: "Report counts of builds"
   minute: "*/10"


### PR DESCRIPTION
After some research, found that the only used cert file under /etc/origin/node dir is the `client-ca.crt`.

So change the monitor script to check the file instead of the path.