### PR TITLE
Bug 1731236: fix script exiting when /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE does not exist

### DIFF
--- a/ansible/roles/openshift_node_group/files/sync.yaml
+++ b/ansible/roles/openshift_node_group/files/sync.yaml
@@ -118,10 +118,12 @@ spec:
               continue
             fi
 
-            KUBELET_HOSTNAME_OVERRIDE=$(cat /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE) || :
-            if ! [[ -z "$KUBELET_HOSTNAME_OVERRIDE" ]]; then
-                  #Patching node-config for hostname override
-                  echo "nodeName: $KUBELET_HOSTNAME_OVERRIDE" >> /etc/origin/node/tmp/node-config.yaml
+            if [[ -f /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE ]]; then
+              KUBELET_HOSTNAME_OVERRIDE=$(cat /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE) || :
+              if ! [[ -z "$KUBELET_HOSTNAME_OVERRIDE" ]]; then
+                #Patching node-config for hostname override
+                echo "nodeName: $KUBELET_HOSTNAME_OVERRIDE" >> /etc/origin/node/tmp/node-config.yaml
+              fi
             fi
 
             # detect whether the node-config.yaml has changed, and if so trigger a restart of the kubelet.


### PR DESCRIPTION
set -e will cause the script to exit if a command returns with a non-zero error code. `cat /etc/sysconfig/KUBELET_HOSTNAME_OVERRIDE` will fail if the file does not exist, so we are going to check for the file's existence before entering the block.