### PR TITLE
oc_storageclass: Drop "beta" from storage class annotation

### DIFF
--- a/ansible/roles/lib_oa_openshift/library/oc_storageclass.py
+++ b/ansible/roles/lib_oa_openshift/library/oc_storageclass.py
@@ -1528,7 +1528,7 @@ class StorageClassConfig(object):
         if self.annotations is not None:
             self.data['metadata']['annotations'] = self.annotations
 
-        self.data['metadata']['annotations']['storageclass.beta.kubernetes.io/is-default-class'] = \
+        self.data['metadata']['annotations']['storageclass.kubernetes.io/is-default-class'] = \
                 self.default_storage_class
 
         self.data['provisioner'] = self.provisioner


### PR DESCRIPTION
To synchronize with https://github.com/openshift/openshift-ansible/commit/18b42ee