### PR TITLE
Adding KubeAPILatency alerts for v3

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_master.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_master.yml
@@ -1385,6 +1385,16 @@ g_template_openshift_master:
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/check_secret_cert_expiry.asciidoc"
     priority: avg
 
+  - name: "Average API latency to LIST 99 percentile of pods is greater than 1 second for past 10 minutes"
+    expression: "{Template Openshift Master:openshift.master.apiserver.latency.summary.pods.quantile.list.99.avg(10m)}>1000"
+    url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_master.asciidoc#210-openshift-master-api-call-latency"
+    priority: warn
+
+  - name: "Average API latency to LIST 90 percentile of pods is greater than 1 second for past 20 minutes"
+    expression: "{Template Openshift Master:openshift.master.apiserver.latency.summary.pods.quantile.list.9.avg(20m)}>1000"
+    url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_master.asciidoc#210-openshift-master-api-call-latency"
+    priority: avg
+
   zgraphs:
   - name: Openshift Master API Server Latency Pods LIST Quantiles
     width: 900


### PR DESCRIPTION
Adding KubeAPILatency alerts as per https://issues.redhat.com/browse/OSD-3037. 

For now, adding the alerts with "warn" and "avg" severities which would be reviewed for clusters for some time and then appropriate severity will be set.

Right now, the logic is following:
1. WARN - Average API Latency for 99 percentile pods with threshold value greater than 1000ms (1 second) for last 10 minutes.
2. AVG - Average API Latency for 90 percentile pods with threshold value greater than 1000ms (1 second) for last 20 minutes.

TODO: Intention is to identify genuine API latency alerts which are actionable by SRE. The severity will be adjusted after review of above alerts for a month.

SOP: https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_master.asciidoc#210-openshift-master-api-call-latency