### PR TITLE
decom of unused v2 zabbix srv OSD-5865

### DIFF
--- a/ansible/roles/os_zabbix/vars/template_app_zabbix_server.yml
+++ b/ansible/roles/os_zabbix/vars/template_app_zabbix_server.yml
@@ -349,12 +349,6 @@ g_template_app_zabbix_server:
        'no': 2
 
    ztriggers:
-   - description: "Zabbix v2 Web UI is not responding"
-     expression: "{Template App Zabbix Server:web.test.fail[check_v2_zabbix_web].last(#1)}<>0 and {Template App Zabbix Server:web.test.fail[check_v2_zabbix_web].last(#2)}<>0"
-     name: "Zabbix v2 Web UI is not responding"
-     priority: high
-     url: https://github.com/openshift/ops-sop/blob/master/services/zabbix/custom_checks.asciidoc
-
    - description: "webcheck_v3prod_sso is unhealthy"
      expression: "{Template App Zabbix Server:web.test.fail[webcheck_v3prod_sso].last(#1)}<>0 and {Template App Zabbix Server:web.test.fail[webcheck_v3prod_sso].last(#2)}<>0"
      name: "webcheck_v3prod_sso is unhealthy"

--- a/ansible/roles/os_zabbix/vars/template_app_zabbix_server.yml
+++ b/ansible/roles/os_zabbix/vars/template_app_zabbix_server.yml
@@ -303,21 +303,6 @@ g_template_app_zabbix_server:
      zabbix_type: trapper
 
    zhttptests:
-   - name: check_v2_zabbix_web
-     interval: 60
-     application: Zabbix server
-     steps:
-     - name: "Check v2 Zabbix web"
-       url: "{{ g_v2_monitor_url }}"
-       status_codes: '200'
-       required: Zabbix
-       'no': 1
-     #- name: "Hit some other service"
-     #  url: "http://google.com"
-     #  status_codes: '200'
-     #  required: google
-     #  'no': 2
-
    - name: webcheck_v3prodpreview_sso
      interval: 60
      application: Zabbix server


### PR DESCRIPTION
This removes the alert trigger that checks for the online status of the V2 Zabbix server. The V2 server and proxy instances are no longer in use, and have been stopped. 