### PR TITLE
aws_api_key_manager.py: Catch botocore.exceptions.ClientError

### DIFF
--- a/scripts/iam-tools/aws_api_key_manager.py
+++ b/scripts/iam-tools/aws_api_key_manager.py
@@ -266,6 +266,10 @@ class ManageKeys(object):
                         )
                     return client
 
+                except botocore.exceptions.ClientError as client_exception:
+                    print(client_exception)
+                    print('Skipping account %s' % aws_account)
+
                 except ValueError as client_exception:
                     if 'Error retrieving SAML token' in client_exception.message and \
                     'Metadata not found' in client_exception.message:


### PR DESCRIPTION
Temporarily works around an AWS account issue, but more robust error handling is a good thing regardless.