### PR TITLE
OSD-7588 detect flapping node NotReady status

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_openshift_master.yml
+++ b/ansible/roles/os_zabbix/vars/template_openshift_master.yml
@@ -1247,6 +1247,13 @@ g_template_openshift_master:
     - "Openshift Master process not running on {HOST.NAME}"
     priority: high
 
+  - name: "Node flapping NotReady status on {HOST.NAME}"
+    expression: "{Template Openshift Master:openshift.master.nodesnotready.count(1h,0,gt)}>5"
+    url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_node_not_ready.asciidoc"
+    dependencies:
+    - "Openshift Master process not running on {HOST.NAME}"
+    priority: info
+
   - name: "Hosts not labeled according to {HOST.NAME}"
     expression: "{Template Openshift Master:openshift.master.nodesnotlabeled.count.min(#2)}>0"
     url: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_node_not_labeled.asciidoc"


### PR DESCRIPTION
STG PR #4360 

Adds trigger to detect if a node is flapping NotReady status