### PR TITLE
Update trigger for dedicated-admin-operator

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_master.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_master.yml
@@ -1340,8 +1340,8 @@ g_template_openshift_master:
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/certificate_expiring.asciidoc"
     priority: high
 
-  - name: "Openshift-dedicated-role service is not running on  {HOST.NAME}"
-    expression: "{Template Openshift Master:openshift.master.service.dedicated.admin.count.sum(#2)}<2"
+  - name: "Dedicated-admin-operator is not running on {HOST.NAME}"
+    expression: "{Template Openshift Master:openshift.master.service.dedicated.admin.count.sum(#2)}=0"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/dedicated-admin.asciidoc"
     priority: high
 


### PR DESCRIPTION
This clears the false alerts we've been getting for dedicated-admin,
and will only alert if the last two dedicated-admin checks returned failures.

Example of trigger behavior:

```
[CTR][root@a23329019c68 ~]$ ops-metric-client -k openshift.master.service.dedicated.admin.count -o 1 # ok
[CTR][root@a23329019c68 ~]$ ops-metric-client -k openshift.master.service.dedicated.admin.count -o 0 # ok
[CTR][root@a23329019c68 ~]$ ops-metric-client -k openshift.master.service.dedicated.admin.count -o 0 # alert
[CTR][root@a23329019c68 ~]$ ops-metric-client -k openshift.master.service.dedicated.admin.count -o 1 # ok
```

https://jira.coreos.com/browse/SREP-2371