### PR TITLE
[OSD-6478] Update monitoring templates to pull hello-openshift image from quay.io

### DIFF
--- a/ansible/roles/daemonset_pods/templates/monitoring-config.yml.j2
+++ b/ansible/roles/daemonset_pods/templates/monitoring-config.yml.j2
@@ -276,7 +276,7 @@ host_monitoring_cron:
 {% if dsp_enable_app_create|bool %}
 - name: run create app
   minute: "*/10"
-  job: "ops-runner -f -t 480 -s 60 -n csca.openshift.master.app.create /usr/bin/cron-send-create-app -v --basename pull --source openshift/hello-openshift:v1.0.6 &>> /var/log/create_app.log"
+  job: "ops-runner -f -t 480 -s 60 -n csca.openshift.master.app.create /usr/bin/cron-send-create-app -v --basename pull --source quay.io/openshift-sre/hello-openshift:v1.0.6 &>> /var/log/create_app.log"
 
 # TODO: This might be fixed, investigate if it's still an issue and possibly remove cron job if it has been fixed.
 - name: run Terminating status project

--- a/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
+++ b/ansible/roles/oso_host_monitoring/templates/monitoring-config.yml.j2
@@ -284,7 +284,7 @@ host_monitoring_cron:
 {% if osohm_enable_app_create|bool %}
 - name: run create app
   minute: "*/10"
-  job: "ops-runner -f -t 480 -s 60 -n csca.openshift.master.app.create /usr/bin/cron-send-create-app -v --basename pull --source openshift/hello-openshift:v1.0.6 --cpulimit 100m --memlimit 256Mi &>> /var/log/create_app.log"
+  job: "ops-runner -f -t 480 -s 60 -n csca.openshift.master.app.create /usr/bin/cron-send-create-app -v --basename pull --source quay.io/openshift-sre/hello-openshift:v1.0.6 --cpulimit 100m --memlimit 256Mi &>> /var/log/create_app.log"
 
 # TODO: This might be fixed, investigate if it's still an issue and possibly remove cron job if it has been fixed.
 - name: run Terminating status project

--- a/scripts/monitoring/cron-send-create-app.py
+++ b/scripts/monitoring/cron-send-create-app.py
@@ -71,7 +71,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(description='OpenShift app create end-to-end test')
     parser.add_argument('-v', '--verbose', action='store_true', default=None, help='Verbose?')
-    parser.add_argument('--source', default="openshift/hello-openshift:v1.0.6",
+    parser.add_argument('--source', default="quay.io/openshift-sre/hello-openshift:v1.0.6",
                         help='source application to use')
     parser.add_argument('--basename', default="test", help='base name, added to via openshift')
     parser.add_argument('--loopcount', default="36",


### PR DESCRIPTION
We are occasionally getting alerts on v3 clusters when they hit docker hub rate limits. Currently, our monitoring scripts contribute to this problem by pulling the https://hub.docker.com/r/openshift/hello-openshift image that we use for an e2e test that runs at regular intervals. This PR updates the monitoring templates and script defaults to pull the same image from quay.io. 