### PR TITLE
Report ELB instance health per cluster

### DIFF
--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -235,7 +235,7 @@ host_monitoring_cron:
 {% if (osohm_master_primary | default(False) | bool) and osohm_cloud == 'aws' %}
 - name: send ELB Health
   minute: "*/5"
-  job: ops-runner -f -s 60 -n cseh.openshift.aws.elb.health /usr/bin/cron-send-elb-health
+  job: ops-runner -f -s 60 -n cseh.openshift.aws.elb.health /usr/bin/cron-send-elb-health --clusterid {{ osohm_cluster_id }}
 {% endif %}
 
 {% if osohm_host_type == 'master' or osohm_host_type == 'node' %}


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-2968

This refines the elb monitoring to report per cluster. Current implementation checks per AWS account and some accounts have multiple clusters.

This relies on filtering by tag:
Both sets of elbs - elbs provisioned as part of our clusters and elbs created by service of type LoadBalancer -  have the tag `kubernetes.io/cluster/<cluster_id>: owned`

Also https://issues.redhat.com/browse/OSD-2665
This script should only alert for elbs created from service of type LoadBalancer from within openshift- and kube- namespaces