### PR TITLE
adding username and password for basic authentitacion to the yum_repos task

### DIFF
--- a/ansible/roles/yum_repos/tasks/main.yml
+++ b/ansible/roles/yum_repos/tasks/main.yml
@@ -40,4 +40,6 @@
     sslverify: "{{ item.sslverify | default(1) }}"
     sslclientkey: "{{ item.sslclientkey | default(omit) }}"
     sslclientcert: "{{ item.sslclientcert | default(omit) }}"
+    username: "{{ item.username | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
   with_items: "{{ yr_yum_repo_list }}"


### PR DESCRIPTION
new mirror servers supporting basic auth, not gpg keys. this adds the ability to add username/password.