### PR TITLE
ansible_inventory: Add oo_rsync_cache_targets_rhmi_only variable

### DIFF
--- a/ansible/roles/ansible_inventory/README.md
+++ b/ansible/roles/ansible_inventory/README.md
@@ -16,6 +16,7 @@ oo_inventory_user
 oo_inventory_accounts
 oo_inventory_cache_max_age
 oo_rsync_cache_targets - array of hosts to rsync inventory cache to
+oo_rsync_cache_targets_rhmi_only - array of hosts to rsync RHMI-only inventory cache to
 oo_rsync_cache_target_user - user on target hosts used for rsync
 oo_rsync_cache_target_dir - directory on target hosts to write inventory cache file
 oo_rsync_private_key - contents of the private key needed for rsync over ssh

--- a/ansible/roles/ansible_inventory/defaults/main.yml
+++ b/ansible/roles/ansible_inventory/defaults/main.yml
@@ -3,5 +3,7 @@ oo_inventory_group: root
 oo_inventory_owner: root
 oo_inventory_cache_max_age: 1800
 oo_rsync_cache_minutes: '*/3'
+oo_rsync_cache_targets: []
+oo_rsync_cache_targets_rhmi_only: []
 oo_rsync_cache_target_user: opsinventory
 oo_rsync_cache_target_dir: /var/inventory_cache/

--- a/ansible/roles/ansible_inventory/tasks/main.yml
+++ b/ansible/roles/ansible_inventory/tasks/main.yml
@@ -58,8 +58,7 @@
 
     - name: setup known_hosts
       include_tasks: known_hosts.yml
-      with_items: "{{ oo_rsync_cache_targets }}"
-      when: oo_rsync_cache_targets is defined
+      with_items: "{{ oo_rsync_cache_targets + oo_rsync_cache_targets_rhmi_only }}"
 
     # This cron uses the above location to call its job
     - name: Cron to keep cache fresh

--- a/ansible/roles/ansible_inventory/tasks/main.yml
+++ b/ansible/roles/ansible_inventory/tasks/main.yml
@@ -64,7 +64,7 @@
     - name: Cron to keep cache fresh
       cron:
         name: 'multi_inventory'
-        minute: '*/10'
+        minute: "{{ oo_rsync_cache_minutes }}"
         job: '/usr/bin/ops-runner -n cmirc.multi_inventory.refresh -t 120 /usr/local/bin/inventory.sh &> /dev/null'
 
     - name: Cron to update cache on reboot

--- a/ansible/roles/ansible_inventory/templates/inventory.sh.j2
+++ b/ansible/roles/ansible_inventory/templates/inventory.sh.j2
@@ -25,6 +25,22 @@ do
     fi
 done
 
+# rsync only inventory hosts with "oo_cluster_tier: rhmi"
+TMPFILE=$(mktemp)
+/usr/bin/jq '._meta.hostvars | with_entries(select(.value.oo_cluster_tier == "rhmi")) | {_meta: {hostvars: .}}' {{ oo_inventory_cache_location }} > $TMPFILE
+for target in {{ oo_rsync_cache_targets_rhmi_only | join(' ') }}
+do
+    # The RHMI targets will put the rsync user in a chroot jail,
+    # so just deposit the inventory file in the login directory.
+    /bin/rsync -e "ssh -i /root/.ssh/rsync_inventory_cache_key" $TMPFILE {{ oo_rsync_cache_target_user }}@$target:
+    RESULT=$?
+    if [ "$RESULT" != "0" ];
+    then
+        rsync_err_count=$((rsync_err_count+1))
+    fi
+done
+rm $TMPFILE
+
 # Send metrics
 ops-metric-client -s $host -k multi_inventory.account.refresh -o $err_count
 #ops-metric-client -s $host -k multi_inventory.account.refresh.rsync -o $rsync_err_count


### PR DESCRIPTION
The `inventory.sh` script will generate a second cached inventory file containing only RHMI hosts and rsync it to the targets specified by the `oo_rsync_cache_targets_rhmi_only` variable, using the same SSH key as the other rsync targets.