### PR TITLE
Resolves missing name:default label

### DIFF
--- a/ansible/roles/openshift_default_ns_settings/tasks/main.yml
+++ b/ansible/roles/openshift_default_ns_settings/tasks/main.yml
@@ -14,3 +14,11 @@
   delay: 5
   until: ('failed' not in l_default_ns) or (not l_default_ns.failed)
 
+- name: Label default namespace
+  oc_label:
+    name: default
+    kind: namespace
+    state: add
+    labels: 
+      - key: name
+        value: default


### PR DESCRIPTION
Cluster provisioning was occurring with the `name:default` label missing from the default namespace. This caused user created projects to fail due to the reliance on this label by the `allow-from-default-namespace` NetworkPolicy.

```
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          name: default
```

Output from test playbook:

```
TASK [tools_roles/openshift_default_ns_settings : Change node-selector on default] **********************************************************************************************************************************
Friday 27 September 2019  02:50:56 +0000 (0:00:00.091)       0:00:15.160 ******
ok: [srep-rhmi-test-master-ip-10-216-0-134.eu-west-2.compute.internal] => (item=default)
ok: [srep-rhmi-test-master-ip-10-216-0-134.eu-west-2.compute.internal] => (item=openshift-infra)

TASK [tools_roles/openshift_default_ns_settings : Label default namespace] ******************************************************************************************************************************************
Friday 27 September 2019  02:51:00 +0000 (0:00:03.683)       0:00:18.843 ******
changed: [srep-rhmi-test-master-ip-10-216-0-134.eu-west-2.compute.internal]
```

Label presence was manually validated also.