### PR TITLE
FIX: Only match MD5 sequence value to avoid Node service restart when Sync Pod starts

### DIFF
--- a/openshift/installer/vendored/openshift-ansible-3.11.28-1/roles/openshift_node_group/files/sync.yaml
+++ b/openshift/installer/vendored/openshift-ansible-3.11.28-1/roles/openshift_node_group/files/sync.yaml
@@ -153,8 +153,10 @@ spec:
               node.openshift.io/last-transition-time="$( date +%Y-%m-%d-%H:%M:%S )" --overwrite
             fi
             # annotate node with md5sum of the config
-            oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
-              node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite
+            if ! oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
+              node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite; then
+                echo "error: annotate node failed"
+            fi
             sleep 180 &
             wait $!
           done

--- a/openshift/installer/vendored/openshift-ansible-3.11.28-1/roles/openshift_node_group/files/sync.yaml
+++ b/openshift/installer/vendored/openshift-ansible-3.11.28-1/roles/openshift_node_group/files/sync.yaml
@@ -60,7 +60,7 @@ spec:
 
           # track the current state of the config
           if [[ -f /etc/origin/node/node-config.yaml ]]; then
-            md5sum /etc/origin/node/node-config.yaml > /tmp/.old
+            md5sum /etc/origin/node/node-config.yaml | cut -d' ' -f1 > /tmp/.old
           else
             touch /tmp/.old
           fi
@@ -119,7 +119,7 @@ spec:
             fi
 
             # detect whether the node-config.yaml has changed, and if so trigger a restart of the kubelet.
-            md5sum /etc/origin/node/tmp/node-config.yaml > /tmp/.new
+            md5sum /etc/origin/node/tmp/node-config.yaml | cut -d' ' -f1 > /tmp/.new
             if [[ "$( cat /tmp/.old )" != "$( cat /tmp/.new )" ]]; then
               mv /etc/origin/node/tmp/node-config.yaml /etc/origin/node/node-config.yaml
               echo "info: Configuration changed, restarting kubelet" 2>&1
@@ -148,11 +148,13 @@ spec:
                 wait $!
                 continue
               fi
+              else
+                oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
+              node.openshift.io/last-transition-time="$( date +%Y-%m-%d-%H:%M:%S )" --overwrite
             fi
             # annotate node with md5sum of the config
             oc annotate --config=/etc/origin/node/node.kubeconfig "node/${NODE_NAME}" \
               node.openshift.io/md5sum="$( cat /tmp/.new | cut -d' ' -f1 )" --overwrite
-            cp -f /tmp/.new /tmp/.old
             sleep 180 &
             wait $!
           done


### PR DESCRIPTION
#4349 As described in the issue