### PR TITLE
Cron send metrics checks fix

### DIFF
--- a/scripts/monitoring/cron-send-metrics-checks.py
+++ b/scripts/monitoring/cron-send-metrics-checks.py
@@ -43,7 +43,7 @@ logger.setLevel(logging.INFO)
 commandDelay = 5
 local_report_details_dir = '/opt/failure_reports/'
 max_details_report_files = 5
-
+ 
 import os
 from datetime import datetime
 import yaml
@@ -112,7 +112,7 @@ class OpenshiftMetricsStatus(object):
                     # if unmarshalled into interface{}
                     # even after yaml.v3 is released (which removes the yaml.v2 issue)
                     # we still need to support differing go yaml packages
-                    if type(pod_start_time) == str:
+                    if isinstance(pod_start_time, str):
                         pod_start_time = datetime.strptime(pod_start_time, "%Y-%m-%dT%H:%M:%SZ")
                         
                         # Since we convert to seconds it is an INT but pylint still complains. Only disable here

--- a/scripts/monitoring/cron-send-metrics-checks.py
+++ b/scripts/monitoring/cron-send-metrics-checks.py
@@ -106,15 +106,25 @@ class OpenshiftMetricsStatus(object):
                 # Get the time the pod was started, otherwise return 0
                 try:
                     pod_start_time = pod['status']['containerStatuses'][0]['state']['running']['startedAt']
+                    # oc get pods is returning this field as both 
+                    # date (oc <= 3.11.153) and a string (oc >= 3.11.154 with yaml.v2 update)
+                    # yaml.v2 contains a modification that will output strings for dates
+                    # if unmarshalled into interface{}
+                    # even after yaml.v3 is released (which removes the yaml.v2 issue)
+                    # we still need to support differing go yaml packages
+                    if type(pod_start_time) == str:
+                        pod_start_time = datetime.strptime(pod_start_time, "%Y-%m-%dT%H:%M:%SZ")
+                        
+                        # Since we convert to seconds it is an INT but pylint still complains. Only disable here
+                        # pylint: disable=E1101
+                        # pylint: disable=maybe-no-member
+                        pod_start_time = int(pod_start_time.strftime("%s"))
+                        # pylint: enable=E1101
+                        # pylint: enable=maybe-no-member
                 except KeyError:
                     pod_start_time = 0
-
-                # Since we convert to seconds it is an INT but pylint still complains. Only disable here
-                # pylint: disable=E1101
-                # pylint: disable=maybe-no-member
-                pod_report[pod_pretty_name]['starttime'] = int(pod_start_time.strftime("%s"))
-                # pylint: enable=E1101
-                # pylint: enable=maybe-no-member
+		
+                pod_report[pod_pretty_name]['starttime'] = pod_start_time
 
         return pod_report
 

--- a/scripts/monitoring/cron-send-metrics-checks.py
+++ b/scripts/monitoring/cron-send-metrics-checks.py
@@ -43,7 +43,7 @@ logger.setLevel(logging.INFO)
 commandDelay = 5
 local_report_details_dir = '/opt/failure_reports/'
 max_details_report_files = 5
- 
+
 import os
 from datetime import datetime
 import yaml
@@ -106,7 +106,7 @@ class OpenshiftMetricsStatus(object):
                 # Get the time the pod was started, otherwise return 0
                 try:
                     pod_start_time = pod['status']['containerStatuses'][0]['state']['running']['startedAt']
-                    # oc get pods is returning this field as both 
+                    # oc get pods is returning this field as both
                     # date (oc <= 3.11.153) and a string (oc >= 3.11.154 with yaml.v2 update)
                     # yaml.v2 contains a modification that will output strings for dates
                     # if unmarshalled into interface{}
@@ -114,7 +114,7 @@ class OpenshiftMetricsStatus(object):
                     # we still need to support differing go yaml packages
                     if isinstance(pod_start_time, str):
                         pod_start_time = datetime.strptime(pod_start_time, "%Y-%m-%dT%H:%M:%SZ")
-                        
+
                         # Since we convert to seconds it is an INT but pylint still complains. Only disable here
                         # pylint: disable=E1101
                         # pylint: disable=maybe-no-member
@@ -123,7 +123,7 @@ class OpenshiftMetricsStatus(object):
                         # pylint: enable=maybe-no-member
                 except KeyError:
                     pod_start_time = 0
-		
+
                 pod_report[pod_pretty_name]['starttime'] = pod_start_time
 
         return pod_report


### PR DESCRIPTION
Fix for cron-send-metrics-checks due to yaml.v2 returning strings for date fields